### PR TITLE
feat(terminal): standalone Bun + OpenTUI integration (oc-edit)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ host and the runtime.
 - **OpenCode** (`integrations/opencode/`) — patches OpenCode 1.4.x; runtime loaded inline
 - **Chrome** (`integrations/chrome/`) — MV3 extension; CSS Custom Highlight API for in-page rendering
 - **Gemini CLI** (`integrations/gemini-cli/`) — patches Gemini CLI 0.41.x; React/Ink host with a render-kick + ZWS-toggle pull model. See its CLAUDE.md for the React quirks (it's the first React/Ink host so the integration was non-trivial).
+- **Terminal** (`integrations/terminal/`) — standalone Bun + OpenTUI + SolidJS app invoked as `oc-edit`. **Self-owned host** — no upstream fork to patch. Built on the same OpenTUI primitives as OpenCode, so the adapter band (`adapters/terminal/v1/`) is structurally a near-clone of `adapters/oc/v1.14/`.
 
 > Re-org in progress — folders rename to `cc/`, `oc/`, `chrome/` in Stage 4 of
 > the repo restructure. See `docs/architecture/repo-structure.md` for the

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ the publish target broadens. Star + Build are wireable today.
 [![GitHub stars](https://img.shields.io/github/stars/opencues/opencues?style=social)](https://github.com/opencues/opencues)
 -->
 
-**Real-time guidance as you type.** Define cues, blanks, and auditors in `.md` config files; the runtime turns them into inline alternatives, `_`-gated substitutions, and live rewrites. Install today in Claude Code, OpenCode, Gemini CLI, and Chrome.
+**Real-time guidance as you type.** Define cues, blanks, and auditors in `.md` config files; the runtime turns them into inline alternatives, `_`-gated substitutions, and live rewrites. Install today in Claude Code, OpenCode, Gemini CLI, Chrome, and a standalone terminal app (`oc-edit`).
 
-The three file formats (Cues / Blanks / Auditors) are open standards — designed so a non-JS port or alternative runtime *could* ship — and the spec at [`spec/`](spec/) is the field reference for anyone authoring those files. Today only the reference runtime in this repo implements them, powering all four integrations as thin host adapters over a shared core.
+The three file formats (Cues / Blanks / Auditors) are open standards — designed so a non-JS port or alternative runtime *could* ship — and the spec at [`spec/`](spec/) is the field reference for anyone authoring those files. Today only the reference runtime in this repo implements them, powering all five integrations as thin host adapters over a shared core.
 
 <!-- TODO[hero]: pick ONE of these three (or ship all three over time):
 
@@ -105,6 +105,7 @@ For per-host installs, deeper troubleshooting, and uninstall: [`docs/install.md`
 | **OpenCode** | Available | `opencues install opencode` | [`integrations/opencode/README.md`](integrations/opencode/README.md) |
 | **Gemini CLI** | Beta | `opencues install gemini-cli` | [`integrations/gemini-cli/README.md`](integrations/gemini-cli/README.md) |
 | **Chrome** | Beta | `opencues install chrome` | [`integrations/chrome/README.md`](integrations/chrome/README.md) |
+| **Terminal (`oc-edit`)** | Beta | `opencues install terminal` | [`integrations/terminal/README.md`](integrations/terminal/README.md) |
 | **VS Code** | Planned | — | — |
 
 Each install pins a specific upstream version (e.g. Claude Code 2.1.110, OpenCode 1.14.17), clones it into its own dir (`~/claude-code-cues/`, `~/opencode-cues/`), and patches that copy. **Your native editor installs are never touched.** Uninstall is `opencues uninstall <host>`.

--- a/docs/features/host-compat.md
+++ b/docs/features/host-compat.md
@@ -4,12 +4,14 @@ last_updated: 2026-05-14
 
 # Host Compatibility
 
-The OpenStandard runs on four integration hosts — `claude-code`, `opencode`,
-`chrome`, `gemini-cli` — that share the same `.md` config format. Native
-hosts (CC, OC, gemini-cli) can spawn subprocesses and read the filesystem
-unconditionally. Chrome can too, but only when chrome-host (the
-native-messaging bridge) is installed — so chrome's spawn capability is
-*runtime-detected*, not a static property.
+The OpenStandard runs on five integration hosts — `claude-code`, `opencode`,
+`chrome`, `gemini-cli`, `terminal` — that share the same `.md` config
+format. Native hosts (CC, OC, gemini-cli, terminal) can spawn
+subprocesses and read the filesystem unconditionally. Chrome can too,
+but only when chrome-host (the native-messaging bridge) is installed —
+so chrome's spawn capability is *runtime-detected*, not a static
+property. `terminal` is the standalone Bun + OpenTUI app (`oc-edit`);
+the others patch an upstream host.
 
 A cue or blank can declare which hosts it works on, but most entries
 don't need to: **every entry advertises as compatible with every host by
@@ -100,7 +102,7 @@ not-on-host: chrome, opencode
 ---
 ```
 
-Valid host names: **`chrome`**, **`claude-code`**, **`gemini-cli`**, **`opencode`**.
+Valid host names: **`chrome`**, **`claude-code`**, **`gemini-cli`**, **`opencode`**, **`terminal`**.
 
 Unknown names are silently dropped at runtime; `opencues validate` prints
 warnings about them so typos are caught.

--- a/docs/guides/adding-an-integration.md
+++ b/docs/guides/adding-an-integration.md
@@ -117,10 +117,11 @@ Before touching code:
 
 1. **Host name.** Pick the canonical name (e.g. `gemini-cli`, `vscode`, `helix`). Use that consistently — directory names, alias maps, schema enums, doc tables.
 2. **Adapter band path.** `packages/opencues-runtime/adapters/<short>/<version>/` (e.g. `gemini/v0.41/`, `cc/v2.1/`, `oc/v1.14/`). The short name is the directory key; major upstream rewrites get a new band, minor versions reuse one.
-3. **Patch strategy.** Three patterns are in use:
+3. **Patch strategy.** Four patterns are in use:
    - **Source patches** (gemini, opencode): host ships `.tsx`/`.ts` source. Apply `str.replace` patches against unique anchor strings, then build the host.
    - **Built-artifact patches** (claude-code via tweakcc): host ships minified `cli.js`. Use regex anchors against the minified structure.
    - **Inline runtime** (chrome): we own the build — runtime is bundled into the extension at build time, no host fork.
+   - **Self-owned app** (terminal): there is no upstream host to patch. The integration ships its own TUI app (Bun + OpenTUI + SolidJS, invoked as `oc-edit`). Adapter band lives in the runtime as usual; the integration directory holds the Solid app + a bootstrap that hands the textarea ref directly to `boot()`. See `integrations/terminal/` for the worked example.
 
 The Gemini recipe below is the **source-patch** flavour. CC's REPAIR.md covers the built-artifact flavour.
 

--- a/integrations/terminal/CLAUDE.md
+++ b/integrations/terminal/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md — Terminal integration
+
+A standalone Bun + OpenTUI + SolidJS app that hosts the OpenCues
+runtime. Unlike CC / OC / Gemini there is no upstream fork to patch —
+we own the entire app. Invoked as `oc-edit` from a shell.
+
+## Why this exists
+
+Native CLI hosts (CC, OC, Gemini) all already have their own editor
+loops, and OpenCues plugs into theirs. A user who isn't running any
+of those still has a terminal — but a raw bash/zsh prompt can't
+host the runtime (no persistent buffer, no `onRender` surface). The
+terminal integration plugs that gap by being itself the host:
+launched as `oc-edit`, it owns a TextareaRenderable, runs OpenCues
+against it, and prints the buffer on submit.
+
+## Where things live
+
+| File | Role |
+|---|---|
+| `pin.json` | OpenTUI version pin (no upstream fork — what's pinned is the renderer stack) |
+| `compat.json` | Declared compatibility (`host-kind: self`) |
+| `patches/setup.sh` | One-command installer (Bun, build runtime, optional symlink) |
+| `bin/oc-edit` | Bun entrypoint — chooses dist/ if built, else src/ |
+| `src/app.tsx` | The Solid app — single `<textarea>` + statusline |
+| `src/bootstrap.ts` | OpenCues wiring (analog of `integrations/opencode/patches/opencuesBootstrap.ts`, but without the holder/publish dance) |
+| `../../packages/opencues-runtime/adapters/terminal/v1/` | Adapter band |
+
+## Differences vs the OC band
+
+OpenTUI is identical between OC and terminal, so the adapter band is
+a near-clone of `adapters/oc/v1.14/` with:
+
+- `hostName: 'terminal'`, `hostVersion: '0.1.0'`
+- No SolidJS reactive holder (`__ocPromptHolder`) — app.tsx hands the
+  textarea + syntax refs straight to `startOpenCues()` on mount.
+- No CC/OC-fork plugin lifecycle hooks (`promptAccess.write`, etc.).
+- No statusline-to-footer SolidJS signal — the statusline tip lands
+  in a plain Solid signal owned by `App` and rendered in `<text>`.
+
+Everything else (extmark applier, spawn sandbox, audit log, user
+blanks loader, multi-provider key bag, agent-rewrite wiring) is a
+direct port.
+
+## OpenTUI extmark contract (read before touching `triggerOpenCuesRender`)
+
+Same trap as OC. `editBuffer.setText` / `replaceText` / `clear`
+nuke every extmark; insert/delete/newline/undo only adjust. Our
+runtime-driven writes (cycling, agent edits, BlankFill substitute)
+funnel through `textarea.setText` → all extmarks gone → next render
+must rebuild from scratch. `setText`/`pushText` in `bootstrap.ts`
+reset `ownedExtmarks = new Map()` to force the rebuild. See
+`packages/opencues-runtime/adapters/oc/REPAIR.md` § "OpenTUI extmark
+contract" for the full ADJUSTS-vs-CLEARS table — same applies here.
+
+## Iteration loop
+
+```bash
+bun --cwd integrations/terminal install
+bun --cwd integrations/terminal src/app.tsx   # dev run
+# or after a runtime change:
+pnpm --filter @opencues/runtime build && bun --cwd integrations/terminal src/app.tsx
+```
+
+## Debugging
+
+- **`tail -f /tmp/opencues.log | grep '\[term\]'`** — runtime logs.
+- Set `DEBUG_OPENCUES=1` for verbose user-blank load tracing.
+- Set `OPENCUES_BRIDGE=1` to enable the event-bridge for off-process
+  inspection (same protocol as OC).

--- a/integrations/terminal/README.md
+++ b/integrations/terminal/README.md
@@ -1,0 +1,50 @@
+# @opencues/terminal
+
+OpenCues as a standalone TUI you invoke as a command. Full feature
+surface — cues, blanks, cycling, agent-rewrite, statusline — without
+patching any host. Built on Bun + OpenTUI + SolidJS.
+
+## Install
+
+```bash
+# Bun is required: https://bun.sh
+./patches/setup.sh --link ~/.local/bin
+```
+
+Then either:
+
+- **As your editor** — `export EDITOR=oc-edit`; any `git commit` /
+  `crontab -e` / `vi`-replacement command now opens OpenCues.
+- **From a pipe** — `echo "the attorney filed today" | oc-edit > out.txt`.
+- **From a ZLE widget** (zsh):
+
+```zsh
+oc-edit-buffer() {
+  local tmp="$(mktemp)"
+  print -r -- "$BUFFER" | oc-edit --out "$tmp"
+  BUFFER="$(<"$tmp")"
+  rm -f "$tmp"
+  zle redisplay
+}
+zle -N oc-edit-buffer
+bindkey '^E' oc-edit-buffer  # Ctrl+E to edit the current shell buffer
+```
+
+## Keys
+
+- Type — cues highlight; `_` triggers blank lookup.
+- **Ctrl+Alt+↑/↓** — cycle the active word's alternatives.
+- **Ctrl+S** — submit (write buffer to stdout / `--out` path).
+- **Ctrl+C** — cancel (exit 130).
+- All standard OpenTUI textarea bindings (undo, word-jump, etc.).
+
+## Configuration
+
+Identical to the native hosts. `~/.cues/CUES.md` for cue sources,
+`~/.cues/OPENCUES.md` for runtime settings (voice-mode, agent-debounce-ms,
+…), `~/.cues/blanks/` for blank packs. The terminal app reads the
+same search paths as CC and OC.
+
+## Architecture
+
+See `CLAUDE.md` in this directory.

--- a/integrations/terminal/TEST-WHEN-MERGED.md
+++ b/integrations/terminal/TEST-WHEN-MERGED.md
@@ -1,0 +1,95 @@
+# Test-when-merged checklist — Terminal integration
+
+Pre-merge automated tests already pass:
+- `pnpm --filter @opencues/runtime test` → 1262/1262
+- `pnpm --filter @opencues/core build && node --test packages/opencues-core/dist/host-compat.test.js` → 31/31
+- `opencues install/run/uninstall/update/version/completion/doctor --help` all surface `terminal`
+
+This file is the **reviewer's manual pass** — boxes to tick after pulling the PR onto a clean machine. Estimated 15 minutes.
+
+## Prerequisites
+- [ ] Bun installed (`curl -fsSL https://bun.sh/install | bash`)
+- [ ] `GROQ_API_KEY` exported (or any of the other supported provider keys)
+- [ ] Fresh clone, `pnpm install` at the repo root
+
+## 1. Install (1 min)
+- [ ] `opencues install terminal` runs to completion in under a minute
+- [ ] Final line is `✓ Terminal integration ready.`
+- [ ] `ls integrations/terminal/node_modules/@opencues/{core,runtime}` shows both staged
+- [ ] `ls integrations/terminal/node_modules/@opencues/core/node-http-adapter.js` exists at the package root (NOT inside `dist/`) — this is the LF-7 trap repeat point
+
+## 2. Doctor sanity (10 s)
+- [ ] `opencues doctor` shows a `Terminal (oc-edit)` section with all four ticks green
+- [ ] No `WARN: bun not on PATH` finding
+
+## 3. Boot + minimal cue (1 min)
+- [ ] `bun integrations/terminal/bin/oc-edit` opens a full-screen TUI with a single textarea + statusline at the bottom
+- [ ] `tail -f /tmp/opencues.log | grep '\[term\]'` (in another shell) shows:
+  - `OpenCues runtime starting (Terminal v1)` with `host: terminal`
+  - `ConfigLoader: USER.md → N fields`
+  - `Resolver: built with 5 sources [sentence-cue:more-formal, word-cues, config-intent, fluid-blank, transform-blank]`
+- [ ] Type `the attorney filed today` — at least one word (e.g. `attorney`) gets a dim underline within ~1 second
+- [ ] Cursor onto a dimmed word and press **Ctrl+Alt+↑** — the word changes to an alternative; statusline shows `word (1/N) - tip`
+- [ ] Ctrl+Alt+↑ again — cycles to the next alt
+- [ ] Ctrl+S — TUI exits, the final buffer content is printed to stdout
+
+## 4. Blanks (2 min)
+- [ ] Re-launch `oc-edit`, type `volume _` (assuming `defaults/blanks/volume/` is in your `~/.cues/`)
+- [ ] The `_` resolves to a number (e.g. current system volume) within a second
+- [ ] Ctrl+Alt+↑ steps the value up; the OS volume changes
+- [ ] Backspace fully wipes the blank — buffer ends `volume ` again
+- [ ] Type `the lawyer is _` and wait — `_` is replaced with a fluid-blank suggestion in italics
+
+## 5. Agent rewrite (1 min)
+- [ ] Append `agentically rewrite this more formally` to a sentence
+- [ ] Within ~2s, the buffer is rewritten by the agent; statusline shows `[task: ...]` while it works
+- [ ] Down-arrow reverts the rewrite
+
+## 6. ZLE widget (zsh users only, optional — 2 min)
+- [ ] Drop into `~/.zshrc`:
+  ```zsh
+  oc-edit-buffer() {
+    local tmp="$(mktemp)"
+    print -r -- "$BUFFER" | oc-edit --out "$tmp"
+    BUFFER="$(<"$tmp")"; rm -f "$tmp"
+    zle redisplay
+  }
+  zle -N oc-edit-buffer
+  bindkey '^E' oc-edit-buffer
+  ```
+- [ ] Open a new shell, type a partial command (`git commit -m "the attorney"`), hit **Ctrl+E**
+- [ ] oc-edit opens with the current $BUFFER; edit + Ctrl+S returns to the prompt with the edited text in $BUFFER
+- [ ] Pressing Enter at the shell runs the edited command
+
+## 7. $EDITOR mode (1 min)
+- [ ] `EDITOR="$PWD/integrations/terminal/bin/oc-edit" git commit --allow-empty` in any git repo
+- [ ] oc-edit opens with the standard `# Please enter the commit message...` template
+- [ ] Cycling works on words in the prefilled commit-template body
+- [ ] Ctrl+S writes the edited file; `git log -1` shows the message
+
+## 8. Cross-terminal key handling (5 min — long tail)
+Verify Ctrl+Alt+↑/↓ actually cycles on each terminal you care about:
+- [ ] WSL/Linux: Alacritty
+- [ ] WSL/Linux: Windows Terminal
+- [ ] WSL/Linux: tmux pane (Alt forwarding can swallow keys)
+- [ ] macOS Terminal.app (Alt is the macOS menu key — may need `Option ↑` instead of `Alt ↑`)
+- [ ] macOS iTerm2 (Profiles → Keys → Left/Right Option = Esc+ if no response)
+- [ ] macOS Ghostty / Kitty
+
+This list mirrors the long-tail the OC + Gemini integrations already document in their REPAIR.md files. Failures here aren't blockers for merge — they're reasons to add a `KEY-COMPAT.md` for the terminal app.
+
+## 9. Uninstall (10 s)
+- [ ] `opencues uninstall terminal` removes `integrations/terminal/node_modules/@opencues/*/`
+- [ ] `opencues install terminal --dry-run` shows the plan; **no files modified**
+
+## Known not-yet-shipped (won't be in this PR)
+- A published `oc-edit` npm bin (today: install from clone only — same as opencode + gemini-cli)
+- The agentic-harness drive for `oc-edit` (the private tests/agentic/ repo will need a `terminal` profile added)
+- A REPAIR.md for the terminal band (will accrete its first quirk only when one shows up)
+
+## If anything fails
+- Logs: `/tmp/opencues.log` (look for `[term]` lines)
+- Trace: `OPENCUES_TRACE_CURSOR=1` env var enables `/tmp/opencues-cursor-trace.log` (parity with OC)
+- Bridge: `OPENCUES_BRIDGE=1` opens the JSONL event bridge for off-process inspection
+
+File issues against `integrations/terminal/` with the relevant /tmp log attached.

--- a/integrations/terminal/bin/install.cjs
+++ b/integrations/terminal/bin/install.cjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// @opencues/terminal CLI — install / uninstall.
+//
+// Unlike CC / OC / Gemini, the terminal integration ships its own app
+// (Bun + OpenTUI). There is no upstream fork to clone or patch —
+// install just builds @opencues/{core,runtime}, stages them into the
+// integration's local node_modules, runs `bun install` for OpenTUI,
+// and optionally symlinks `oc-edit` into a PATH location.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const PKG_DIR = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(PKG_DIR, '../..');
+const pkg = JSON.parse(fs.readFileSync(path.join(PKG_DIR, 'package.json'), 'utf8'));
+
+const { command, args, unknown } = parseArgv(process.argv.slice(2));
+warnUnknownFlags(unknown);
+if (args.help || command === 'help') { printHelp(); process.exit(0); }
+
+printBanner();
+
+const isClone = fs.existsSync(path.join(REPO_ROOT, 'pnpm-workspace.yaml'));
+if (!isClone) {
+  console.error(
+    '\nPublished-package install path is not implemented yet.\n' +
+    'For now, install from a clone:\n' +
+    '  git clone https://github.com/opencues/opencues\n' +
+    '  pnpm install\n' +
+    '  opencues install terminal\n',
+  );
+  process.exit(1);
+}
+
+if (command === 'install') doInstall();
+else if (command === 'uninstall') doUninstall();
+else if (command === 'seed-configs') doSeedConfigs();
+else { console.error(`Unknown command: ${command}\n`); printHelp(); process.exit(1); }
+
+// --- INSTALL --------------------------------------------------------------
+
+function doInstall() {
+  const bunCheck = spawnSync('which', ['bun'], { stdio: ['ignore', 'pipe', 'ignore'] });
+  if (bunCheck.status !== 0) {
+    const msg = args.dryRun
+      ? '\nWARNING: bun is not on PATH. A real install would fail here — the terminal app is a Bun app.'
+      : '\nERROR: bun is not on PATH. The terminal app is a Bun + OpenTUI app, so install cannot proceed.';
+    console.error(msg);
+    console.error('Install bun: curl -fsSL https://bun.sh/install | bash  (or https://bun.sh/)');
+    console.error('Then re-run: opencues install terminal');
+    if (!args.dryRun) process.exit(127);
+  }
+
+  if (args.dryRun) {
+    console.log('\n[dry-run] Would build @opencues/{core,runtime}.');
+    console.log('[dry-run] Would run `bun install` in:');
+    console.log(`  ${PKG_DIR}`);
+    console.log('[dry-run] Would stage runtime + core into:');
+    console.log(`  ${path.join(PKG_DIR, 'node_modules', '@opencues', 'core')}/`);
+    console.log(`  ${path.join(PKG_DIR, 'node_modules', '@opencues', 'runtime')}/`);
+    if (args.link) console.log(`[dry-run] Would symlink: ${args.link}/oc-edit → ${path.join(PKG_DIR, 'bin', 'oc-edit')}`);
+    return;
+  }
+
+  // Seed configs first so cues/blanks/OPENCUES.md are present before
+  // the user's first `oc-edit`.
+  const seedConfigsPath = path.join(REPO_ROOT, 'packages/opencues-cli/src/commands/seed-configs.cjs');
+  if (fs.existsSync(seedConfigsPath)) {
+    const seedConfigs = require(seedConfigsPath);
+    seedConfigs(['--silent'], { REPO_ROOT });
+  }
+
+  const setupSh = path.join(PKG_DIR, 'patches', 'setup.sh');
+  const setupArgs = args.link ? ['--link', args.link] : [];
+  const result = spawnSync('bash', [setupSh, ...setupArgs], { stdio: 'inherit' });
+  if (result.status !== 0) {
+    console.error(`\nInstall failed. To roll back: opencues uninstall terminal`);
+    process.exit(result.status || 1);
+  }
+}
+
+// --- UNINSTALL ------------------------------------------------------------
+
+function doUninstall() {
+  // The terminal integration is self-owned — blast radius is just the
+  // local node_modules + the optional symlink the user passed via --link.
+  const stagedCore = path.join(PKG_DIR, 'node_modules', '@opencues', 'core');
+  const stagedRt = path.join(PKG_DIR, 'node_modules', '@opencues', 'runtime');
+  const linkPath = args.link ? path.join(args.link, 'oc-edit') : null;
+
+  console.log('Uninstall plan:');
+  for (const p of [stagedCore, stagedRt]) {
+    if (fs.existsSync(p)) console.log(`  rm -rf ${p}`);
+  }
+  if (linkPath) {
+    try {
+      if (fs.lstatSync(linkPath).isSymbolicLink()) console.log(`  rm ${linkPath}`);
+    } catch { /* ignore */ }
+  }
+
+  if (args.dryRun) { console.log('\n[dry-run] Nothing executed.'); return; }
+
+  for (const p of [stagedCore, stagedRt]) {
+    if (fs.existsSync(p)) { fs.rmSync(p, { recursive: true, force: true }); console.log(`  removed ${p}/`); }
+  }
+  if (linkPath) {
+    try {
+      if (fs.lstatSync(linkPath).isSymbolicLink()) { fs.unlinkSync(linkPath); console.log(`  removed ${linkPath}`); }
+    } catch { /* ignore */ }
+  }
+  console.log(`\n${pkg.name} uninstall complete.`);
+}
+
+// --- SEED CONFIGS ---------------------------------------------------------
+
+function doSeedConfigs() {
+  // Delegate to the umbrella seed-configs — terminal has no host-specific
+  // seed step (no fork to patch, no host-side bridge).
+  const seedConfigsPath = path.join(REPO_ROOT, 'packages/opencues-cli/src/commands/seed-configs.cjs');
+  if (fs.existsSync(seedConfigsPath)) {
+    const seedConfigs = require(seedConfigsPath);
+    seedConfigs([], { REPO_ROOT });
+  } else {
+    console.error('seed-configs.cjs not found; cannot run.');
+    process.exit(1);
+  }
+}
+
+// --- helpers --------------------------------------------------------------
+
+function parseArgv(argv) {
+  const KNOWN_COMMANDS = new Set(['install', 'uninstall', 'seed-configs', 'help']);
+  const out = { command: 'install', args: { help: false, dryRun: false, link: null }, unknown: [] };
+  let i = 0;
+  if (argv[i] && !argv[i].startsWith('-')) {
+    if (KNOWN_COMMANDS.has(argv[i])) { out.command = argv[i]; i++; }
+    else { out.unknown.push(argv[i]); i++; }
+  }
+  for (; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--') continue;
+    if (a === '--help' || a === '-h') out.args.help = true;
+    else if (a === '--dry-run') out.args.dryRun = true;
+    else if (a === '--link') out.args.link = argv[++i];
+    else out.unknown.push(a);
+  }
+  return out;
+}
+
+function warnUnknownFlags(unknown) {
+  if (!unknown.length) return;
+  console.warn(`WARNING: ignoring unknown argument(s): ${unknown.join(' ')}`);
+  console.warn(`Known commands: install, uninstall, seed-configs, help`);
+  console.warn(`Known flags:    --link <dir>, --dry-run, --help`);
+  console.warn('');
+}
+
+function printBanner() {
+  console.log(`${pkg.name} v${pkg.version}`);
+}
+
+function printHelp() {
+  printBanner();
+  console.log('');
+  console.log('Commands:');
+  console.log('  install (default)   Build runtime, stage @opencues/* into local node_modules, run bun install');
+  console.log('  uninstall           Remove the staged @opencues/* and optional `oc-edit` symlink');
+  console.log('  seed-configs        Copy repo defaults to ~/.cues/ (skips files that exist)');
+  console.log('  help                Show this message');
+  console.log('');
+  console.log('Flags:');
+  console.log('  --link <dir>        Symlink bin/oc-edit into <dir> (typically ~/.local/bin)');
+  console.log('  --dry-run           Print the plan; do not execute');
+  console.log('  --help              Show this message');
+  console.log('');
+  console.log('Blast radius (much smaller than the patching hosts — no fork to clone):');
+  console.log(`  ${path.join(PKG_DIR, 'node_modules', '@opencues', 'core')}/`);
+  console.log(`  ${path.join(PKG_DIR, 'node_modules', '@opencues', 'runtime')}/`);
+  console.log(`  ${path.join(PKG_DIR, 'node_modules', '@opentui')}/        (and other Bun-resolved deps)`);
+  console.log(`  --link target (optional symlink only)`);
+  console.log('  Repo state (no host pollution):');
+  console.log('    packages/*/dist/  (build cache, gitignored)');
+}

--- a/integrations/terminal/bin/oc-edit
+++ b/integrations/terminal/bin/oc-edit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bun
+// Entry shim. Resolves the bundled or source app.tsx and runs it.
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const distApp = path.join(here, '..', 'dist', 'app.js');
+const srcApp = path.join(here, '..', 'src', 'app.tsx');
+const entry = fs.existsSync(distApp) ? distApp : srcApp;
+await import(entry);

--- a/integrations/terminal/bun.lock
+++ b/integrations/terminal/bun.lock
@@ -1,0 +1,396 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@opencues/terminal",
+      "dependencies": {
+        "@opentui/core": "0.1.99",
+        "@opentui/solid": "0.1.99",
+        "solid-js": "1.9.10",
+      },
+      "devDependencies": {
+        "@tsconfig/bun": "1.0.9",
+        "@types/bun": "1.3.11",
+        "typescript": "5.8.2",
+      },
+    },
+  },
+  "packages": {
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.3", "", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
+
+    "@babel/core": ["@babel/core@7.28.0", "", { "dependencies": { "@ampproject/remapping": "^2.2.0", "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.0", "@babel/helper-compilation-targets": "^7.27.2", "@babel/helper-module-transforms": "^7.27.3", "@babel/helpers": "^7.27.6", "@babel/parser": "^7.28.0", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.0", "@babel/types": "^7.28.0", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-annotate-as-pure": ["@babel/helper-annotate-as-pure@7.27.3", "", { "dependencies": { "@babel/types": "^7.27.3" } }, "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-create-class-features-plugin": ["@babel/helper-create-class-features-plugin@7.29.3", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/helper-replace-supers": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/traverse": "^7.29.0", "semver": "^6.3.1" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-member-expression-to-functions": ["@babel/helper-member-expression-to-functions@7.28.5", "", { "dependencies": { "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5" } }, "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-optimise-call-expression": ["@babel/helper-optimise-call-expression@7.27.1", "", { "dependencies": { "@babel/types": "^7.27.1" } }, "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-replace-supers": ["@babel/helper-replace-supers@7.28.6", "", { "dependencies": { "@babel/helper-member-expression-to-functions": "^7.28.5", "@babel/helper-optimise-call-expression": "^7.27.1", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg=="],
+
+    "@babel/helper-skip-transparent-expression-wrappers": ["@babel/helper-skip-transparent-expression-wrappers@7.27.1", "", { "dependencies": { "@babel/traverse": "^7.27.1", "@babel/types": "^7.27.1" } }, "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w=="],
+
+    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A=="],
+
+    "@babel/plugin-transform-modules-commonjs": ["@babel/plugin-transform-modules-commonjs@7.28.6", "", { "dependencies": { "@babel/helper-module-transforms": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA=="],
+
+    "@babel/plugin-transform-typescript": ["@babel/plugin-transform-typescript@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-create-class-features-plugin": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw=="],
+
+    "@babel/preset-typescript": ["@babel/preset-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1", "@babel/helper-validator-option": "^7.27.1", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-transform-modules-commonjs": "^7.27.1", "@babel/plugin-transform-typescript": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
+
+    "@jimp/core": ["@jimp/core@1.6.0", "", { "dependencies": { "@jimp/file-ops": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "await-to-js": "^3.0.0", "exif-parser": "^0.1.12", "file-type": "^16.0.0", "mime": "3" } }, "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w=="],
+
+    "@jimp/diff": ["@jimp/diff@1.6.0", "", { "dependencies": { "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "pixelmatch": "^5.3.0" } }, "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw=="],
+
+    "@jimp/file-ops": ["@jimp/file-ops@1.6.0", "", {}, "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ=="],
+
+    "@jimp/js-bmp": ["@jimp/js-bmp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "bmp-ts": "^1.0.9" } }, "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw=="],
+
+    "@jimp/js-gif": ["@jimp/js-gif@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "gifwrap": "^0.10.1", "omggif": "^1.0.10" } }, "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g=="],
+
+    "@jimp/js-jpeg": ["@jimp/js-jpeg@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "jpeg-js": "^0.4.4" } }, "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA=="],
+
+    "@jimp/js-png": ["@jimp/js-png@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "pngjs": "^7.0.0" } }, "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg=="],
+
+    "@jimp/js-tiff": ["@jimp/js-tiff@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "utif2": "^4.1.0" } }, "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw=="],
+
+    "@jimp/plugin-blit": ["@jimp/plugin-blit@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA=="],
+
+    "@jimp/plugin-blur": ["@jimp/plugin-blur@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw=="],
+
+    "@jimp/plugin-circle": ["@jimp/plugin-circle@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw=="],
+
+    "@jimp/plugin-color": ["@jimp/plugin-color@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "tinycolor2": "^1.6.0", "zod": "^3.23.8" } }, "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA=="],
+
+    "@jimp/plugin-contain": ["@jimp/plugin-contain@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ=="],
+
+    "@jimp/plugin-cover": ["@jimp/plugin-cover@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA=="],
+
+    "@jimp/plugin-crop": ["@jimp/plugin-crop@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang=="],
+
+    "@jimp/plugin-displace": ["@jimp/plugin-displace@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q=="],
+
+    "@jimp/plugin-dither": ["@jimp/plugin-dither@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0" } }, "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ=="],
+
+    "@jimp/plugin-fisheye": ["@jimp/plugin-fisheye@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA=="],
+
+    "@jimp/plugin-flip": ["@jimp/plugin-flip@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg=="],
+
+    "@jimp/plugin-hash": ["@jimp/plugin-hash@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "any-base": "^1.1.0" } }, "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q=="],
+
+    "@jimp/plugin-mask": ["@jimp/plugin-mask@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA=="],
+
+    "@jimp/plugin-print": ["@jimp/plugin-print@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/types": "1.6.0", "parse-bmfont-ascii": "^1.0.6", "parse-bmfont-binary": "^1.0.6", "parse-bmfont-xml": "^1.1.6", "simple-xml-to-json": "^1.2.2", "zod": "^3.23.8" } }, "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A=="],
+
+    "@jimp/plugin-quantize": ["@jimp/plugin-quantize@1.6.0", "", { "dependencies": { "image-q": "^4.0.0", "zod": "^3.23.8" } }, "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg=="],
+
+    "@jimp/plugin-resize": ["@jimp/plugin-resize@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA=="],
+
+    "@jimp/plugin-rotate": ["@jimp/plugin-rotate@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw=="],
+
+    "@jimp/plugin-threshold": ["@jimp/plugin-threshold@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w=="],
+
+    "@jimp/types": ["@jimp/types@1.6.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg=="],
+
+    "@jimp/utils": ["@jimp/utils@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "tinycolor2": "^1.6.0" } }, "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@opentui/core": ["@opentui/core@0.1.99", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.99", "@opentui/core-darwin-x64": "0.1.99", "@opentui/core-linux-arm64": "0.1.99", "@opentui/core-linux-x64": "0.1.99", "@opentui/core-win32-arm64": "0.1.99", "@opentui/core-win32-x64": "0.1.99", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-I3+AEgGzqNWIpWX9g2WOscSPwtQDNOm4KlBjxBWCZjLxkF07u77heWXF7OiAdhKLtNUW6TFiyt6yznqAZPdG3A=="],
+
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.99", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bzVrqeX2vb5iWrc/ftOUOqeUY8XO+qSgoTwj5TXHuwagavgwD3Hpeyjx8+icnTTeM4pao0som1WR9xfye6/X5Q=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.99", "", { "os": "darwin", "cpu": "x64" }, "sha512-VE4FrXBYpkxnvkqcCV1a8aN9jyyMJMihVW+V2NLCtp+4yQsj0AapG5TiUSN76XnmSZRptxDy5rBmEempeoIZbg=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.1.99", "", { "os": "linux", "cpu": "arm64" }, "sha512-viXQsbpS7yHjYkl7+am32JdvG96QU9lvHh1UiZtpOxcNUUqiYmA2ZwZFPD2Bi54jNyj5l2hjH6YkD3DzE2FEWA=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.1.99", "", { "os": "linux", "cpu": "x64" }, "sha512-WLoEFINOSp0tZSR9y4LUuGc7n4Y7H1wcpjUPzQ9vChkYDXrfZltEanzoDWbDcQ4kZQW5tHVC7LrZHpAsRLwFZg=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.1.99", "", { "os": "win32", "cpu": "arm64" }, "sha512-yWMOLWCEO8HdrctU1dMkgZC8qGkiO4Dwr4/e11tTvVpRmYhDsP/IR89ZjEEtOwnKwFOFuB/MxvflqaEWVQ2g5Q=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.1.99", "", { "os": "win32", "cpu": "x64" }, "sha512-aYRlsL2w8YRL6vPd7/hrqlNVkXU3QowWb01TOvAcHS8UAsXaGFUr47kSDyjxDi1wg1MzmVduCfsC7T3NoThV1w=="],
+
+    "@opentui/solid": ["@opentui/solid@0.1.99", "", { "dependencies": { "@babel/core": "7.28.0", "@babel/preset-typescript": "7.27.1", "@opentui/core": "0.1.99", "babel-plugin-module-resolver": "5.0.2", "babel-preset-solid": "1.9.10", "entities": "7.0.1", "s-js": "^0.4.9" }, "peerDependencies": { "solid-js": "1.9.11" } }, "sha512-DrqqO4h2V88FmeIP2cErYkMU0ZK5MrUsZw3w6IzZpoXyyiL4/9qpWzUq+CXx+r16VP2iGxDJwGKUmtFAzUch2Q=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tsconfig/bun": ["@tsconfig/bun@1.0.9", "", {}, "sha512-4M0/Ivfwcpz325z6CwSifOBZYji3DFOEpY6zEUt0+Xi2qRhzwvmqQN9XAHJh3OVvRJuAqVTLU2abdCplvp6mwQ=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
+    "@webgpu/types": ["@webgpu/types@0.1.70", "", {}, "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
+
+    "await-to-js": ["await-to-js@3.0.0", "", {}, "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g=="],
+
+    "babel-plugin-jsx-dom-expressions": ["babel-plugin-jsx-dom-expressions@0.40.7", "", { "dependencies": { "@babel/helper-module-imports": "7.18.6", "@babel/plugin-syntax-jsx": "^7.18.6", "@babel/types": "^7.20.7", "html-entities": "2.3.3", "parse5": "^7.1.2" }, "peerDependencies": { "@babel/core": "^7.20.12" } }, "sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ=="],
+
+    "babel-plugin-module-resolver": ["babel-plugin-module-resolver@5.0.2", "", { "dependencies": { "find-babel-config": "^2.1.1", "glob": "^9.3.3", "pkg-up": "^3.1.0", "reselect": "^4.1.7", "resolve": "^1.22.8" } }, "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg=="],
+
+    "babel-preset-solid": ["babel-preset-solid@1.9.10", "", { "dependencies": { "babel-plugin-jsx-dom-expressions": "^0.40.3" }, "peerDependencies": { "@babel/core": "^7.0.0", "solid-js": "^1.9.10" }, "optionalPeers": ["solid-js"] }, "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.32", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg=="],
+
+    "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
+
+    "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "bun-webgpu": ["bun-webgpu@0.1.5", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.5", "bun-webgpu-darwin-x64": "^0.1.5", "bun-webgpu-linux-x64": "^0.1.5", "bun-webgpu-win32-x64": "^0.1.5" } }, "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA=="],
+
+    "bun-webgpu-darwin-arm64": ["bun-webgpu-darwin-arm64@0.1.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mRrFFyHzPWjsTRidAZBRcu808CPQBOUL0P6b4nxLhp+XHcV/mbUHERZMgW9s58tsojQfSdzschiQa8q+JCgRWA=="],
+
+    "bun-webgpu-darwin-x64": ["bun-webgpu-darwin-x64@0.1.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-g0NXGNgvaVCSH/jCWWlfdiquOHkbUN6vP4zqzSkIxWKQeLnqm3oADcok7SO3yIgI7v5mKpRc/ks7NDEKNH+jNQ=="],
+
+    "bun-webgpu-linux-x64": ["bun-webgpu-linux-x64@0.1.7", "", { "os": "linux", "cpu": "x64" }, "sha512-UEP7UZdEhx9otvkZczjsszL8ZVlrODANQvgl+C88/bNVmxDoFi7w1fWzGi1sZyakiETjmtFDq2/xCLhbSZxjqw=="],
+
+    "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.7", "", { "os": "win32", "cpu": "x64" }, "sha512-KZktiFkBz6sN7PEm1NVdeaLP5Q5X/PlSHZqefY4nNuWtf0LNvh54NhZe7yVv/Plz/nGbv92b0KHMBY3ki/pp6g=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001793", "", {}, "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.361", "", {}, "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
+
+    "file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
+
+    "find-babel-config": ["find-babel-config@2.1.2", "", { "dependencies": { "json5": "^2.2.3" } }, "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg=="],
+
+    "find-up": ["find-up@3.0.0", "", { "dependencies": { "locate-path": "^3.0.0" } }, "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
+
+    "glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "html-entities": ["html-entities@2.3.3", "", {}, "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
+
+    "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
+
+    "jimp": ["jimp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/diff": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-gif": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-blur": "1.6.0", "@jimp/plugin-circle": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-contain": "1.6.0", "@jimp/plugin-cover": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-displace": "1.6.0", "@jimp/plugin-dither": "1.6.0", "@jimp/plugin-fisheye": "1.6.0", "@jimp/plugin-flip": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/plugin-mask": "1.6.0", "@jimp/plugin-print": "1.6.0", "@jimp/plugin-quantize": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/plugin-rotate": "1.6.0", "@jimp/plugin-threshold": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg=="],
+
+    "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "locate-path": ["locate-path@3.0.0", "", { "dependencies": { "p-locate": "^3.0.0", "path-exists": "^3.0.0" } }, "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "minimatch": ["minimatch@8.0.7", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg=="],
+
+    "minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "node-releases": ["node-releases@2.0.46", "", {}, "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ=="],
+
+    "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
+
+    "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "^2.0.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parse-bmfont-ascii": ["parse-bmfont-ascii@1.0.6", "", {}, "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="],
+
+    "parse-bmfont-binary": ["parse-bmfont-binary@1.0.6", "", {}, "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="],
+
+    "parse-bmfont-xml": ["parse-bmfont-xml@1.1.6", "", { "dependencies": { "xml-parse-from-string": "^1.0.0", "xml2js": "^0.5.0" } }, "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
+
+    "pkg-up": ["pkg-up@3.1.0", "", { "dependencies": { "find-up": "^3.0.0" } }, "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA=="],
+
+    "planck": ["planck@1.5.0", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g=="],
+
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
+
+    "reselect": ["reselect@4.1.8", "", {}, "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "s-js": ["s-js@0.4.9", "", {}, "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "seroval": ["seroval@1.3.2", "", {}, "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ=="],
+
+    "seroval-plugins": ["seroval-plugins@1.3.3", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w=="],
+
+    "simple-xml-to-json": ["simple-xml-to-json@1.2.7", "", {}, "sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q=="],
+
+    "solid-js": ["solid-js@1.9.10", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.3.0", "seroval-plugins": "~1.3.0" } }, "sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew=="],
+
+    "stage-js": ["stage-js@1.0.2", "", {}, "sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "three": ["three@0.177.0", "", {}, "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg=="],
+
+    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
+
+    "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
+
+    "typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
+
+    "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
+
+    "xml-parse-from-string": ["xml-parse-from-string@1.0.1", "", {}, "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="],
+
+    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "babel-plugin-jsx-dom-expressions/@babel/helper-module-imports": ["@babel/helper-module-imports@7.18.6", "", { "dependencies": { "@babel/types": "^7.18.6" } }, "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA=="],
+
+    "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "path-scurry/minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
+  }
+}

--- a/integrations/terminal/bunfig.toml
+++ b/integrations/terminal/bunfig.toml
@@ -1,0 +1,1 @@
+preload = ["@opentui/solid/preload"]

--- a/integrations/terminal/compat.json
+++ b/integrations/terminal/compat.json
@@ -1,0 +1,14 @@
+{
+  "//": "OpenCues compatibility manifest for the standalone terminal integration. Unlike CC/OC/Gemini, there is no upstream host to pin — the integration ships its own Bun/OpenTUI app. Pin still tracked here for the @opentui/* dep so a UI break upstream can be re-tested against a known-good combo.",
+  "host-kind": "self",
+  "host-repo": "opencues/opencues",
+  "current-pin-source": {
+    "kind": "json-file",
+    "path-from-repo": "integrations/terminal/pin.json"
+  },
+  "tested": [
+    { "version": "0.1.0", "opentui": "0.1.99" }
+  ],
+  "compat-range": ["0.1.x"],
+  "known-incompatible": []
+}

--- a/integrations/terminal/package.json
+++ b/integrations/terminal/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@opencues/terminal",
+  "version": "0.1.0",
+  "private": true,
+  "description": "OpenCues for the terminal — a standalone Bun/OpenTUI TUI you launch as `oc-edit`. Brings full cues, blanks, cycling, agent-rewrite to any shell via $EDITOR or a ZLE widget.",
+  "type": "module",
+  "bin": {
+    "oc-edit": "./bin/oc-edit"
+  },
+  "scripts": {
+    "build": "bun build src/app.tsx --outfile=dist/app.js --target=bun --external @opentui/core --external @opentui/solid --external solid-js --external @opencues/core --external @opencues/runtime",
+    "dev": "bun --conditions=browser src/app.tsx"
+  },
+  "dependencies": {
+    "@opentui/core": "0.1.99",
+    "@opentui/solid": "0.1.99",
+    "solid-js": "1.9.10"
+  },
+  "//comment-on-opencues-deps": "@opencues/{core,runtime} are NOT npm-resolved deps here. setup.sh cp -r's the built dist into node_modules/@opencues/{core,runtime}/, mirroring the way integrations/opencode/patches/setup.sh wires the same packages into its fork. This keeps the install path identical across hosts and avoids workspace-resolution drift between pnpm (top-level) and bun (this integration).",
+  "devDependencies": {
+    "@tsconfig/bun": "1.0.9",
+    "@types/bun": "1.3.11",
+    "typescript": "5.8.2"
+  },
+  "files": [
+    "bin/",
+    "dist/",
+    "README.md"
+  ]
+}

--- a/integrations/terminal/patches/setup.sh
+++ b/integrations/terminal/patches/setup.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Terminal integration setup.
+#
+# Builds @opencues/{core,runtime}, installs the standalone @opencues/terminal
+# package's deps via bun, and (optionally) symlinks `oc-edit` into a
+# PATH location. Unlike CC/OC there is no upstream fork to clone or
+# patch — the app is self-owned.
+#
+# Usage: ./setup.sh [--link DIR]
+#   --link DIR  symlink bin/oc-edit into DIR (default: skip)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPENCUES_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TERM_DIR="$OPENCUES_ROOT/integrations/terminal"
+
+LINK_DIR=""
+while (( "$#" )); do
+  case "$1" in
+    --link) LINK_DIR="${2:-}"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+LOG="${OPENCUES_INSTALL_LOG:-/tmp/opencues-install-terminal.log}"
+: > "$LOG"
+
+# ─── Bun prereq ──────────────────────────────────────────────────────
+if ! command -v bun >/dev/null 2>&1; then
+  echo "✗ bun not found on PATH. Install: https://bun.sh"
+  exit 1
+fi
+
+# ─── Build runtime + core ────────────────────────────────────────────
+echo "  ▸ building @opencues/core + @opencues/runtime"
+(
+  cd "$OPENCUES_ROOT"
+  pnpm --filter @opencues/core --filter @opencues/runtime build
+) >>"$LOG" 2>&1
+
+# ─── Install terminal deps ───────────────────────────────────────────
+echo "  ▸ installing @opencues/terminal deps via bun"
+(
+  cd "$TERM_DIR"
+  bun install
+) >>"$LOG" 2>&1
+
+# ─── Stage @opencues/{core,runtime} into local node_modules ──────────
+# Mirrors integrations/opencode/patches/setup.sh's install_into_fork:
+# cp -r the built dist + package.json into a vendored path. Avoids
+# workspace-resolution drift between top-level pnpm and Bun.
+echo "  ▸ staging @opencues/core + @opencues/runtime into local node_modules"
+RT_DEST="$TERM_DIR/node_modules/@opencues/runtime"
+CORE_DEST="$TERM_DIR/node_modules/@opencues/core"
+rm -rf "$RT_DEST" "$CORE_DEST"
+mkdir -p "$RT_DEST" "$CORE_DEST"
+cp -r "$OPENCUES_ROOT/packages/opencues-runtime/dist" "$RT_DEST/"
+cp "$OPENCUES_ROOT/packages/opencues-runtime/package.json" "$RT_DEST/"
+cp -r "$OPENCUES_ROOT/packages/opencues-core/dist" "$CORE_DEST/"
+cp "$OPENCUES_ROOT/packages/opencues-core/package.json" "$CORE_DEST/"
+if [[ -f "$OPENCUES_ROOT/packages/opencues-core/node-http-adapter.js" ]]; then
+  # Lives at the package root, not dist/ — resolver's
+  # `require('@opencues/core/node-http-adapter')` resolves to
+  # <pkg-root>/node-http-adapter.js. See packages/opencues-runtime
+  # /adapters/oc/REPAIR.md § LF-7 for the OC analogue of this trap.
+  cp "$OPENCUES_ROOT/packages/opencues-core/node-http-adapter.js" "$CORE_DEST/"
+fi
+
+# ─── Optional symlink ────────────────────────────────────────────────
+if [[ -n "$LINK_DIR" ]]; then
+  mkdir -p "$LINK_DIR"
+  ln -sf "$TERM_DIR/bin/oc-edit" "$LINK_DIR/oc-edit"
+  echo "  ▸ symlinked oc-edit → $LINK_DIR/oc-edit"
+fi
+
+echo "✓ Terminal integration ready."
+echo
+echo "Try it:"
+echo "  $TERM_DIR/bin/oc-edit"
+echo "  echo 'the attorney filed today' | $TERM_DIR/bin/oc-edit"
+echo
+echo "As your editor:"
+echo "  export EDITOR=$TERM_DIR/bin/oc-edit"
+echo "  git commit  # opens oc-edit"

--- a/integrations/terminal/pin.json
+++ b/integrations/terminal/pin.json
@@ -1,0 +1,5 @@
+{
+  "//": "OpenTUI pin for the terminal integration. The terminal app has no upstream fork; what's pinned is the rendering stack. Bump in lockstep with OpenCode's catalog when a new OpenTUI lands so REPAIR.md fixes apply uniformly.",
+  "opentui": "0.1.99",
+  "solid-js": "1.9.10"
+}

--- a/integrations/terminal/src/app.tsx
+++ b/integrations/terminal/src/app.tsx
@@ -1,0 +1,124 @@
+// Standalone OpenCues terminal app.
+//
+// Renders a single full-width TextareaRenderable with a one-line
+// statusline below it. On Ctrl+S (or Ctrl+D / Enter-on-empty / submit
+// keybind) the current buffer is printed to stdout and the process
+// exits — same shape as $EDITOR-style invocations.
+
+import { render, useKeyboard, useRenderer } from '@opentui/solid';
+import { createSignal, onMount } from 'solid-js';
+import type { TextareaRenderable } from '@opentui/core';
+import { SyntaxStyle } from '@opentui/core';
+import { startOpenCues, dispatchOpenCuesKey } from './bootstrap';
+
+interface AppOpts {
+  initialText: string;
+  outputPath: string | null;
+}
+
+function App(props: AppOpts) {
+  const renderer = useRenderer();
+  const [tip, setTip] = createSignal<string | null>(null);
+  let textarea: TextareaRenderable | undefined;
+  const syntax = SyntaxStyle.create();
+
+  onMount(() => {
+    if (!textarea) return;
+    textarea.syntaxStyle = syntax;
+    if (props.initialText) {
+      textarea.setText(props.initialText);
+      textarea.cursorOffset = props.initialText.length;
+    }
+    startOpenCues({
+      renderer,
+      textarea,
+      syntax,
+      cwd: process.cwd(),
+      onTipChange: (t) => setTip(t),
+    });
+    textarea.focus();
+  });
+
+  useKeyboard((evt: any) => {
+    // Ctrl+S commits the buffer; Ctrl+C exits without committing.
+    if (evt.ctrl && (evt.name === 's' || evt.sequence === '\x13')) {
+      finish(textarea?.plainText ?? '', 0);
+      return;
+    }
+    if (evt.ctrl && (evt.name === 'c' || evt.sequence === '\x03')) {
+      finish('', 130);
+      return;
+    }
+    // Forward to OpenCues first; only fall through to OpenTUI's own
+    // textarea key handling if the runtime didn't consume it.
+    dispatchOpenCuesKey(evt);
+  });
+
+  function finish(text: string, exitCode: number): void {
+    try {
+      if (props.outputPath) {
+        require('node:fs').writeFileSync(props.outputPath, text);
+      } else {
+        process.stdout.write(text);
+      }
+    } catch { /* swallow */ }
+    setTimeout(() => process.exit(exitCode), 0);
+  }
+
+  return (
+    <box style={{ flexDirection: 'column', width: '100%', height: '100%' }}>
+      <box style={{ flexGrow: 1, width: '100%' }}>
+        <textarea
+          ref={(t: TextareaRenderable) => { textarea = t; }}
+          style={{ width: '100%', height: '100%' }}
+          wrapMode="word"
+        />
+      </box>
+      <box style={{ height: 1, width: '100%', flexDirection: 'row' }}>
+        <text>{tip() ?? 'opencues — Ctrl+S submit, Ctrl+C cancel'}</text>
+      </box>
+    </box>
+  );
+}
+
+function parseArgs(argv: string[]): { initialText: string; outputPath: string | null } {
+  let initialText = '';
+  let outputPath: string | null = null;
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--out' || a === '-o') {
+      outputPath = argv[++i] ?? null;
+    } else if (a === '--initial' || a === '-i') {
+      initialText = argv[++i] ?? '';
+    } else if (a === '--help' || a === '-h') {
+      console.log('Usage: oc-edit [--initial TEXT] [--out FILE]');
+      console.log('       echo TEXT | oc-edit');
+      process.exit(0);
+    } else if (!a.startsWith('-')) {
+      // Positional: treat as a file to edit.
+      try { initialText = require('node:fs').readFileSync(a, 'utf8'); outputPath = a; } catch {}
+    }
+  }
+  return { initialText, outputPath };
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv);
+
+  // Pipe-from-stdin shortcut: if stdin isn't a TTY, slurp it as initial text.
+  if (!process.stdin.isTTY && !args.initialText) {
+    args.initialText = await new Promise<string>((resolve) => {
+      let buf = '';
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', (chunk) => { buf += chunk; });
+      process.stdin.on('end', () => resolve(buf));
+    });
+  }
+
+  await render(() => <App initialText={args.initialText} outputPath={args.outputPath} />);
+}
+
+main().catch((err) => {
+  console.error('[oc-edit] fatal:', err);
+  process.exit(1);
+});

--- a/integrations/terminal/src/bootstrap.ts
+++ b/integrations/terminal/src/bootstrap.ts
@@ -1,0 +1,492 @@
+// OpenCues bootstrap for the standalone terminal app.
+//
+// Mirrors integrations/opencode/patches/opencuesBootstrap.ts but
+// targets a self-owned OpenTUI app (no fork, no patch, no holder/
+// publish dance). The textarea + renderer refs are passed directly
+// in by src/app.tsx on mount.
+
+import type { CliRenderer, TextareaRenderable } from '@opentui/core';
+import { RGBA, SyntaxStyle } from '@opentui/core';
+import { boot, type BootResult } from '@opencues/runtime/dist/adapters/terminal/v1/boot';
+import type { KeyEvent, LogLevel } from '@opencues/runtime/dist/src/adapter';
+import { createSourceReclassifier } from '@opencues/runtime/dist/src/boot-common';
+import {
+  createBlankInvoke,
+  createDefaultBlanksRegistry,
+  type Blank,
+} from '@opencues/runtime/dist/src/blanks';
+import {
+  validateScriptPath,
+  appendAuditLog,
+} from '@opencues/runtime/dist/src/security/spawn-sandbox';
+import { wrapWithBwrap } from '@opencues/runtime/dist/src/security/sandbox-runner';
+import {
+  buildUserBlankRegistry,
+  createNativeLlmAdapter,
+  type BlankConfigLike,
+} from '@opencues/runtime/dist/src/user-blanks/registry';
+import { parseSingleCueMd } from '@opencues/core';
+import {
+  existsSync as fsExistsSync,
+  readdirSync as fsReaddirSync,
+  readFileSync as fsReadFileSync,
+} from 'node:fs';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import { spawn as nodeSpawn } from 'node:child_process';
+
+function getCuesRoots(): string[] {
+  const roots: string[] = [];
+  if (process.env['OPENCUES_HOME']) roots.push(process.env['OPENCUES_HOME']);
+  roots.push(path.join(process.cwd(), '.cues'));
+  roots.push(path.join(os.homedir(), '.cues'));
+  return roots;
+}
+
+function findOpenCuesMdPath(): string {
+  if (process.env['OPENCUES_HOME']) {
+    return path.join(process.env['OPENCUES_HOME'], 'OPENCUES.md');
+  }
+  return path.join(process.env['HOME'] ?? os.homedir(), '.cues', 'OPENCUES.md');
+}
+
+function resolveTtsScript(): string {
+  const root = process.env['OPENCUES_HOME'] ?? path.join(process.env['HOME'] ?? os.homedir(), '.cues');
+  return path.join(root, 'scripts/speak.sh');
+}
+
+const groqApiKey = process.env['GROQ_API_KEY'];
+const blanksRegistry: Map<string, Blank> = createDefaultBlanksRegistry({
+  llmConfig: groqApiKey ? { apiKey: groqApiKey } : undefined,
+  finnhubApiKey: process.env['FINNHUB_API_KEY'],
+  opencuesMdIO: {
+    readFile: async () => {
+      try { return await fs.readFile(findOpenCuesMdPath(), 'utf8'); } catch { return null; }
+    },
+    writeFile: async (content) => {
+      await fs.writeFile(findOpenCuesMdPath(), content, 'utf8');
+    },
+  },
+});
+
+function _discoverUserBlankConfigs(): BlankConfigLike[] {
+  const rawRoots: string[] = [];
+  if (process.env['OPENCUES_HOME']) rawRoots.push(process.env['OPENCUES_HOME']);
+  rawRoots.push(path.join(process.cwd(), '.cues'));
+  rawRoots.push(path.join(process.env['HOME'] ?? os.homedir(), '.cues'));
+  const seen = new Set<string>();
+  const roots: string[] = [];
+  for (const r of rawRoots) {
+    const abs = path.resolve(r);
+    if (seen.has(abs)) continue;
+    seen.add(abs);
+    roots.push(abs);
+  }
+  const out: BlankConfigLike[] = [];
+  for (const root of roots) {
+    const blanksDir = path.join(root, 'blanks');
+    if (!fsExistsSync(blanksDir)) continue;
+    for (const entry of fsReaddirSync(blanksDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const blankMdPath = path.join(blanksDir, entry.name, 'BLANK.md');
+      if (!fsExistsSync(blankMdPath)) continue;
+      try {
+        const content = fsReadFileSync(blankMdPath, 'utf8');
+        const parsed = parseSingleCueMd(content, path.dirname(blankMdPath));
+        const blk = parsed.blanks?.[entry.name];
+        if (blk?.impl) out.push(blk as BlankConfigLike);
+      } catch { /* skip on parse error */ }
+    }
+  }
+  return out;
+}
+
+const _userBlanks = buildUserBlankRegistry(_discoverUserBlankConfigs(), {
+  storageRoot: process.env['OPENCUES_HOME'] ?? path.join(process.env['HOME'] ?? os.homedir(), '.cues'),
+  secrets: process.env as Readonly<Record<string, string>>,
+  llm: createNativeLlmAdapter(process.env as Record<string, string>),
+  log: (lvl, msg) => {
+    if (lvl === 'warn' || lvl === 'error') console.warn(`[opencues] user-blank ${lvl}: ${msg}`);
+    else if (process.env['DEBUG_OPENCUES']) console.log(`[opencues] user-blank ${lvl}: ${msg}`);
+  },
+});
+for (const [n, b] of _userBlanks) blanksRegistry.set(n, b);
+const blankInvoke = createBlankInvoke(blanksRegistry);
+
+export interface TerminalBootOpts {
+  renderer: CliRenderer;
+  textarea: TextareaRenderable;
+  /** SyntaxStyle attached to the textarea (created by app.tsx on mount). */
+  syntax: SyntaxStyle;
+  cwd: string;
+  /** Live tip subscriber — the footer reads from this. */
+  onTipChange?: (tip: string | null) => void;
+}
+
+const sourceReclassifier = createSourceReclassifier();
+let bootResult: BootResult | undefined;
+
+export function startOpenCues(opts: TerminalBootOpts): BootResult {
+  if (bootResult) return bootResult;
+
+  const log = (level: LogLevel, msg: string, data?: unknown): void => {
+    try {
+      const ts = new Date().toISOString().slice(11, 23);
+      let dataStr = '';
+      if (data !== undefined && data !== null) {
+        if (data instanceof Error) {
+          dataStr = `${data.name}: ${data.message}${data.stack ? '\n' + data.stack : ''}`;
+        } else if (typeof data === 'string') {
+          dataStr = data;
+        } else {
+          dataStr = JSON.stringify(data).slice(0, 400);
+        }
+      }
+      const line = `[${ts}][term][${level}] ${msg} ${dataStr}\n`;
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      require('fs').appendFile('/tmp/opencues.log', line, () => {});
+    } catch { /* swallow */ }
+  };
+
+  const getText = (): string => opts.textarea.plainText;
+  const getCursor = (): number => opts.textarea.cursorOffset;
+
+  bootResult = boot({
+    hostVersion: '0.1.0',
+    cwd: opts.cwd || process.cwd(),
+    getText,
+    getCursorOffset: getCursor,
+    setText: (text) => {
+      sourceReclassifier.markRuntimeWrite(text);
+      opts.textarea.setText(text);
+      // OpenTUI's editBuffer.setText clears every extmark — see comment
+      // by ocOwnedExtmarks in opencode's bootstrap. Drop our owned map
+      // so the next render rebuilds.
+      ownedExtmarks = new Map();
+    },
+    setCursorOffset: (offset) => {
+      opts.textarea.cursorOffset = offset;
+    },
+    pushText: (text, cursor) => {
+      sourceReclassifier.markRuntimeWrite(text);
+      opts.textarea.setText(text);
+      if (cursor !== undefined) opts.textarea.cursorOffset = cursor;
+      ownedExtmarks = new Map();
+    },
+    forceRender: () => {
+      try { triggerOpenCuesRender(getText(), getCursor()); } catch { /* swallow */ }
+      opts.renderer.requestRender();
+    },
+    readFile: async (p) => { try { return await fs.readFile(p, 'utf8'); } catch { return null; } },
+    readDir: async (p) => {
+      try {
+        const entries = await fs.readdir(p, { withFileTypes: true });
+        return entries.map(e => ({ name: e.name, isDirectory: e.isDirectory() }));
+      } catch { return null; }
+    },
+    writeFile: async (p, c) => { await fs.writeFile(p, c); },
+    spawnProcess: (spec: any) => {
+      const cuesRoots = getCuesRoots();
+      const rawArgs: string[] = Array.isArray(spec.args) ? spec.args.map(String) : [];
+      const safeArgs: string[] = [];
+      for (const a of rawArgs) {
+        const r = validateScriptPath(a, cuesRoots);
+        if (!r.ok) {
+          appendAuditLog('terminal', spec, { exitCode: 126 }, cuesRoots);
+          return {
+            result: Promise.resolve({ exitCode: 126, stdout: '', stderr: r.reason ?? 'path outside CUES roots', timedOut: false }),
+            kill: () => {},
+          };
+        }
+        safeArgs.push(r.resolved ?? a);
+      }
+      const wrapped = wrapWithBwrap(spec.command, safeArgs, spec.sandbox, cuesRoots);
+      const finalCommand = wrapped?.command ?? spec.command;
+      const finalArgs = wrapped?.args ?? safeArgs;
+
+      const startedAt = Date.now();
+      const wantStdin = typeof spec.input === 'string' && spec.input.length > 0;
+      const stdio: any = spec.detached
+        ? 'ignore'
+        : [wantStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'];
+      let child: any;
+      try {
+        child = nodeSpawn(finalCommand, finalArgs, {
+          env: spec.env,
+          cwd: spec.cwd,
+          detached: !!spec.detached,
+          stdio,
+        });
+      } catch (err: any) {
+        appendAuditLog('terminal', spec, { exitCode: 127 }, cuesRoots);
+        return {
+          result: Promise.resolve({ exitCode: 127, stdout: '', stderr: String(err?.message ?? err), timedOut: false }),
+          kill: () => {},
+        };
+      }
+      if (wantStdin && child.stdin) {
+        try { child.stdin.write(spec.input); child.stdin.end(); } catch {}
+      }
+      let stdout = '', stderr = '';
+      child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+      child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+      const result = new Promise<{ exitCode: number; stdout: string; stderr: string; timedOut: boolean }>((resolve) => {
+        let timedOut = false;
+        let killer: NodeJS.Timeout | null = null;
+        const timer = spec.timeoutMs
+          ? setTimeout(() => {
+              timedOut = true;
+              try { child.kill('SIGTERM'); } catch {}
+              killer = setTimeout(() => { try { child.kill('SIGKILL'); } catch {} }, 1000);
+            }, spec.timeoutMs)
+          : null;
+        const finish = (code: number | null): void => {
+          if (timer) clearTimeout(timer);
+          if (killer) clearTimeout(killer);
+          const exit = code ?? 0;
+          appendAuditLog('terminal', spec, { exitCode: exit, timedOut }, cuesRoots, Date.now() - startedAt);
+          resolve({ exitCode: exit, stdout, stderr, timedOut });
+        };
+        child.on('exit', finish);
+        child.on('error', (err: any) => {
+          stderr += String(err?.message ?? err);
+          finish(127);
+        });
+      });
+      if (spec.detached) child.unref();
+      return { result, kill: (sig?: string) => { try { child.kill((sig as any) || 'SIGTERM'); } catch {} } };
+    },
+    log,
+    blankInvoke,
+    statusFilePath: `/tmp/opencues-status-${process.pid}.json`,
+    cursorStatePath: `/tmp/opencues-cursor-state-${process.pid}.json`,
+    statusSnapshotHook: (payload: any) => {
+      if (!opts.onTipChange) return;
+      const agentTask = payload?.agentTask as string | null | undefined;
+      const agentBadge = agentTask ? `[task: ${agentTask}]` : null;
+      let wordPart: string | null = null;
+      if (payload?.active) {
+        const tip = payload?.cueTip as string | null | undefined;
+        const word = payload?.highlightedWord as string | undefined;
+        const alts = payload?.alts as readonly string[] | undefined;
+        const cueBlank = !!payload?.cueBlank;
+        if (cueBlank) {
+          wordPart = tip ?? null;
+        } else if (alts && alts.length > 1 && word) {
+          const idx = (payload?.currentAltIndex ?? 0) + 1;
+          const head = `${word} (${idx}/${alts.length})`;
+          wordPart = tip ? `${head} - ${tip}` : head;
+        } else {
+          wordPart = tip ?? null;
+        }
+      }
+      const combined = wordPart && agentBadge ? `${wordPart} | ${agentBadge}` : (agentBadge ?? wordPart ?? null);
+      opts.onTipChange(combined);
+    },
+    ttsScriptPath: resolveTtsScript(),
+    ttsRate: 2,
+    llmApiKey: process.env['GROQ_API_KEY'],
+    llmEndpoint: process.env['OPENCUES_LLM_ENDPOINT'],
+    llmDefaultModel: process.env['OPENCUES_LLM_MODEL'],
+    llmApiKeys: {
+      GROQ_API_KEY: process.env['GROQ_API_KEY'],
+      OPENROUTER_API_KEY: process.env['OPENROUTER_API_KEY'],
+      GEMINI_API_KEY: process.env['GEMINI_API_KEY'],
+      OPENAI_API_KEY: process.env['OPENAI_API_KEY'],
+      ANTHROPIC_API_KEY: process.env['ANTHROPIC_API_KEY'],
+      CEREBRAS_API_KEY: process.env['CEREBRAS_API_KEY'],
+    },
+  });
+
+  // Wire OpenTUI's content-change → notify runtime + repaint extmarks.
+  opts.textarea.onContentChange = () => {
+    const text = getText();
+    const cursor = getCursor();
+    const actualSource = sourceReclassifier.reclassify(text, 'user');
+    bootResult!.notifyTextChange(text, cursor, actualSource);
+    triggerOpenCuesRender(text, cursor);
+  };
+  opts.textarea.onCursorChange = () => {
+    bootResult!.notifyCursorChange(getText(), getCursor(), 'user');
+  };
+
+  // Stash refs for the renderer helper.
+  _textareaRef = opts.textarea;
+  _syntaxRef = opts.syntax;
+
+  return bootResult;
+}
+
+export function dispatchOpenCuesKey(evt: any): boolean {
+  if (!bootResult) return false;
+  const text = _textareaRef?.plainText ?? '';
+  const cursor = _textareaRef?.cursorOffset ?? 0;
+  const e: KeyEvent = {
+    key: normaliseKeyName(evt),
+    modifiers: {
+      ctrl: !!evt.ctrl,
+      alt: !!evt.option || !!evt.alt,
+      shift: !!evt.shift,
+      meta: !!evt.meta,
+    },
+    text,
+    cursorOffset: cursor,
+  };
+  const consumed = bootResult.dispatchKey(e);
+  if (consumed) triggerOpenCuesRender(_textareaRef?.plainText ?? text, _textareaRef?.cursorOffset ?? cursor);
+  return consumed;
+}
+
+function normaliseKeyName(evt: any): string {
+  if (evt.name) return String(evt.name).toLowerCase();
+  if (evt.sequence) return String(evt.sequence);
+  return '';
+}
+
+// ─── Extmark applier ────────────────────────────────────────────────────
+// Lifted from integrations/opencode/patches/opencuesBootstrap.ts. The
+// diff-based approach (keep / delete-stale / create-new) avoids the
+// 100-300ms input-lag from clearing-and-recreating ~30 dim extmarks
+// per keystroke. See the OpenTUI extmark-contract comment in that
+// file for the ADJUSTS vs CLEARS table — same trap applies here.
+
+type ExtmarkKey = string;
+let ownedExtmarks = new Map<ExtmarkKey, number>();
+let styleIds: {
+  dim?: number; highlight?: number; typeId?: number;
+  bold?: number; italic?: number; code?: number; strike?: number; heading?: number; list?: number;
+} = {};
+let loadingColorIds = new Map<string, number>();
+let _textareaRef: TextareaRenderable | null = null;
+let _syntaxRef: SyntaxStyle | null = null;
+
+export function triggerOpenCuesRender(text: string, cursor: number): void {
+  if (!bootResult || !_textareaRef || !_syntaxRef) return;
+  const syntax = _syntaxRef;
+  const textarea = _textareaRef;
+  if (textarea.isDestroyed) return;
+
+  if (styleIds.dim === undefined) {
+    styleIds.dim = syntax.getStyleId('opencues-dim') ?? syntax.registerStyle('opencues-dim', { dim: true });
+  }
+  if (styleIds.highlight === undefined) {
+    styleIds.highlight = syntax.getStyleId('opencues-highlight')
+      ?? syntax.registerStyle('opencues-highlight', {
+        fg: RGBA.fromValues(1, 1, 1, 1),
+        bg: RGBA.fromValues(0, 0, 0, 1),
+      });
+  }
+  if (styleIds.bold === undefined) {
+    styleIds.bold = syntax.getStyleId('opencues-bold') ?? syntax.registerStyle('opencues-bold', { bold: true });
+  }
+  if (styleIds.italic === undefined) {
+    styleIds.italic = syntax.getStyleId('opencues-italic') ?? syntax.registerStyle('opencues-italic', { italic: true });
+  }
+  if (styleIds.code === undefined) {
+    styleIds.code = syntax.getStyleId('opencues-code')
+      ?? syntax.registerStyle('opencues-code', { fg: RGBA.fromValues(0.9, 0.7, 0.4, 1) });
+  }
+  if (styleIds.strike === undefined) {
+    try {
+      styleIds.strike = syntax.getStyleId('opencues-strike')
+        ?? syntax.registerStyle('opencues-strike', { strikethrough: true } as any);
+    } catch {
+      styleIds.strike = syntax.getStyleId('opencues-strike-dim')
+        ?? syntax.registerStyle('opencues-strike-dim', { dim: true });
+    }
+  }
+  if (styleIds.heading === undefined) {
+    styleIds.heading = syntax.getStyleId('opencues-heading')
+      ?? syntax.registerStyle('opencues-heading', { bold: true, underline: true } as any);
+  }
+  if (styleIds.list === undefined) {
+    styleIds.list = syntax.getStyleId('opencues-list')
+      ?? syntax.registerStyle('opencues-list', { fg: RGBA.fromValues(0.7, 0.7, 0.7, 1) });
+  }
+  if (styleIds.typeId === undefined) {
+    styleIds.typeId = textarea.extmarks.registerType('opencues');
+  }
+
+  type Kind = 'd' | 'h' | 'b' | 'i' | 'c' | 's' | 'H' | 'L';
+  type Spec = { kind: Kind; start: number; end: number };
+  const desired = new Map<ExtmarkKey, Spec>();
+  const addRanges = (ranges: ReadonlyArray<{ start: number; end: number }> | undefined, kind: Kind): void => {
+    if (!ranges) return;
+    for (const r of ranges) {
+      desired.set(`${kind}:${r.start}:${r.end}`, { kind, start: r.start, end: r.end });
+    }
+  };
+  const desiredColored = new Map<ExtmarkKey, { hex: string; start: number; end: number }>();
+  const directiveSets = bootResult.collectRenderDirectives(text, cursor);
+  for (const directives of directiveSets) {
+    addRanges(directives.dimRanges, 'd');
+    if (directives.highlight) {
+      const h = directives.highlight;
+      desired.set(`h:${h.start}:${h.end}`, { kind: 'h', start: h.start, end: h.end });
+    }
+    addRanges(directives.boldRanges, 'b');
+    addRanges(directives.italicRanges, 'i');
+    addRanges(directives.codeRanges, 'c');
+    addRanges(directives.strikeRanges, 's');
+    addRanges(directives.headingRanges, 'H');
+    addRanges(directives.listRanges, 'L');
+    const cr = (directives as { coloredRanges?: ReadonlyArray<{ start: number; end: number; rgb?: string }> }).coloredRanges;
+    if (cr) {
+      for (const r of cr) {
+        if (!r.rgb) continue;
+        const hex = r.rgb.toLowerCase();
+        desiredColored.set(`load:${hex}:${r.start}:${r.end}`, { hex, start: r.start, end: r.end });
+      }
+    }
+  }
+
+  for (const [key, id] of ownedExtmarks) {
+    if (desired.has(key) || desiredColored.has(key)) continue;
+    try { (textarea.extmarks as any).delete?.(id); } catch {}
+    ownedExtmarks.delete(key);
+  }
+
+  const styleFor = (kind: Kind): number | undefined => {
+    switch (kind) {
+      case 'd': return styleIds.dim;
+      case 'h': return styleIds.highlight;
+      case 'b': return styleIds.bold;
+      case 'i': return styleIds.italic;
+      case 'c': return styleIds.code;
+      case 's': return styleIds.strike;
+      case 'H': return styleIds.heading;
+      case 'L': return styleIds.list;
+    }
+  };
+  for (const [key, spec] of desired) {
+    if (ownedExtmarks.has(key)) continue;
+    const styleId = styleFor(spec.kind);
+    if (styleId === undefined) continue;
+    const id = textarea.extmarks.create({
+      start: spec.start,
+      end: spec.end,
+      styleId,
+      typeId: styleIds.typeId,
+    });
+    ownedExtmarks.set(key, id);
+  }
+  for (const [key, spec] of desiredColored) {
+    if (ownedExtmarks.has(key)) continue;
+    let styleId = loadingColorIds.get(spec.hex);
+    if (styleId === undefined) {
+      const styleName = `opencues-load-${spec.hex.slice(1)}`;
+      try {
+        styleId = syntax.getStyleId(styleName) ?? syntax.registerStyle(styleName, { fg: RGBA.fromHex(spec.hex) });
+      } catch { continue; }
+      loadingColorIds.set(spec.hex, styleId);
+    }
+    const id = textarea.extmarks.create({
+      start: spec.start,
+      end: spec.end,
+      styleId,
+      typeId: styleIds.typeId,
+    });
+    ownedExtmarks.set(key, id);
+  }
+}

--- a/integrations/terminal/tsconfig.json
+++ b/integrations/terminal/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/bun/tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "@opentui/solid",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*", "bin/**/*"]
+}

--- a/packages/opencues-cli/src/commands/completion.cjs
+++ b/packages/opencues-cli/src/commands/completion.cjs
@@ -10,7 +10,7 @@ const COMMANDS = [
   'set-key', 'check-keys', 'update', 'debug', 'completion',
   'which', 'version', 'help',
 ];
-const HOSTS = ['claude-code', 'claudecode', 'claude', 'cc', 'opencode', 'oc', 'chrome', 'gemini-cli', 'geminicli', 'gemini'];
+const HOSTS = ['claude-code', 'claudecode', 'claude', 'cc', 'opencode', 'oc', 'chrome', 'gemini-cli', 'geminicli', 'gemini', 'terminal', 'term', 'oc-edit'];
 const KINDS = ['cue', 'blank'];
 const FILES = ['cues', 'blanks', 'opencues'];
 

--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -328,6 +328,33 @@ module.exports = function doctor(argv, ctx) {
     s.render();
   }
 
+  // ── Terminal install (standalone Bun + OpenTUI app) ──────────────────
+  // No upstream fork — staged @opencues/{core,runtime} live inside the
+  // repo at integrations/terminal/node_modules/. Bun is a hard prereq.
+  {
+    const s = section('Terminal (oc-edit)', 'standalone Bun + OpenTUI app');
+    const termDir = path.join(ctx.REPO_ROOT, 'integrations/terminal');
+    const termRt = path.join(termDir, 'node_modules/@opencues/runtime');
+    const termCore = path.join(termDir, 'node_modules/@opencues/core');
+    const ocEditBin = path.join(termDir, 'bin/oc-edit');
+    s.ok(`integration dir at ${termDir}`, fs.existsSync(termDir));
+    s.ok(`bin/oc-edit`, fs.existsSync(ocEditBin));
+    s.ok(`node_modules/@opencues/runtime (staged)`, fs.existsSync(termRt));
+    s.ok(`node_modules/@opencues/core (staged)`, fs.existsSync(termCore));
+    s.ok(`bun on PATH`, !!findOnPath('bun'));
+    if (!findOnPath('bun')) {
+      findings.push({
+        sev: 'warn',
+        msg: 'bun not on PATH — terminal integration needs Bun',
+        fix: 'curl -fsSL https://bun.sh/install | bash   # then re-run setup',
+      });
+    }
+    if (!fs.existsSync(termRt)) {
+      findings.push({ sev: 'info', msg: 'Terminal integration not installed', fix: 'opencues install terminal' });
+    }
+    s.render();
+  }
+
   // ── Gemini CLI install ────────────────────────────────────────────────
   {
     const s = section('Gemini CLI', 'patched Gemini CLI fork + installed runtime');

--- a/packages/opencues-cli/src/commands/install.cjs
+++ b/packages/opencues-cli/src/commands/install.cjs
@@ -26,7 +26,7 @@ function loadHostResolver(ctx) {
   } catch {
     // Pre-build fallback — keep CLI usable.
     return {
-      HOSTS: ['chrome', 'claude-code', 'gemini-cli', 'opencode'],
+      HOSTS: ['chrome', 'claude-code', 'gemini-cli', 'opencode', 'terminal'],
       resolve: (name) => {
         const map = {
           'claude-code': 'claude-code', 'claudecode': 'claude-code',
@@ -35,6 +35,7 @@ function loadHostResolver(ctx) {
           'chrome': 'chrome', 'chrome-host': 'chrome',
           'gemini-cli': 'gemini-cli', 'geminicli': 'gemini-cli',
           'gemini': 'gemini-cli',
+          'terminal': 'terminal', 'term': 'terminal', 'oc-edit': 'terminal',
         };
         return map[name?.toLowerCase?.()] ?? null;
       },
@@ -134,7 +135,8 @@ function printHelp(ctx) {
   console.log('  opencode      Patches an OpenCode 1.4.x fork                 (alias: oc)');
   console.log('  chrome        Chrome MV3 extension');
   console.log('  gemini-cli    Patches a Gemini CLI 0.41.x fork               (aliases: geminicli, gemini)');
-  console.log('  --all         Install all four');
+  console.log('  terminal      Standalone Bun + OpenTUI app (oc-edit)         (aliases: term, oc-edit)');
+  console.log('  --all         Install all five');
   console.log('');
   console.log('Common flags (passed through to the per-host installer):');
   console.log('  --target <path>   Host install path (cli.js for claude-code, fork dir for opencode/gemini-cli)');

--- a/packages/opencues-cli/src/commands/run.cjs
+++ b/packages/opencues-cli/src/commands/run.cjs
@@ -265,7 +265,19 @@ function runTerminal(passthrough, ctx) {
     console.error(`${style.tag('err')} bun not found on PATH. Install: https://bun.sh`);
     process.exit(127);
   }
-  const result = spawnSync('bun', [ocEdit, ...passthrough], { stdio: 'inherit' });
+  // Bun reads bunfig.toml from the cwd, NOT from the script's directory.
+  // The terminal app's bunfig.toml supplies `preload = ["@opentui/solid
+  // /preload"]` — without it the JSX runtime resolves to react/jsx-dev-
+  // runtime and the app dies on import. cwd-pin to integrations/terminal
+  // so bunfig is found regardless of where `opencues run terminal` was
+  // invoked from. Also pass --preload explicitly as a belt-and-braces
+  // guard in case bunfig discovery breaks in a future Bun release.
+  const termDir = path.join(ctx.REPO_ROOT, 'integrations', 'terminal');
+  const result = spawnSync(
+    'bun',
+    ['--preload', '@opentui/solid/preload', ocEdit, ...passthrough],
+    { stdio: 'inherit', cwd: termDir },
+  );
   exitFromSpawn(result, 'bun');
 }
 

--- a/packages/opencues-cli/src/commands/run.cjs
+++ b/packages/opencues-cli/src/commands/run.cjs
@@ -40,7 +40,7 @@ function printLaunchBanner(ctx, host, rows) {
 // Map full host name → the short prefix used in /tmp/opencues.log so the
 // printed `grep` filter actually matches the lines that host writes.
 function shortPrefix(host) {
-  return ({ 'claude-code': 'cc', 'opencode': 'oc', 'gemini-cli': 'gemini' })[host] ?? host;
+  return ({ 'claude-code': 'cc', 'opencode': 'oc', 'gemini-cli': 'gemini', 'terminal': 'term' })[host] ?? host;
 }
 
 // Host name resolution — sourced from @opencues/core.
@@ -50,12 +50,13 @@ function loadHostResolver(ctx) {
     return { HOSTS: core.HOSTS.slice().sort(), resolve: core.resolveHost };
   } catch {
     return {
-      HOSTS: ['chrome', 'claude-code', 'gemini-cli', 'opencode'],
+      HOSTS: ['chrome', 'claude-code', 'gemini-cli', 'opencode', 'terminal'],
       resolve: (n) => ({
         'claude-code': 'claude-code', 'claudecode': 'claude-code', 'claude': 'claude-code', 'cc': 'claude-code',
         'opencode': 'opencode', 'oc': 'opencode',
         'chrome': 'chrome',
         'gemini-cli': 'gemini-cli', 'geminicli': 'gemini-cli', 'gemini': 'gemini-cli',
+        'terminal': 'terminal', 'term': 'terminal', 'oc-edit': 'terminal',
       })[n?.toLowerCase?.()] ?? null,
     };
   }
@@ -88,6 +89,7 @@ module.exports = function run(argv, ctx) {
   if (folder === 'opencode')    return runOC(passthrough, argv, ctx);
   if (folder === 'chrome') return runChrome(ctx);
   if (folder === 'gemini-cli') return runGemini(passthrough, argv, ctx);
+  if (folder === 'terminal') return runTerminal(passthrough, ctx);
 };
 
 function runCC(passthrough, ctx) {
@@ -242,6 +244,31 @@ function runGemini(passthrough, fullArgv, ctx) {
   exitFromSpawn(result, 'node');
 }
 
+function runTerminal(passthrough, ctx) {
+  // Standalone Bun app — invoke bin/oc-edit directly. The shim chooses
+  // dist/app.js (if built) or falls through to src/app.tsx (Bun handles TSX).
+  const ocEdit = path.join(ctx.REPO_ROOT, 'integrations', 'terminal', 'bin', 'oc-edit');
+  if (!fs.existsSync(ocEdit)) {
+    console.error(`${style.tag('err')} oc-edit not found at ${ocEdit}`);
+    console.error(`     Install first: ${style.bold('opencues install terminal')}`);
+    process.exit(1);
+  }
+  printLaunchBanner(ctx, 'terminal', [
+    ['host', 'terminal  ' + style.dim('(standalone Bun + OpenTUI app)')],
+    ['command', `oc-edit ${passthrough.join(' ')}`.trim()],
+    ['bin', style.fileLink(ocEdit, ocEdit)],
+  ]);
+  // Bun is the runtime — exec bun directly rather than depending on the
+  // shebang resolving (which fails when bun isn't first on PATH).
+  const bunCheck = spawnSync('which', ['bun'], { stdio: ['ignore', 'pipe', 'ignore'] });
+  if (bunCheck.status !== 0) {
+    console.error(`${style.tag('err')} bun not found on PATH. Install: https://bun.sh`);
+    process.exit(127);
+  }
+  const result = spawnSync('bun', [ocEdit, ...passthrough], { stdio: 'inherit' });
+  exitFromSpawn(result, 'bun');
+}
+
 function runChrome(ctx) {
   printLaunchBanner(ctx, 'chrome', [
     ['host', 'chrome  ' + style.dim('(extensions are loaded by chrome itself)')],
@@ -266,6 +293,7 @@ function printHelp() {
   console.log('  opencode      cd into the fork dir + bun run dev');
   console.log('  chrome        print Chrome reload instructions (no programmatic launch)');
   console.log('  gemini-cli    node packages/cli/dist/index.js inside the fork (default: $HOME/gemini-cli-cues)');
+  console.log('  terminal      bun integrations/terminal/bin/oc-edit  (standalone Bun + OpenTUI app)');
   console.log('');
   console.log('Flags:');
   console.log('  --bin <name>      (claude-code only) override which binary to exec');

--- a/packages/opencues-cli/src/commands/uninstall.cjs
+++ b/packages/opencues-cli/src/commands/uninstall.cjs
@@ -20,9 +20,12 @@ const HOST_ALIASES = {
   'gemini-cli':  'gemini-cli',
   'geminicli':   'gemini-cli',
   'gemini':      'gemini-cli',
+  'terminal':    'terminal',
+  'term':        'terminal',
+  'oc-edit':     'terminal',
 };
-const HOSTS = ['claude-code', 'opencode', 'chrome', 'gemini-cli'];
-const HOST_FOLDERS = ['claude-code', 'opencode', 'chrome', 'gemini-cli'];
+const HOSTS = ['claude-code', 'opencode', 'chrome', 'gemini-cli', 'terminal'];
+const HOST_FOLDERS = ['claude-code', 'opencode', 'chrome', 'gemini-cli', 'terminal'];
 
 module.exports = function uninstall(argv, ctx) {
   if (argv.includes('--help') || argv.includes('-h')) return printHelp();

--- a/packages/opencues-cli/src/commands/update.cjs
+++ b/packages/opencues-cli/src/commands/update.cjs
@@ -28,8 +28,9 @@ const HOST_ALIASES = {
   opencode: 'opencode', oc: 'opencode',
   chrome: 'chrome',
   'gemini-cli': 'gemini-cli', geminicli: 'gemini-cli', gemini: 'gemini-cli',
+  terminal: 'terminal', term: 'terminal', 'oc-edit': 'terminal',
 };
-const ALL_HOSTS = ['claude-code', 'opencode', 'chrome', 'gemini-cli'];
+const ALL_HOSTS = ['claude-code', 'opencode', 'chrome', 'gemini-cli', 'terminal'];
 
 module.exports = async function update(argv, ctx) {
   if (argv.includes('--help') || argv.includes('-h')) return printHelp();
@@ -392,6 +393,12 @@ function detectInstalled(HOME, REPO_ROOT) {
   const geminiFork = path.join(HOME, 'gemini-cli-cues');
   if (fs.existsSync(path.join(geminiFork, 'node_modules/@opencues/runtime'))) {
     out.push({ host: 'gemini-cli', folder: 'gemini-cli', evidence: `${geminiFork}/node_modules/@opencues/runtime exists` });
+  }
+  // Terminal: self-owned app — install lives inside the repo at
+  // integrations/terminal/node_modules/@opencues/runtime (staged by setup.sh).
+  const termRt = path.join(REPO_ROOT, 'integrations/terminal/node_modules/@opencues/runtime');
+  if (fs.existsSync(termRt)) {
+    out.push({ host: 'terminal', folder: 'terminal', evidence: `${termRt} exists` });
   }
   return out;
 }

--- a/packages/opencues-cli/src/commands/version.cjs
+++ b/packages/opencues-cli/src/commands/version.cjs
@@ -7,7 +7,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { banner, tree, dim, cliVersion } = require('../lib/style.cjs');
 
-const HOSTS = ['claude-code', 'opencode', 'chrome', 'gemini-cli'];
+const HOSTS = ['claude-code', 'opencode', 'chrome', 'gemini-cli', 'terminal'];
 
 module.exports = function version(argv, ctx) {
   if (argv.includes('--help') || argv.includes('-h')) return printHelp();

--- a/packages/opencues-core/src/host-compat.test.ts
+++ b/packages/opencues-core/src/host-compat.test.ts
@@ -139,7 +139,7 @@ describe('formatHostList', () => {
   });
 
   it('native hosts → comma-separated alphabetical', () => {
-    assert.strictEqual(formatHostList(SORTED_NATIVE), 'claude-code, gemini-cli, opencode');
+    assert.strictEqual(formatHostList(SORTED_NATIVE), 'claude-code, gemini-cli, opencode, terminal');
   });
 
   it('single host → just the name', () => {

--- a/packages/opencues-core/src/host-compat.ts
+++ b/packages/opencues-core/src/host-compat.ts
@@ -31,14 +31,14 @@
  */
 
 /** Every integration host. Keep alphabetical for stable equality checks. */
-export const HOSTS = ['chrome', 'claude-code', 'gemini-cli', 'opencode'] as const;
+export const HOSTS = ['chrome', 'claude-code', 'gemini-cli', 'opencode', 'terminal'] as const;
 export type Host = typeof HOSTS[number];
 
 /** Hosts that can spawn subprocesses + access the filesystem WITHOUT an
  *  auxiliary helper. Chrome can also spawn subprocesses, but only when
  *  chrome-host (the native-messaging bridge) is installed — so chrome's
  *  capability is runtime-detected, not a static property. */
-export const NATIVE_HOSTS: readonly Host[] = ['claude-code', 'gemini-cli', 'opencode'];
+export const NATIVE_HOSTS: readonly Host[] = ['claude-code', 'gemini-cli', 'opencode', 'terminal'];
 
 /**
  * The subset of frontmatter fields host-compat resolution looks at. Accepts
@@ -160,6 +160,8 @@ export const HOST_ALIASES: Readonly<Record<string, Host>> = {
   'oc': 'opencode',
   'gemini': 'gemini-cli',
   'geminicli': 'gemini-cli',
+  'term': 'terminal',
+  'oc-edit': 'terminal',
 };
 
 /**

--- a/packages/opencues-runtime/adapters/terminal/v1/adapter.ts
+++ b/packages/opencues-runtime/adapters/terminal/v1/adapter.ts
@@ -1,0 +1,162 @@
+// Terminal v1 HostAdapter.
+//
+// Standalone OpenTUI app (Bun + SolidJS + @opentui/core), invoked as
+// `oc-edit` from a shell. Unlike CC/OC/Gemini we own the host: there
+// is no upstream TUI to patch, no Prompt component to publish a ref
+// from. The bootstrap mounts a single TextareaRenderable, hands its
+// ref straight to the adapter, and we run the runtime against it.
+//
+// Bindings shape is intentionally identical to the OC v1.14 band so
+// adapter-band drift between the two stays minimal — the underlying
+// editor primitive (OpenTUI's TextareaRenderable) is the same.
+
+import type {
+  HostAdapter,
+  KeyEvent,
+  KeyFilter,
+  Range,
+  RenderContext,
+  RenderDirectives,
+  TextChangeEvent,
+  CursorChangeEvent,
+  Unsubscribe,
+  ProcessSpec,
+  ProcessHandle,
+  BlankInvokeSpec,
+  DirEntry,
+  LogLevel,
+  Capability,
+} from '../../../src/adapter';
+import { HOST_ADAPTER_INTERFACE_VERSION } from '../../../src/adapter';
+
+export interface TerminalBindings {
+  hostVersion: string;
+  cwd: string;
+  getText(): string;
+  getCursorOffset(): number;
+  setText(text: string): void;
+  setCursorOffset(offset: number): void;
+  forceRender(): void;
+  registerKeyHandler(cb: (e: KeyEvent) => boolean): Unsubscribe;
+  registerTextChangeHandler(cb: (e: TextChangeEvent) => void): Unsubscribe;
+  registerCursorChangeHandler(cb: (e: CursorChangeEvent) => void): Unsubscribe;
+  registerRenderHandler(cb: (ctx: RenderContext) => RenderDirectives | null): Unsubscribe;
+  readFile?(path: string): Promise<string | null>;
+  readDir?(path: string): Promise<readonly DirEntry[] | null>;
+  writeFile?(path: string, content: string): Promise<void>;
+  spawnProcess?(spec: ProcessSpec): ProcessHandle;
+  blankInvoke?(spec: BlankInvokeSpec): ProcessHandle | null;
+  pushText?(text: string, cursor?: number): void;
+  log?(level: LogLevel, msg: string, data?: unknown): void;
+  emitEvent?(type: string, body?: Record<string, unknown>): void;
+  registerEventHandler?(cb: (type: string, body?: Record<string, unknown>) => void): Unsubscribe;
+}
+
+export const TERMINAL_V1_CAPABILITIES: readonly Capability[] = [
+  'file-read',
+  'file-write',
+  'force-render',
+  'render-override',
+  'dim-ranges',
+  'highlight-range',
+  'render-rgb-color',
+];
+
+export class TerminalV1Adapter implements HostAdapter {
+  readonly interfaceVersion = HOST_ADAPTER_INTERFACE_VERSION;
+  readonly hostName = 'terminal';
+  readonly hostVersion: string;
+  readonly cwd: string;
+  readonly capabilities: readonly Capability[];
+
+  private _disposed = false;
+
+  constructor(private bindings: TerminalBindings) {
+    this.hostVersion = bindings.hostVersion;
+    this.cwd = bindings.cwd;
+    const caps: Capability[] = [...TERMINAL_V1_CAPABILITIES];
+    if (bindings.spawnProcess) caps.push('spawn-process');
+    if (bindings.blankInvoke) caps.push('blank-invoke');
+    this.capabilities = caps;
+  }
+
+  getText(): string {
+    try { return this.bindings.getText(); } catch { return ''; }
+  }
+  getCursorOffset(): number {
+    try { return this.bindings.getCursorOffset(); } catch { return 0; }
+  }
+  getSelection(): Range | null { return null; }
+
+  setText(text: string): void {
+    if (this._disposed) return;
+    try { this.bindings.setText(text); } catch (err) {
+      this.log('error', 'setText failed', err);
+    }
+  }
+  setCursorOffset(offset: number): void {
+    if (this._disposed) return;
+    try { this.bindings.setCursorOffset(Math.max(0, offset)); } catch (err) {
+      this.log('error', 'setCursorOffset failed', err);
+    }
+  }
+  forceRender(): void {
+    if (this._disposed) return;
+    try { this.bindings.forceRender(); } catch (err) {
+      this.log('error', 'forceRender failed', err);
+    }
+  }
+
+  onKey(filter: KeyFilter | null, handler: (e: KeyEvent) => boolean): Unsubscribe {
+    if (!filter) return this.bindings.registerKeyHandler(handler);
+    const wrapped = (e: KeyEvent): boolean => {
+      if (filter.keys && filter.keys.length > 0 && !filter.keys.includes(e.key)) return false;
+      if (filter.requireModifiers) for (const m of filter.requireModifiers) if (!e.modifiers[m]) return false;
+      if (filter.forbidModifiers) for (const m of filter.forbidModifiers) if (e.modifiers[m]) return false;
+      return handler(e);
+    };
+    return this.bindings.registerKeyHandler(wrapped);
+  }
+  onTextChange(handler: (e: TextChangeEvent) => void): Unsubscribe {
+    return this.bindings.registerTextChangeHandler(handler);
+  }
+  onCursorChange(handler: (e: CursorChangeEvent) => void): Unsubscribe {
+    return this.bindings.registerCursorChangeHandler(handler);
+  }
+  onRender(handler: (ctx: RenderContext) => RenderDirectives | null): Unsubscribe {
+    return this.bindings.registerRenderHandler(handler);
+  }
+
+  readFile(path: string): Promise<string | null> {
+    return this.bindings.readFile?.(path) ?? Promise.resolve(null);
+  }
+  readDir(path: string): Promise<readonly DirEntry[] | null> {
+    return this.bindings.readDir?.(path) ?? Promise.resolve(null);
+  }
+  writeFile(path: string, content: string): Promise<void> {
+    return this.bindings.writeFile?.(path, content) ?? Promise.resolve();
+  }
+  spawnProcess(spec: ProcessSpec): ProcessHandle {
+    if (!this.bindings.spawnProcess) throw new Error('spawnProcess not supported');
+    return this.bindings.spawnProcess(spec);
+  }
+  blankInvoke(spec: BlankInvokeSpec): ProcessHandle | null {
+    return this.bindings.blankInvoke?.(spec) ?? null;
+  }
+  pushText(text: string, cursor?: number): void {
+    this.bindings.pushText?.(text, cursor);
+  }
+
+  log(level: LogLevel, msg: string, data?: unknown): void {
+    this.bindings.log?.(level, msg, data);
+  }
+  emitEvent(type: string, body?: Record<string, unknown>): void {
+    this.bindings.emitEvent?.(type, body);
+  }
+  onEvent(handler: (type: string, body?: Record<string, unknown>) => void): Unsubscribe {
+    return this.bindings.registerEventHandler?.(handler) ?? (() => {});
+  }
+  dispose(): void {
+    this._disposed = true;
+  }
+}

--- a/packages/opencues-runtime/adapters/terminal/v1/boot.test.ts
+++ b/packages/opencues-runtime/adapters/terminal/v1/boot.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { boot } from './boot';
+import type { KeyEvent } from '../../../src/adapter';
+
+describe('Terminal v1 boot()', () => {
+  const minimalHost = {
+    hostVersion: '0.1.0',
+    cwd: '/proj',
+    getText: () => '',
+    getCursorOffset: () => 0,
+    setText: () => {},
+    setCursorOffset: () => {},
+    forceRender: () => {},
+  };
+
+  it('returns dispatchKey + notifyTextChange + dispose handles', () => {
+    const result = boot(minimalHost);
+    expect(typeof result.dispatchKey).toBe('function');
+    expect(typeof result.notifyTextChange).toBe('function');
+    expect(typeof result.notifyCursorChange).toBe('function');
+    expect(typeof result.collectRenderDirectives).toBe('function');
+    expect(typeof result.dispose).toBe('function');
+  });
+
+  it('dispatchKey returns false when no handler is subscribed', () => {
+    const result = boot(minimalHost);
+    const evt: KeyEvent = {
+      key: 'left',
+      modifiers: { ctrl: true, alt: false, shift: false, meta: false },
+      text: '',
+      cursorOffset: 0,
+    };
+    expect(result.dispatchKey(evt)).toBe(false);
+  });
+
+  it('logs "OpenCues runtime starting (Terminal v1)" with host=terminal', () => {
+    const log = vi.fn();
+    boot({ ...minimalHost, log });
+    expect(log).toHaveBeenCalledWith(
+      'info',
+      expect.stringContaining('Terminal v1'),
+      expect.objectContaining({ host: 'terminal' }),
+    );
+  });
+
+  it('reports the right capability set (no spawn unless host.spawnProcess)', () => {
+    const log = vi.fn();
+    boot({ ...minimalHost, log });
+    const startupCall = log.mock.calls.find(c => String(c[1]).includes('Terminal v1'));
+    const caps = (startupCall?.[2] as { capabilities?: string[] } | undefined)?.capabilities ?? [];
+    expect(caps).toContain('file-read');
+    expect(caps).toContain('file-write');
+    expect(caps).toContain('force-render');
+    expect(caps).toContain('dim-ranges');
+    expect(caps).toContain('render-rgb-color');
+    expect(caps).not.toContain('spawn-process');
+  });
+
+  it('opt-in spawn-process when host supplies spawnProcess', () => {
+    const log = vi.fn();
+    boot({ ...minimalHost, spawnProcess: () => ({} as any), log });
+    const startupCall = log.mock.calls.find(c => String(c[1]).includes('Terminal v1'));
+    const caps = (startupCall?.[2] as { capabilities?: string[] } | undefined)?.capabilities ?? [];
+    expect(caps).toContain('spawn-process');
+  });
+
+  it('Navigation subscribed — Ctrl+Alt+Left consumed when text has words', () => {
+    let text = 'alpha beta gamma';
+    let cursor = 0;
+    const result = boot({
+      ...minimalHost,
+      getText: () => text,
+      getCursorOffset: () => cursor,
+      setText: (t) => { text = t; },
+      setCursorOffset: (c) => { cursor = c; },
+    });
+    const consumed = result.dispatchKey({
+      key: 'left',
+      modifiers: { ctrl: true, alt: true, shift: false, meta: false },
+      text,
+      cursorOffset: cursor,
+    });
+    expect(consumed).toBe(true);
+  });
+});

--- a/packages/opencues-runtime/adapters/terminal/v1/boot.ts
+++ b/packages/opencues-runtime/adapters/terminal/v1/boot.ts
@@ -1,0 +1,227 @@
+// Terminal v1 host bootstrap.
+//
+// The terminal-side app's job:
+//   1. Build a TerminalBindings object from its TUI primitives (an
+//      OpenTUI TextareaRenderable + the renderer for forceRender).
+//   2. Call boot(host) once on app mount.
+//   3. Forward useKeyboard events to BootResult.dispatchKey.
+//   4. On textarea onContentChange, call notifyTextChange + ask the
+//      runtime for render directives, which the app applies as extmarks.
+//
+// Identical wiring to the OC v1.14 band — the underlying primitive
+// (OpenTUI TextareaRenderable) is the same. The split exists so the
+// host-name/version surface stays accurate (`adapter.hostName ===
+// 'terminal'`) and so future divergence between the two doesn't
+// require rebooting OpenCode users.
+
+import { Runtime } from '../../../src/runtime';
+import { TerminalV1Adapter, type TerminalBindings } from './adapter';
+import { startEventBridge } from '../../../src/event-bridge';
+import { Statusline } from '../../../src/modules/statusline';
+import { Resolver } from '../../../src/modules/resolver';
+import { AgentRewrite } from '../../../src/modules/agent-rewrite';
+import { TTS } from '../../../src/modules/tts';
+import { CursorStateExport } from '../../../src/modules/cursor-state-export';
+import { ConfigLoader } from '../../../src/modules/config-loader';
+import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver } from '../../../src/boot-common';
+import { EventEmitter } from '../../../src/lib/event-emitter';
+import type {
+  CommonHostInfo,
+  KeyEvent,
+  RenderContext,
+  RenderDirectives,
+  TextChangeEvent,
+  CursorChangeEvent,
+} from '../../../src/adapter';
+
+export interface HostInfo extends CommonHostInfo {
+  spawnProcess?(spec: unknown): unknown;
+  ttsScriptPath?: string;
+  blankInvoke?(spec: import('../../../src/adapter').BlankInvokeSpec):
+    import('../../../src/adapter').ProcessHandle | null;
+}
+
+export interface BootResult {
+  dispatchKey(event: KeyEvent): boolean;
+  notifyTextChange(text: string, cursorOffset: number, source: 'user' | 'runtime'): void;
+  notifyCursorChange(text: string, cursorOffset: number, source: 'user' | 'runtime'): void;
+  collectRenderDirectives(text: string, cursor: number): RenderDirectives[];
+  dispose(): void;
+}
+
+export function boot(host: HostInfo): BootResult {
+  let configLoaderRef: ConfigLoader | null = null;
+  const log = createLogFunction({
+    sink: (level, msg, data) => host.log?.(level, msg, data),
+    isDebugEnabled: () => configLoaderRef?.loaded === true
+      ? configLoaderRef.opencuesState.debugMode === 'on'
+      : !!process.env.DEBUG_OPENCUES,
+  });
+
+  const keyEvents = new EventEmitter<KeyEvent, boolean>();
+  const textEvents = new EventEmitter<TextChangeEvent>();
+  const cursorEvents = new EventEmitter<CursorChangeEvent>();
+  const renderEvents = new EventEmitter<RenderContext, RenderDirectives | null>();
+  const moduleEvents = new EventEmitter<{ type: string; body?: Record<string, unknown> }>();
+
+  let lastSeenText: string | null = null;
+  let lastSeenCursor = 0;
+  const fireTextChange = (text: string, cursor: number, source: 'user' | 'runtime'): void => {
+    textEvents.emit(
+      { text, cursorOffset: cursor, previousText: lastSeenText ?? '', source },
+      err => log('error', 'text handler threw', err),
+    );
+    lastSeenText = text;
+    lastSeenCursor = cursor;
+  };
+
+  const fireCursorChange = (text: string, cursor: number, source: 'user' | 'runtime'): void => {
+    if (cursor === lastSeenCursor && text === lastSeenText) return;
+    cursorEvents.emit(
+      { text, cursorOffset: cursor, source },
+      err => log('error', 'cursor handler threw', err),
+    );
+    lastSeenCursor = cursor;
+    lastSeenText = text;
+  };
+
+  const bindings: TerminalBindings = {
+    hostVersion: host.hostVersion,
+    cwd: host.cwd,
+    getText: host.getText,
+    getCursorOffset: host.getCursorOffset,
+    setText: host.setText,
+    setCursorOffset: host.setCursorOffset,
+    forceRender: host.forceRender,
+    registerKeyHandler: cb => keyEvents.subscribe(cb),
+    registerTextChangeHandler: cb => textEvents.subscribe(cb),
+    registerCursorChangeHandler: cb => cursorEvents.subscribe(cb),
+    registerRenderHandler: cb => renderEvents.subscribe(cb),
+    readFile: host.readFile,
+    readDir: host.readDir,
+    writeFile: host.writeFile,
+    spawnProcess: host.spawnProcess as TerminalBindings['spawnProcess'],
+    blankInvoke: host.blankInvoke,
+    pushText: host.pushText,
+    log,
+    emitEvent: (type, body) => moduleEvents.emit(
+      { type, body },
+      err => log('error', 'event handler threw', err),
+    ),
+    registerEventHandler: cb => moduleEvents.subscribe(({ type, body }) => cb(type, body)),
+  };
+
+  const adapter = new TerminalV1Adapter(bindings);
+  Runtime.create(adapter).catch(err => log('error', 'Runtime.create failed', err));
+
+  const HOME = process.env.HOME ?? '~';
+  const configSearchPaths = [
+    ...(process.env.OPENCUES_HOME ? [process.env.OPENCUES_HOME] : []),
+    `${host.cwd}/.cues`,
+    `${HOME}/.cues`,
+  ];
+  const settingsFile = process.env.OPENCUES_HOME
+    ? `${process.env.OPENCUES_HOME}/OPENCUES.md`
+    : `${HOME}/.cues/OPENCUES.md`;
+  const shared = buildSharedRuntime(adapter, { log, configSearchPaths, settingsFile });
+  configLoaderRef = shared.configLoader;
+
+  const {
+    configLoader, hlState, dynDefs,
+    spanFillState, selectorSatelliteState, agentTaskState,
+  } = shared;
+
+  if (host.statusFilePath || host.statusSnapshotHook) {
+    const statusline = new Statusline(adapter, hlState, dynDefs, {
+      exportPath: host.statusFilePath ?? '',
+      onSnapshot: host.statusSnapshotHook
+        ? (payload) => host.statusSnapshotHook!(payload)
+        : undefined,
+    }, configLoader, spanFillState, selectorSatelliteState, agentTaskState);
+    statusline.subscribe();
+  }
+
+  if (host.cursorStatePath && adapter.capabilities.includes('file-write')) {
+    const cse = new CursorStateExport(adapter, { exportPath: host.cursorStatePath });
+    cse.subscribe();
+  }
+
+  if (host.ttsScriptPath && adapter.capabilities.includes('spawn-process')) {
+    const tts = new TTS(adapter, hlState, dynDefs, configLoader, {
+      scriptPath: host.ttsScriptPath,
+      rate: host.ttsRate !== undefined ? String(host.ttsRate) : undefined,
+    }, spanFillState, selectorSatelliteState);
+    tts.subscribe();
+  }
+
+  const apiKeys: Record<string, string | undefined> = { ...(host.llmApiKeys ?? {}) };
+  if (host.llmApiKey && !apiKeys.GROQ_API_KEY) apiKeys.GROQ_API_KEY = host.llmApiKey;
+  const hasAnyKey = Object.values(apiKeys).some(Boolean);
+  if (hasAnyKey) {
+    const resolver = new Resolver(adapter, hlState, dynDefs, configLoader, {
+      endpoint: host.llmEndpoint ?? 'https://api.groq.com/openai/v1/chat/completions',
+      apiKey: host.llmApiKey ?? apiKeys.GROQ_API_KEY ?? '',
+      defaultModel: host.llmDefaultModel ?? 'openai/gpt-oss-120b',
+      apiKeys,
+      debounceMs: host.llmDebounceMs ?? 500,
+    }, spanFillState, agentTaskState, shared.blankLoading, shared.markdownRender, selectorSatelliteState);
+    configLoader.load().then(() => resolver.subscribe()).catch(() => { /* logged by ConfigLoader */ });
+
+    const agentRewrite = new AgentRewrite(adapter, dynDefs, agentTaskState, {
+      endpoint: host.llmEndpoint ?? 'https://api.groq.com/openai/v1/chat/completions',
+      apiKey: host.llmApiKey ?? apiKeys.GROQ_API_KEY ?? '',
+      defaultModel: host.llmDefaultModel ?? 'openai/gpt-oss-120b',
+      resolveLLM: () => buildAgentLLMResolver(configLoader, apiKeys),
+      windowWords: () => parseInt(configLoader.opencuesState.settings.get('agent-window-words') ?? '0', 10) || 0,
+      cadenceMs: () => parseInt(configLoader.opencuesState.settings.get('agent-debounce-ms') ?? '', 10),
+      auditorPrompts: () => configLoader.composeAuditorPrompts(),
+      maxConcurrentAuditors: () => parseInt(configLoader.opencuesState.settings.get('max-concurrent-auditors') ?? '', 10) || 0,
+    });
+    agentRewrite.start();
+  }
+
+  log('info', 'OpenCues runtime starting (Terminal v1)', {
+    host: 'terminal',
+    hostVersion: host.hostVersion,
+    capabilities: adapter.capabilities,
+  });
+
+  if (process.env.OPENCUES_BRIDGE === '1') {
+    startEventBridge({
+      adapter,
+      dispatchKey: (e) => keyEvents.emitUntilConsumed(e, err => log('error', 'key handler threw', err)),
+      notifyTextChange: (text, cursor, source) => fireTextChange(text, cursor, source),
+      notifyCursorChange: (text, cursor, source) => fireCursorChange(text, cursor, source),
+      state: { hlState, dynDefs, spanFillState, selectorSatelliteState, agentTaskState },
+    });
+  }
+
+  return {
+    dispatchKey(event) {
+      return keyEvents.emitUntilConsumed(event, err => log('error', 'key handler threw', err));
+    },
+    notifyTextChange(text, cursorOffset, source) {
+      fireTextChange(text, cursorOffset, source);
+    },
+    notifyCursorChange(text, cursorOffset, source) {
+      fireCursorChange(text, cursorOffset, source);
+    },
+    collectRenderDirectives(text, cursor) {
+      // Observe-only (same contract as OC) — Cycling synchronously
+      // writes text then forceRenders before onContentChange fires,
+      // so any "drift" we'd synthesise here is the cycle, not the user.
+      lastSeenText = text;
+      lastSeenCursor = cursor;
+      const ctx: RenderContext = { text, cursor, externalHighlights: [] };
+      return renderEvents.collect(ctx, err => log('error', 'render handler threw', err));
+    },
+    dispose() {
+      adapter.dispose();
+      keyEvents.clear();
+      textEvents.clear();
+      cursorEvents.clear();
+      renderEvents.clear();
+      moduleEvents.clear();
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,28 @@ importers:
 
   integrations/opencode: {}
 
+  integrations/terminal:
+    dependencies:
+      '@opentui/core':
+        specifier: 0.1.99
+        version: 0.1.99(stage-js@1.0.2)(typescript@5.8.2)(web-tree-sitter@0.25.10)
+      '@opentui/solid':
+        specifier: 0.1.99
+        version: 0.1.99(solid-js@1.9.10)(stage-js@1.0.2)(typescript@5.8.2)(web-tree-sitter@0.25.10)
+      solid-js:
+        specifier: 1.9.10
+        version: 1.9.10
+    devDependencies:
+      '@tsconfig/bun':
+        specifier: 1.0.9
+        version: 1.0.9
+      '@types/bun':
+        specifier: 1.3.11
+        version: 1.3.11
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+
   packages/opencues-cli: {}
 
   packages/opencues-core: {}
@@ -86,6 +108,10 @@ importers:
 
 packages:
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@anthropic-ai/sdk@0.39.0':
     resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
 
@@ -103,6 +129,139 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.28.0':
+    resolution: {integrity: sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.27.3':
+    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-create-class-features-plugin@7.29.3':
+    resolution: {integrity: sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.18.6':
+    resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.27.1':
+    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.28.6':
+    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6':
+    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.28.6':
+    resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.27.1':
+    resolution: {integrity: sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -143,6 +302,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@dimforge/rapier2d-simd-compat@0.17.3':
+    resolution: {integrity: sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -291,8 +453,170 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@jimp/core@1.6.0':
+    resolution: {integrity: sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==}
+    engines: {node: '>=18'}
+
+  '@jimp/diff@1.6.0':
+    resolution: {integrity: sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==}
+    engines: {node: '>=18'}
+
+  '@jimp/file-ops@1.6.0':
+    resolution: {integrity: sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-bmp@1.6.0':
+    resolution: {integrity: sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-gif@1.6.0':
+    resolution: {integrity: sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-jpeg@1.6.0':
+    resolution: {integrity: sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-png@1.6.0':
+    resolution: {integrity: sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==}
+    engines: {node: '>=18'}
+
+  '@jimp/js-tiff@1.6.0':
+    resolution: {integrity: sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-blit@1.6.0':
+    resolution: {integrity: sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-blur@1.6.0':
+    resolution: {integrity: sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-circle@1.6.0':
+    resolution: {integrity: sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-color@1.6.0':
+    resolution: {integrity: sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-contain@1.6.0':
+    resolution: {integrity: sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-cover@1.6.0':
+    resolution: {integrity: sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-crop@1.6.0':
+    resolution: {integrity: sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-displace@1.6.0':
+    resolution: {integrity: sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-dither@1.6.0':
+    resolution: {integrity: sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-fisheye@1.6.0':
+    resolution: {integrity: sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-flip@1.6.0':
+    resolution: {integrity: sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-hash@1.6.0':
+    resolution: {integrity: sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-mask@1.6.0':
+    resolution: {integrity: sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-print@1.6.0':
+    resolution: {integrity: sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-quantize@1.6.0':
+    resolution: {integrity: sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-resize@1.6.0':
+    resolution: {integrity: sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-rotate@1.6.0':
+    resolution: {integrity: sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==}
+    engines: {node: '>=18'}
+
+  '@jimp/plugin-threshold@1.6.0':
+    resolution: {integrity: sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==}
+    engines: {node: '>=18'}
+
+  '@jimp/types@1.6.0':
+    resolution: {integrity: sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==}
+    engines: {node: '>=18'}
+
+  '@jimp/utils@1.6.0':
+    resolution: {integrity: sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==}
+    engines: {node: '>=18'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@opentui/core-darwin-arm64@0.1.99':
+    resolution: {integrity: sha512-bzVrqeX2vb5iWrc/ftOUOqeUY8XO+qSgoTwj5TXHuwagavgwD3Hpeyjx8+icnTTeM4pao0som1WR9xfye6/X5Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@opentui/core-darwin-x64@0.1.99':
+    resolution: {integrity: sha512-VE4FrXBYpkxnvkqcCV1a8aN9jyyMJMihVW+V2NLCtp+4yQsj0AapG5TiUSN76XnmSZRptxDy5rBmEempeoIZbg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@opentui/core-linux-arm64@0.1.99':
+    resolution: {integrity: sha512-viXQsbpS7yHjYkl7+am32JdvG96QU9lvHh1UiZtpOxcNUUqiYmA2ZwZFPD2Bi54jNyj5l2hjH6YkD3DzE2FEWA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@opentui/core-linux-x64@0.1.99':
+    resolution: {integrity: sha512-WLoEFINOSp0tZSR9y4LUuGc7n4Y7H1wcpjUPzQ9vChkYDXrfZltEanzoDWbDcQ4kZQW5tHVC7LrZHpAsRLwFZg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@opentui/core-win32-arm64@0.1.99':
+    resolution: {integrity: sha512-yWMOLWCEO8HdrctU1dMkgZC8qGkiO4Dwr4/e11tTvVpRmYhDsP/IR89ZjEEtOwnKwFOFuB/MxvflqaEWVQ2g5Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@opentui/core-win32-x64@0.1.99':
+    resolution: {integrity: sha512-aYRlsL2w8YRL6vPd7/hrqlNVkXU3QowWb01TOvAcHS8UAsXaGFUr47kSDyjxDi1wg1MzmVduCfsC7T3NoThV1w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentui/core@0.1.99':
+    resolution: {integrity: sha512-I3+AEgGzqNWIpWX9g2WOscSPwtQDNOm4KlBjxBWCZjLxkF07u77heWXF7OiAdhKLtNUW6TFiyt6yznqAZPdG3A==}
+    peerDependencies:
+      web-tree-sitter: 0.25.10
+
+  '@opentui/solid@0.1.99':
+    resolution: {integrity: sha512-DrqqO4h2V88FmeIP2cErYkMU0ZK5MrUsZw3w6IzZpoXyyiL4/9qpWzUq+CXx+r16VP2iGxDJwGKUmtFAzUch2Q==}
+    peerDependencies:
+      solid-js: 1.9.11
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -432,6 +756,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tsconfig/bun@1.0.9':
+    resolution: {integrity: sha512-4M0/Ivfwcpz325z6CwSifOBZYji3DFOEpY6zEUt0+Xi2qRhzwvmqQN9XAHJh3OVvRJuAqVTLU2abdCplvp6mwQ==}
+
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
@@ -462,6 +792,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/bun@1.3.11':
+    resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
+
   '@types/chrome@0.0.268':
     resolution: {integrity: sha512-7N1QH9buudSJ7sI8Pe4mBHJr5oZ48s0hcanI9w3wgijAlv1OZNUZve9JR4x42dn5lJ5Sm87V1JNfnoh10EnQlA==}
 
@@ -479,6 +812,9 @@ packages:
 
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@16.9.1':
+    resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
@@ -518,6 +854,9 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  '@webgpu/types@0.1.70':
+    resolution: {integrity: sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -535,6 +874,9 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
+  any-base@1.1.0:
+    resolution: {integrity: sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -542,8 +884,85 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  await-to-js@3.0.0:
+    resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
+    engines: {node: '>=6.0.0'}
+
+  babel-plugin-jsx-dom-expressions@0.40.7:
+    resolution: {integrity: sha512-/O6JWUmjv03OI9lL2ry9bUjpD5S3PclM55RRJEyCdcFZ5W2SEA/59d+l2hNsk3gI6kiWRdRPdOtqZmsQzFN1pQ==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+
+  babel-plugin-module-resolver@5.0.2:
+    resolution: {integrity: sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==}
+
+  babel-preset-solid@1.9.10:
+    resolution: {integrity: sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      solid-js: ^1.9.10
+    peerDependenciesMeta:
+      solid-js:
+        optional: true
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  bmp-ts@1.0.9:
+    resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bun-ffi-structs@0.1.2:
+    resolution: {integrity: sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==}
+    peerDependencies:
+      typescript: ^5
+
+  bun-types@1.3.11:
+    resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
+
+  bun-webgpu-darwin-arm64@0.1.7:
+    resolution: {integrity: sha512-mRrFFyHzPWjsTRidAZBRcu808CPQBOUL0P6b4nxLhp+XHcV/mbUHERZMgW9s58tsojQfSdzschiQa8q+JCgRWA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  bun-webgpu-darwin-x64@0.1.7:
+    resolution: {integrity: sha512-g0NXGNgvaVCSH/jCWWlfdiquOHkbUN6vP4zqzSkIxWKQeLnqm3oADcok7SO3yIgI7v5mKpRc/ks7NDEKNH+jNQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  bun-webgpu-linux-x64@0.1.7:
+    resolution: {integrity: sha512-UEP7UZdEhx9otvkZczjsszL8ZVlrODANQvgl+C88/bNVmxDoFi7w1fWzGi1sZyakiETjmtFDq2/xCLhbSZxjqw==}
+    cpu: [x64]
+    os: [linux]
+
+  bun-webgpu-win32-x64@0.1.7:
+    resolution: {integrity: sha512-KZktiFkBz6sN7PEm1NVdeaLP5Q5X/PlSHZqefY4nNuWtf0LNvh54NhZe7yVv/Plz/nGbv92b0KHMBY3ki/pp6g==}
+    cpu: [x64]
+    os: [win32]
+
+  bun-webgpu@0.1.5:
+    resolution: {integrity: sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -552,6 +971,9 @@ packages:
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -565,9 +987,15 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -593,12 +1021,23 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  diff@8.0.2:
+    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+    engines: {node: '>=0.3.1'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  electron-to-chromium@1.5.361:
+    resolution: {integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   es-define-property@1.0.1:
@@ -625,6 +1064,10 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -632,9 +1075,27 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
+  exif-parser@0.1.12:
+    resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  file-type@16.5.4:
+    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
+    engines: {node: '>=10'}
+
+  find-babel-config@2.1.2:
+    resolution: {integrity: sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==}
+
+  find-up@3.0.0:
+    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
+    engines: {node: '>=6'}
 
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
@@ -647,6 +1108,9 @@ packages:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
 
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -655,6 +1119,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -662,6 +1130,14 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  gifwrap@0.10.1:
+    resolution: {integrity: sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==}
+
+  glob@9.3.5:
+    resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -683,11 +1159,34 @@ packages:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  html-entities@2.3.3:
+    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  image-q@4.0.0:
+    resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  jimp@1.6.0:
+    resolution: {integrity: sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==}
+    engines: {node: '>=18'}
+
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   jsdom@29.0.2:
     resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
@@ -698,15 +1197,40 @@ packages:
       canvas:
         optional: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  locate-path@3.0.0:
+    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
+    engines: {node: '>=6'}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -722,6 +1246,23 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  minimatch@8.0.7:
+    resolution: {integrity: sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@4.2.8:
+    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
+    engines: {node: '>=8'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -745,8 +1286,53 @@ packages:
       encoding:
         optional: true
 
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
+
+  omggif@1.0.10:
+    resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@3.0.0:
+    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
+    engines: {node: '>=6'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  parse-bmfont-ascii@1.0.6:
+    resolution: {integrity: sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==}
+
+  parse-bmfont-binary@1.0.6:
+    resolution: {integrity: sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==}
+
+  parse-bmfont-xml@1.1.6:
+    resolution: {integrity: sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-exists@3.0.0:
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
+    engines: {node: '>=4'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -755,32 +1341,109 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  peek-readable@4.1.0:
+    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
+    engines: {node: '>=8'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  pixelmatch@5.3.0:
+    resolution: {integrity: sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==}
+    hasBin: true
+
+  pkg-up@3.1.0:
+    resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
+    engines: {node: '>=8'}
+
+  planck@1.5.0:
+    resolution: {integrity: sha512-dlvqJE+FscZgrGUXJ5ybd0o5bvZ5XXyZNbm08xGsXp9WjXeAyWSFT6n9s/1PQcUBo4546fDXA5RMA4wbDyZw6g==}
+    engines: {node: '>=24.0'}
+    peerDependencies:
+      stage-js: ^1.0.0-alpha.12
+
+  pngjs@6.0.0:
+    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
+    engines: {node: '>=12.13.0'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readable-web-to-node-stream@3.0.4:
+    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
+    engines: {node: '>=8'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@4.1.8:
+    resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  s-js@0.4.9:
+    resolution: {integrity: sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  seroval-plugins@1.3.3:
+    resolution: {integrity: sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.3.2:
+    resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
+    engines: {node: '>=10'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  simple-xml-to-json@1.2.7:
+    resolution: {integrity: sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==}
+    engines: {node: '>=20.12.2'}
+
+  solid-js@1.9.10:
+    resolution: {integrity: sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -789,14 +1452,35 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stage-js@1.0.2:
+    resolution: {integrity: sha512-EWTRBYlg7Qv9wGUao99/PfRe3KaiQqWmgSvTOXvaWnu1Jk/q/vV8yJVu6bi/3EqDZeMVnCPAjheba6OFc5k1GQ==}
+    engines: {node: '>=24.0'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strtok3@6.3.0:
+    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
+    engines: {node: '>=10'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  three@0.177.0:
+    resolution: {integrity: sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinycolor2@1.6.0:
+    resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -820,6 +1504,10 @@ packages:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
+  token-types@4.2.1:
+    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
+    engines: {node: '>=10'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -833,6 +1521,11 @@ packages:
 
   turbo@2.9.6:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
+    hasBin: true
+
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   typescript@5.9.3:
@@ -852,6 +1545,15 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  utif2@4.1.0:
+    resolution: {integrity: sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -922,6 +1624,14 @@ packages:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
 
+  web-tree-sitter@0.25.10:
+    resolution: {integrity: sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA==}
+    peerDependencies:
+      '@types/emscripten': ^1.40.0
+    peerDependenciesMeta:
+      '@types/emscripten':
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -949,10 +1659,35 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-parse-from-string@1.0.1:
+    resolution: {integrity: sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==}
+
+  xml2js@0.5.0:
+    resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
+    engines: {node: '>=4.0.0'}
+
+  xmlbuilder@11.0.1:
+    resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
+    engines: {node: '>=4.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@anthropic-ai/sdk@0.39.0':
     dependencies:
@@ -986,6 +1721,196 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.28.0':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.27.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.18.6':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-optimise-call-expression@7.27.1':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.28.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.27.1(@babel/core@7.28.0)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.28.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -1013,6 +1938,9 @@ snapshots:
       css-tree: 3.2.1
 
   '@csstools/css-tokenizer@4.0.0': {}
+
+  '@dimforge/rapier2d-simd-compat@0.17.3':
+    optional: true
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1085,7 +2013,265 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@jimp/core@1.6.0':
+    dependencies:
+      '@jimp/file-ops': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      await-to-js: 3.0.0
+      exif-parser: 0.1.12
+      file-type: 16.5.4
+      mime: 3.0.0
+
+  '@jimp/diff@1.6.0':
+    dependencies:
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      pixelmatch: 5.3.0
+
+  '@jimp/file-ops@1.6.0': {}
+
+  '@jimp/js-bmp@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      bmp-ts: 1.0.9
+
+  '@jimp/js-gif@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      gifwrap: 0.10.1
+      omggif: 1.0.10
+
+  '@jimp/js-jpeg@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      jpeg-js: 0.4.4
+
+  '@jimp/js-png@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      pngjs: 7.0.0
+
+  '@jimp/js-tiff@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      utif2: 4.1.0
+
+  '@jimp/plugin-blit@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-blur@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/utils': 1.6.0
+
+  '@jimp/plugin-circle@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-color@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      tinycolor2: 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-contain@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/plugin-blit': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-cover@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/plugin-crop': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-crop@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-displace@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-dither@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+
+  '@jimp/plugin-fisheye@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-flip@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-hash@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/js-bmp': 1.6.0
+      '@jimp/js-jpeg': 1.6.0
+      '@jimp/js-png': 1.6.0
+      '@jimp/js-tiff': 1.6.0
+      '@jimp/plugin-color': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      any-base: 1.1.0
+
+  '@jimp/plugin-mask@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-print@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/js-jpeg': 1.6.0
+      '@jimp/js-png': 1.6.0
+      '@jimp/plugin-blit': 1.6.0
+      '@jimp/types': 1.6.0
+      parse-bmfont-ascii: 1.0.6
+      parse-bmfont-binary: 1.0.6
+      parse-bmfont-xml: 1.1.6
+      simple-xml-to-json: 1.2.7
+      zod: 3.25.76
+
+  '@jimp/plugin-quantize@1.6.0':
+    dependencies:
+      image-q: 4.0.0
+      zod: 3.25.76
+
+  '@jimp/plugin-resize@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/types': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-rotate@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/plugin-crop': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/plugin-threshold@1.6.0':
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/plugin-color': 1.6.0
+      '@jimp/plugin-hash': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+      zod: 3.25.76
+
+  '@jimp/types@1.6.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@jimp/utils@1.6.0':
+    dependencies:
+      '@jimp/types': 1.6.0
+      tinycolor2: 1.6.0
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@opentui/core-darwin-arm64@0.1.99':
+    optional: true
+
+  '@opentui/core-darwin-x64@0.1.99':
+    optional: true
+
+  '@opentui/core-linux-arm64@0.1.99':
+    optional: true
+
+  '@opentui/core-linux-x64@0.1.99':
+    optional: true
+
+  '@opentui/core-win32-arm64@0.1.99':
+    optional: true
+
+  '@opentui/core-win32-x64@0.1.99':
+    optional: true
+
+  '@opentui/core@0.1.99(stage-js@1.0.2)(typescript@5.8.2)(web-tree-sitter@0.25.10)':
+    dependencies:
+      bun-ffi-structs: 0.1.2(typescript@5.8.2)
+      diff: 8.0.2
+      jimp: 1.6.0
+      marked: 17.0.1
+      web-tree-sitter: 0.25.10
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@dimforge/rapier2d-simd-compat': 0.17.3
+      '@opentui/core-darwin-arm64': 0.1.99
+      '@opentui/core-darwin-x64': 0.1.99
+      '@opentui/core-linux-arm64': 0.1.99
+      '@opentui/core-linux-x64': 0.1.99
+      '@opentui/core-win32-arm64': 0.1.99
+      '@opentui/core-win32-x64': 0.1.99
+      bun-webgpu: 0.1.5
+      planck: 1.5.0(stage-js@1.0.2)
+      three: 0.177.0
+    transitivePeerDependencies:
+      - stage-js
+      - typescript
+
+  '@opentui/solid@0.1.99(solid-js@1.9.10)(stage-js@1.0.2)(typescript@5.8.2)(web-tree-sitter@0.25.10)':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
+      '@opentui/core': 0.1.99(stage-js@1.0.2)(typescript@5.8.2)(web-tree-sitter@0.25.10)
+      babel-plugin-module-resolver: 5.0.2
+      babel-preset-solid: 1.9.10(@babel/core@7.28.0)(solid-js@1.9.10)
+      entities: 7.0.1
+      s-js: 0.4.9
+      solid-js: 1.9.10
+    transitivePeerDependencies:
+      - stage-js
+      - supports-color
+      - typescript
+      - web-tree-sitter
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -1162,6 +2348,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
+  '@tokenizer/token@0.3.0': {}
+
+  '@tsconfig/bun@1.0.9': {}
+
   '@turbo/darwin-64@2.9.6':
     optional: true
 
@@ -1179,6 +2369,10 @@ snapshots:
 
   '@turbo/windows-arm64@2.9.6':
     optional: true
+
+  '@types/bun@1.3.11':
+    dependencies:
+      bun-types: 1.3.11
 
   '@types/chrome@0.0.268':
     dependencies:
@@ -1200,6 +2394,8 @@ snapshots:
       '@types/node': 22.19.17
       form-data: 4.0.5
 
+  '@types/node@16.9.1': {}
+
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
@@ -1219,14 +2415,6 @@ snapshots:
       '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
-
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17))':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 5.4.21(@types/node@22.19.17)
 
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.6.0))':
     dependencies:
@@ -1261,6 +2449,9 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@webgpu/types@0.1.70':
+    optional: true
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -1275,13 +2466,96 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
+  any-base@1.1.0: {}
+
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
 
+  await-to-js@3.0.0: {}
+
+  babel-plugin-jsx-dom-expressions@0.40.7(@babel/core@7.28.0):
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.0)
+      '@babel/types': 7.29.0
+      html-entities: 2.3.3
+      parse5: 7.3.0
+
+  babel-plugin-module-resolver@5.0.2:
+    dependencies:
+      find-babel-config: 2.1.2
+      glob: 9.3.5
+      pkg-up: 3.1.0
+      reselect: 4.1.8
+      resolve: 1.22.12
+
+  babel-preset-solid@1.9.10(@babel/core@7.28.0)(solid-js@1.9.10):
+    dependencies:
+      '@babel/core': 7.28.0
+      babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.28.0)
+    optionalDependencies:
+      solid-js: 1.9.10
+
+  balanced-match@1.0.2: {}
+
+  base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.10.32: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  bmp-ts@1.0.9: {}
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.361
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bun-ffi-structs@0.1.2(typescript@5.8.2):
+    dependencies:
+      typescript: 5.8.2
+
+  bun-types@1.3.11:
+    dependencies:
+      '@types/node': 22.19.17
+
+  bun-webgpu-darwin-arm64@0.1.7:
+    optional: true
+
+  bun-webgpu-darwin-x64@0.1.7:
+    optional: true
+
+  bun-webgpu-linux-x64@0.1.7:
+    optional: true
+
+  bun-webgpu-win32-x64@0.1.7:
+    optional: true
+
+  bun-webgpu@0.1.5:
+    dependencies:
+      '@webgpu/types': 0.1.70
+    optionalDependencies:
+      bun-webgpu-darwin-arm64: 0.1.7
+      bun-webgpu-darwin-x64: 0.1.7
+      bun-webgpu-linux-x64: 0.1.7
+      bun-webgpu-win32-x64: 0.1.7
+    optional: true
 
   cac@6.7.14: {}
 
@@ -1289,6 +2563,8 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  caniuse-lite@1.0.30001793: {}
 
   chai@5.3.3:
     dependencies:
@@ -1304,10 +2580,14 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  convert-source-map@2.0.0: {}
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+
+  csstype@3.2.3: {}
 
   data-urls@7.0.0:
     dependencies:
@@ -1326,13 +2606,19 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  diff@8.0.2: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  electron-to-chromium@1.5.361: {}
+
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -1377,13 +2663,33 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
+  escalade@3.2.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
   event-target-shim@5.0.1: {}
 
+  events@3.3.0: {}
+
+  exif-parser@0.1.12: {}
+
   expect-type@1.3.0: {}
+
+  file-type@16.5.4:
+    dependencies:
+      readable-web-to-node-stream: 3.0.4
+      strtok3: 6.3.0
+      token-types: 4.2.1
+
+  find-babel-config@2.1.2:
+    dependencies:
+      json5: 2.2.3
+
+  find-up@3.0.0:
+    dependencies:
+      locate-path: 3.0.0
 
   form-data-encoder@1.7.2: {}
 
@@ -1400,10 +2706,14 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -1423,6 +2733,18 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  gifwrap@0.10.1:
+    dependencies:
+      image-q: 4.0.0
+      omggif: 1.0.10
+
+  glob@9.3.5:
+    dependencies:
+      fs.realpath: 1.0.0
+      minimatch: 8.0.7
+      minipass: 4.2.8
+      path-scurry: 1.11.1
+
   gopd@1.2.0: {}
 
   has-symbols@1.1.0: {}
@@ -1441,11 +2763,57 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  html-entities@2.3.3: {}
+
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
 
+  ieee754@1.2.1: {}
+
+  image-q@4.0.0:
+    dependencies:
+      '@types/node': 16.9.1
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
+
   is-potential-custom-element-name@1.0.1: {}
+
+  jimp@1.6.0:
+    dependencies:
+      '@jimp/core': 1.6.0
+      '@jimp/diff': 1.6.0
+      '@jimp/js-bmp': 1.6.0
+      '@jimp/js-gif': 1.6.0
+      '@jimp/js-jpeg': 1.6.0
+      '@jimp/js-png': 1.6.0
+      '@jimp/js-tiff': 1.6.0
+      '@jimp/plugin-blit': 1.6.0
+      '@jimp/plugin-blur': 1.6.0
+      '@jimp/plugin-circle': 1.6.0
+      '@jimp/plugin-color': 1.6.0
+      '@jimp/plugin-contain': 1.6.0
+      '@jimp/plugin-cover': 1.6.0
+      '@jimp/plugin-crop': 1.6.0
+      '@jimp/plugin-displace': 1.6.0
+      '@jimp/plugin-dither': 1.6.0
+      '@jimp/plugin-fisheye': 1.6.0
+      '@jimp/plugin-flip': 1.6.0
+      '@jimp/plugin-hash': 1.6.0
+      '@jimp/plugin-mask': 1.6.0
+      '@jimp/plugin-print': 1.6.0
+      '@jimp/plugin-quantize': 1.6.0
+      '@jimp/plugin-resize': 1.6.0
+      '@jimp/plugin-rotate': 1.6.0
+      '@jimp/plugin-threshold': 1.6.0
+      '@jimp/types': 1.6.0
+      '@jimp/utils': 1.6.0
+
+  jpeg-js@0.4.4: {}
+
+  js-tokens@4.0.0: {}
 
   jsdom@29.0.2:
     dependencies:
@@ -1473,13 +2841,30 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  locate-path@3.0.0:
+    dependencies:
+      p-locate: 3.0.0
+      path-exists: 3.0.0
+
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.3.5: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@17.0.1: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -1491,6 +2876,16 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mime@3.0.0: {}
+
+  minimatch@8.0.7:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minipass@4.2.8: {}
+
+  minipass@7.1.3: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
@@ -1501,15 +2896,72 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-releases@2.0.46: {}
+
+  omggif@1.0.10: {}
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@3.0.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
+  pako@1.0.11: {}
+
+  parse-bmfont-ascii@1.0.6: {}
+
+  parse-bmfont-binary@1.0.6: {}
+
+  parse-bmfont-xml@1.1.6:
+    dependencies:
+      xml-parse-from-string: 1.0.1
+      xml2js: 0.5.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
+
+  path-exists@3.0.0: {}
+
+  path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@1.1.2: {}
 
   pathval@2.0.1: {}
 
+  peek-readable@4.1.0: {}
+
   picocolors@1.1.1: {}
+
+  pixelmatch@5.3.0:
+    dependencies:
+      pngjs: 6.0.0
+
+  pkg-up@3.1.0:
+    dependencies:
+      find-up: 3.0.0
+
+  planck@1.5.0(stage-js@1.0.2):
+    dependencies:
+      stage-js: 1.0.2
+    optional: true
+
+  pngjs@6.0.0: {}
+
+  pngjs@7.0.0: {}
 
   postcss@8.5.10:
     dependencies:
@@ -1517,9 +2969,32 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  process@0.11.10: {}
+
   punycode@2.3.1: {}
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readable-web-to-node-stream@3.0.4:
+    dependencies:
+      readable-stream: 4.7.0
+
   require-from-string@2.0.2: {}
+
+  reselect@4.1.8: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   rollup@4.60.2:
     dependencies:
@@ -1552,21 +3027,62 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  s-js@0.4.9: {}
+
+  safe-buffer@5.2.1: {}
+
+  sax@1.6.0: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
 
+  semver@6.3.1: {}
+
+  seroval-plugins@1.3.3(seroval@1.3.2):
+    dependencies:
+      seroval: 1.3.2
+
+  seroval@1.3.2: {}
+
   siginfo@2.0.0: {}
+
+  simple-xml-to-json@1.2.7: {}
+
+  solid-js@1.9.10:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.3.2
+      seroval-plugins: 1.3.3(seroval@1.3.2)
 
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
+  stage-js@1.0.2:
+    optional: true
+
   std-env@3.10.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strtok3@6.3.0:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      peek-readable: 4.1.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
 
+  three@0.177.0:
+    optional: true
+
   tinybench@2.9.0: {}
+
+  tinycolor2@1.6.0: {}
 
   tinyexec@0.3.2: {}
 
@@ -1581,6 +3097,11 @@ snapshots:
   tldts@7.0.28:
     dependencies:
       tldts-core: 7.0.28
+
+  token-types@4.2.1:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   tough-cookie@6.0.1:
     dependencies:
@@ -1601,6 +3122,8 @@ snapshots:
       '@turbo/windows-64': 2.9.6
       '@turbo/windows-arm64': 2.9.6
 
+  typescript@5.8.2: {}
+
   typescript@5.9.3: {}
 
   undici-types@5.26.5: {}
@@ -1611,6 +3134,16 @@ snapshots:
     optional: true
 
   undici@7.25.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  utif2@4.1.0:
+    dependencies:
+      pako: 1.0.11
 
   vite-node@2.1.9(@types/node@22.19.17):
     dependencies:
@@ -1669,7 +3202,7 @@ snapshots:
   vitest@2.1.9(@types/node@22.19.17)(jsdom@29.0.2):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.6.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -1744,6 +3277,8 @@ snapshots:
 
   web-streams-polyfill@4.0.0-beta.3: {}
 
+  web-tree-sitter@0.25.10: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
@@ -1770,4 +3305,19 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
+  xml-parse-from-string@1.0.1: {}
+
+  xml2js@0.5.0:
+    dependencies:
+      sax: 1.6.0
+      xmlbuilder: 11.0.1
+
+  xmlbuilder@11.0.1: {}
+
   xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}
+
+  yoga-layout@3.2.1: {}
+
+  zod@3.25.76: {}


### PR DESCRIPTION
## Summary

- **Fifth integration**: `oc-edit`, a self-owned Bun + OpenTUI + SolidJS TUI app. Useful where none of CC/OC/Gemini is installed but the user still wants the full feature surface — invoke as `$EDITOR`, pipe from stdin, or wire to a zsh ZLE widget for in-shell editing.
- **New adapter band** at `packages/opencues-runtime/adapters/terminal/v1/` — structural near-clone of `adapters/oc/v1.14/` since both target the same OpenTUI `TextareaRenderable`. All 5 source types wire (sentence-cue, word-cues, config-intent, fluid-blank, transform-blank); full capability set including spawn + blank-invoke.
- **CLI wiring**: `install`, `run`, `uninstall`, `update`, `version`, `completion`, `doctor` each handle `terminal` and its aliases (`term`, `oc-edit`).
- **Docs**: top-level README + CLAUDE.md updated; `docs/features/host-compat.md` lists the new host; `docs/guides/adding-an-integration.md` documents the **self-owned-app** pattern as a fourth patch strategy.

## Why this fits

Raw shells can't host the runtime (no persistent buffer, no `onRender` surface). A standalone TUI plugs that gap without inventing a new pattern — it reuses the same `HostAdapter` contract every other host implements, just behind an app we own end-to-end. Adapter band diff vs OC is ~5 lines (`hostName`, `hostVersion`, comments).

## Tests

- ✅ `pnpm --filter @opencues/runtime test` → **1262/1262** (incl. 6 new terminal-band tests)
- ✅ `node --test packages/opencues-core/dist/host-compat.test.js` → **31/31**
- ✅ `opencues install/run/uninstall/update/version/completion --help` all surface `terminal`
- ✅ `opencues doctor` shows a green Terminal section
- ✅ Live boot smoke: `bun src/app.tsx` brings up Terminal v1, ConfigLoader loads USER.md, Resolver builds with all 5 source types

## Test plan (reviewer's manual pass)

Full 9-section checklist lives at `integrations/terminal/TEST-WHEN-MERGED.md` — ~15 minutes on a clean machine. Highlights:

- [ ] `opencues install terminal` completes; doctor section green
- [ ] `bun integrations/terminal/bin/oc-edit` opens TUI; typing produces dim cues; Ctrl+Alt+↑/↓ cycles
- [ ] `_` triggers blank fill (e.g. `volume _`); fluid-blank works
- [ ] Agent-rewrite (`agentically X`) rewrites buffer; Down-arrow reverts
- [ ] `$EDITOR=oc-edit git commit` opens for commit messages
- [ ] zsh `Ctrl+E` ZLE widget round-trips the shell buffer through oc-edit
- [ ] Cross-terminal key handling — Alacritty / Windows Terminal / iTerm / macOS Terminal.app / Ghostty (long tail, not a blocker)
- [ ] `opencues uninstall terminal` removes staged paths cleanly

## Blast radius

Small. All changes are additive except `host-compat.{ts,test.ts}` (3-line array extensions) and 7 CLI command files (each adds one terminal case + a help line). No semantic conflicts with master expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)