### PR TITLE
feat(providers): blank-llm-provider scalar + OpenCode Zen free pool + ProviderHealth surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,17 @@ Full config reference, scalar table, and authoring guide: [`docs/configuration.m
 
 ## LLM providers
 
-OpenCues supports **six providers** out of the box: Groq (default — free tier), Cerebras, OpenAI, Anthropic, OpenRouter, Gemini. Set the env key for whichever you want; pick different providers per feature (word-cues vs fluid-blank vs transform-blank vs agent-rewrite) in `~/.cues/OPENCUES.md`.
+OpenCues supports **seven providers** out of the box: Groq (default — free tier), Cerebras, OpenAI, Anthropic, OpenRouter, Gemini, and OpenCode Zen. Set the env key for whichever you want; pick different providers per feature (word-cues vs fluid-blank vs transform-blank vs agent-rewrite) in `~/.cues/OPENCUES.md`.
 
 Setting both `GROQ_API_KEY` and `CEREBRAS_API_KEY` enables automatic 429/5xx failover between them — same `gpt-oss-120b` weights mean no quality shift when one provider rate-limits.
+
+### Free mode (no API key)
+
+Add `blank-llm-provider: free` to `~/.cues/OPENCUES.md` and **blanks** (FluidBlank / TransformBlank / ConfigIntent) route through [OpenCode Zen](https://opencode.ai/zen)'s free model pool — anonymously, no key required. The runtime walks the pool on transient failures and surfaces the resolved model in the status line.
+
+> ⚠️ **Data warning.** OpenCode Zen's free tier ToS says **your inputs may be used to train the underlying models**. Free mode is **blank-only by design** — cues, auditors, agent-rewrite (which run automatically on prose) never use this path, and `llm-provider: free` (the cue path) is refused at startup. Only `_` triggers go through the free pool, and only the surrounding context window — but treat anything you type next to a `_` in free mode as public.
+
+> ⚠️ **The pool changes.** Free models on OpenCode Zen rotate in and out — promotions end, models move behind paid tiers, new ones arrive. As of May 2026 the working set is `big-pickle` + `deepseek-v4-flash-free` + `nemotron-3-super-free`; the other two we benched (`qwen3.6-plus-free`, `minimax-m2.5-free`) have already moved to the paid OpenCode Go tier. The runtime health-caches dead entries for 30s and walks the rest, but the **canonical live list** is `GET https://opencode.ai/zen/v1/models` — re-check before relying on any specific model.
 
 Per-provider setup, per-feature routing, and the bench data behind the recommendations: [`docs/guides/llm-providers.md`](docs/guides/llm-providers.md).
 

--- a/packages/opencues-cli/src/commands/help.cjs
+++ b/packages/opencues-cli/src/commands/help.cjs
@@ -253,6 +253,7 @@ const PROVIDER_DISPLAY = {
   anthropic: 'Claude', openrouter: 'OpenRouter', gemini: 'Gemini',
   'claude-cli': 'Claude (CLI, subscription)',
   'openai-subscription': 'OpenAI (ChatGPT subscription)',
+  'opencode-zen': 'OpenCode Zen',
 };
 
 // Default model fallback for pre-build. Live data sourced from
@@ -266,6 +267,7 @@ const PROVIDER_DEFAULT_MODEL = {
   gemini:     'gemini-3.1-flash-lite',
   'claude-cli': 'haiku',
   'openai-subscription': 'gpt-5.4-mini',
+  'opencode-zen': 'big-pickle',
 };
 // Strip cosmetic prefixes/suffixes for display ('openai/foo' → 'foo',
 // 'foo:free' → 'foo'). Keeps the meaningful model identity, trims chrome.

--- a/packages/opencues-core/src/feature-registry.ts
+++ b/packages/opencues-core/src/feature-registry.ts
@@ -333,6 +333,30 @@ export const FEATURES: readonly FeatureSpec[] = [
     ],
   },
 
+  // ── Provider routing ─────────────────────────────────────────────
+  {
+    scalar: 'blank-llm-provider',
+    camelCase: 'blankLlmProvider',
+    description: 'LLM provider used for blank-class sources (FluidBlank / TransformBlank / ConfigIntent / keyword blanks). Inherits llm-provider by default.',
+    menuTip: 'Pick a separate provider for blanks (the opt-in `_` surface). `free` routes blanks through OpenCode Zen\'s free model pool — no API key, but the provider trains on data. Cues + auditors are unaffected by this setting.',
+    values: [
+      { id: 'inherit', description: 'Default — blanks use the same provider as llm-provider' },
+      { id: 'free',    description: 'OpenCode Zen free pool (no API key required; providers train on blank inputs). Cues + auditors never use this.' },
+      // The seven concrete provider ids stay parser-valid but are hidden
+      // from the menu — picking a specific paid provider per-surface is
+      // an advanced override better edited in OPENCUES.md directly. The
+      // menu's job is the inherit-vs-free split.
+      { id: 'groq',         description: 'Pin blanks to Groq',         exposeInMenu: false },
+      { id: 'openrouter',   description: 'Pin blanks to OpenRouter',   exposeInMenu: false },
+      { id: 'gemini',       description: 'Pin blanks to Gemini',       exposeInMenu: false },
+      { id: 'openai',       description: 'Pin blanks to OpenAI',       exposeInMenu: false },
+      { id: 'anthropic',    description: 'Pin blanks to Anthropic',    exposeInMenu: false },
+      { id: 'cerebras',     description: 'Pin blanks to Cerebras',     exposeInMenu: false },
+      { id: 'claude-cli',   description: 'Pin blanks to claude-cli',   exposeInMenu: false },
+      { id: 'opencode-zen', description: 'Pin blanks to opencode-zen', exposeInMenu: false },
+    ],
+  },
+
   // ── Context injection ────────────────────────────────────────────
   {
     scalar: 'ambient-context-mode',

--- a/packages/opencues-core/src/llm-provider.ts
+++ b/packages/opencues-core/src/llm-provider.ts
@@ -20,9 +20,9 @@
  * model defaults + request/response translators. Nothing else changes.
  */
 
-export type ProviderId = 'groq' | 'openrouter' | 'gemini' | 'openai' | 'openai-subscription' | 'anthropic' | 'cerebras' | 'claude-cli';
+export type ProviderId = 'groq' | 'openrouter' | 'gemini' | 'openai' | 'openai-subscription' | 'anthropic' | 'cerebras' | 'claude-cli' | 'opencode-zen';
 
-export const PROVIDER_IDS: readonly ProviderId[] = ['groq', 'openrouter', 'gemini', 'openai', 'openai-subscription', 'anthropic', 'cerebras', 'claude-cli'];
+export const PROVIDER_IDS: readonly ProviderId[] = ['groq', 'openrouter', 'gemini', 'openai', 'openai-subscription', 'anthropic', 'cerebras', 'claude-cli', 'opencode-zen'];
 
 /**
  * Internal chat-request shape — provider-neutral. Each provider's
@@ -131,6 +131,17 @@ export interface ProviderAdapter {
   readonly defaultModel: string;
   /** The env-var name the boot layer reads to find this provider's API key. */
   readonly envKeyName: string;
+  /**
+   * When true, `resolveLLM` will return a usable tuple even if the API
+   * key is unset — `apiKey` resolves to `''`. The provider's
+   * `buildRequest` is responsible for handling the empty case (e.g.
+   * omitting the Authorization header). Today only `opencode-zen` opts
+   * in: its free model pool authenticates anonymously, paid models
+   * still need a key. Without this flag, the provider is unusable
+   * until a key is set — which would break `blank-llm-provider: free`
+   * for the no-account case the feature was designed for.
+   */
+  readonly optionalAuth?: boolean;
   /**
    * Per-provider reasoning-effort default. Applied when a call site
    * leaves `req.reasoningEffort` undefined. Derived from the May 18
@@ -720,6 +731,258 @@ const CLAUDE_CLI: ProviderAdapter = {
   },
 };
 
+/**
+ * OpenCode Zen — the curated hosted gateway at opencode.ai. OpenAI-shape
+ * chat-completions at `https://opencode.ai/zen/v1/chat/completions`. The
+ * gateway hosts both paid and free models; free models do not require an
+ * API key (verified May 2026 — anonymous POSTs returned 200 + a
+ * `"cost":"0"` field).
+ *
+ * Model IDs are BARE (e.g. `big-pickle`), not `opencode/<id>` despite
+ * what the docs at opencode.ai/docs/zen suggest — the prefixed form
+ * 401s with "Model … is not supported". The `/v1/models` GET endpoint
+ * is the authoritative live list.
+ *
+ * Used by the `blank-llm-provider: free` mode. The pool of free
+ * model IDs is in OPENCODE_ZEN_FREE_POOL (priority order) and
+ * `dispatchWithFreePool` walks it on transient failure with 30s
+ * health-caching of dead entries.
+ *
+ * IMPORTANT: free-tier ToS says collected data may be used to improve
+ * the models. Never route cues / auditors / agent-rewrite through this
+ * adapter — only blanks (the user typed `_`, an opt-in surface).
+ */
+const OPENCODE_ZEN: ProviderAdapter = {
+  id: 'opencode-zen',
+  displayName: 'OpenCode Zen',
+  defaultEndpoint: 'https://opencode.ai/zen/v1/chat/completions',
+  // First entry of the free pool. Used when no model is explicitly set
+  // (most common case for `blank-llm-provider: free`).
+  defaultModel: 'big-pickle',
+  // Optional. Free models work without it; paid models need it.
+  envKeyName: 'OPENCODE_ZEN_API_KEY',
+  optionalAuth: true,
+  // Most free models are reasoning models; low keeps latency reasonable.
+  defaultReasoningEffort: 'low',
+  buildRequest(req, ctx) {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    // API key is optional — free models authenticate as anonymous.
+    // Don't send a bearer header when the key is empty; some gateways
+    // reject `Authorization: Bearer ` (empty bearer) with 401.
+    if (ctx.apiKey) headers.Authorization = `Bearer ${ctx.apiKey}`;
+    return {
+      url: ctx.endpoint ?? this.defaultEndpoint,
+      body: buildOpenAIBody(req, { defaultReasoningEffort: this.defaultReasoningEffort }),
+      headers,
+    };
+  },
+  parseResponse: parseOpenAIResponse,
+};
+
+/**
+ * Free-tier model pool in priority order — first entry is preferred.
+ * `dispatchWithFreePool` walks this list on transient failure.
+ *
+ * Ranking from the May 2026 fluid-blank bench (`tests/results/opencode-zen-free/`,
+ * 30-case sample, fused mode). Order = accuracy-desc; the latency
+ * trade is the user's to accept by editing `free-model-preference:`
+ * in OPENCUES.md if they want speed over accuracy.
+ *
+ *   nemotron-3-super-free   86.7% acc · ~14000ms p50  (winner — slow but solid)
+ *   deepseek-v4-flash-free  46.7% acc · ~5000ms p50   (fast, mediocre)
+ *   big-pickle              40.0% acc · ~5000ms p50   (a deepseek-v4-flash variant — same speed, worse)
+ *
+ * Pool entries removed in the May 2026 sweep:
+ *   - qwen3.6-plus-free     → moved to paid OpenCode Go (HTTP 402)
+ *   - minimax-m2.5-free     → moved to paid OpenCode Go (HTTP 402)
+ *
+ * The `/v1/models` endpoint is the authoritative live list — entries
+ * here that 4xx are health-cached out of rotation for 30s in
+ * dispatchWithFreePool, so a quietly-rotated-out model doesn't break
+ * the pool. Re-bench when the user reports an unexpected miss rate.
+ */
+export const OPENCODE_ZEN_FREE_POOL: readonly string[] = [
+  'nemotron-3-super-free',
+  'deepseek-v4-flash-free',
+  'big-pickle',
+];
+
+/**
+ * In-process health cache for the free pool. Maps model id → epoch ms
+ * when the model is allowed to be retried. Modules that need to
+ * inspect or reset this (tests, doctor) use the exported reset helper.
+ */
+const _opencodeZenHealth = new Map<string, number>();
+
+/** Default cool-down before retrying a model that returned a transient failure. */
+const FREE_POOL_COOLDOWN_MS = 30_000;
+
+/** Test hook — reset health cache between cases. */
+export function _resetOpencodeZenHealthForTesting(): void {
+  _opencodeZenHealth.clear();
+}
+
+/**
+ * Inspect the health cache. Useful for doctor's "which free models are
+ * currently down?" diagnostic and for tests asserting cache state.
+ */
+export function getOpencodeZenHealth(now?: () => number): ReadonlyArray<{ model: string; nextRetryAt: number }> {
+  const n = (now ?? (() => Date.now()))();
+  return Array.from(_opencodeZenHealth.entries())
+    .filter(([_, at]) => at > n)
+    .map(([model, nextRetryAt]) => ({ model, nextRetryAt }));
+}
+
+/**
+ * Dispatch a chat against the OpenCode Zen free pool. Walks
+ * `OPENCODE_ZEN_FREE_POOL` in order; on transient failure (rate-limit,
+ * outage, model-missing) marks the model unhealthy for 30s and tries
+ * the next. Sticky failures (auth, quota) bubble up immediately —
+ * they're config issues, not "try a different model" issues.
+ *
+ * The `req.model` field is overwritten with the pool entry per attempt.
+ *
+ * Returns the assistant text on first success. Throws an Error with
+ * a synthesized message when every pool entry is exhausted.
+ *
+ * `opts.now` lets tests fake the clock; `opts.pool` lets tests pass a
+ * shorter pool. In production both should be omitted.
+ */
+export async function dispatchWithFreePool(
+  httpAdapter: HttpAdapterShape,
+  req: ChatRequest,
+  ctx: { apiKey: string; endpoint?: string },
+  opts: {
+    readonly pool?: readonly string[];
+    readonly now?: () => number;
+    readonly cooldownMs?: number;
+    /** Called with classification input on each failed attempt — used by ProviderHealth wiring. */
+    readonly onFailure?: (info: { model: string; status?: number; body?: string; cause?: unknown }) => void;
+  } = {},
+): Promise<string> {
+  const pool = opts.pool ?? OPENCODE_ZEN_FREE_POOL;
+  const now = opts.now ?? (() => Date.now());
+  const cooldown = opts.cooldownMs ?? FREE_POOL_COOLDOWN_MS;
+  const errors: string[] = [];
+  for (const model of pool) {
+    const downUntil = _opencodeZenHealth.get(model) ?? 0;
+    if (downUntil > now()) continue; // skip — still in cool-down
+    try {
+      const result = await dispatchChat(OPENCODE_ZEN, httpAdapter, { ...req, model }, ctx);
+      // parseResponse already throws on error envelopes — if we got
+      // here with an empty string we treat that as a transient failure
+      // too (some free models return empty body on overload).
+      if (result === '') {
+        _opencodeZenHealth.set(model, now() + cooldown);
+        opts.onFailure?.({ model, body: '' });
+        errors.push(`${model}: empty response`);
+        continue;
+      }
+      _opencodeZenHealth.delete(model); // mark healthy
+      return result;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      errors.push(`${model}: ${msg}`);
+      // Heuristic: if the message smells like auth or quota, bubble
+      // immediately — no other model in the pool will work either.
+      if (/unauthorized|invalid[_ -]?api[_ -]?key|forbidden|payment[_ -]?required|insufficient[_ -]?(?:quota|credit)/i.test(msg)) {
+        opts.onFailure?.({ model, cause: err });
+        throw err;
+      }
+      // Otherwise treat as transient — cool down this model and try next.
+      _opencodeZenHealth.set(model, now() + cooldown);
+      opts.onFailure?.({ model, cause: err });
+    }
+  }
+  throw new Error(`opencode-zen free pool exhausted: ${errors.join('; ')}`);
+}
+
+/**
+ * HTTP-adapter wrapper that walks `OPENCODE_ZEN_FREE_POOL` on transient
+ * failure. Symmetric in shape with `withFallback` — wraps a base
+ * `HttpAdapterShape` and exposes the same `post(url, body, headers)`
+ * surface; pool walking is invisible to the caller.
+ *
+ * Each post:
+ *   1. Parses the JSON body to read `body.model`. If the model isn't in
+ *      the pool, passes through to the base (no walking — the request
+ *      isn't a free-pool request).
+ *   2. Walks the pool from the current model. Skips entries still in
+ *      health cool-down (the same `_opencodeZenHealth` cache that
+ *      `dispatchWithFreePool` uses).
+ *   3. On transient failure (looksTransient + auth/quota-bubble rule)
+ *      marks the model down and retries with the next pool entry's
+ *      model substituted into the body. Auth/quota bubble through
+ *      immediately so ProviderHealth can show the right error class.
+ *
+ * Use this in build-sources.ts when the resolved provider is
+ * `opencode-zen` so existing sources (FluidBlankSource etc.) get
+ * pool-walking for free.
+ */
+export function withFreePool(
+  base: HttpAdapterShape,
+  opts: {
+    readonly pool?: readonly string[];
+    readonly now?: () => number;
+    readonly cooldownMs?: number;
+    readonly onFailure?: (info: { model: string; status?: number; body?: string; cause?: unknown }) => void;
+  } = {},
+): HttpAdapterShape {
+  const pool = opts.pool ?? OPENCODE_ZEN_FREE_POOL;
+  const now = opts.now ?? (() => Date.now());
+  const cooldown = opts.cooldownMs ?? FREE_POOL_COOLDOWN_MS;
+  return {
+    post: async (url, body, headers) => {
+      let parsedBody: { model?: string } | null = null;
+      try { parsedBody = JSON.parse(body) as { model?: string }; }
+      catch { return base.post(url, body, headers); }            // non-JSON body — passthrough
+      const startModel = parsedBody?.model;
+      // Pass through requests for models not in the pool — the wrapper
+      // is opt-in by virtue of the resolved model. This lets the same
+      // adapter be reused safely if a caller mixes routes.
+      if (!startModel || !pool.includes(startModel)) return base.post(url, body, headers);
+      const errors: string[] = [];
+      // Reorder the pool: tried model first, then the rest in pool order.
+      const startIdx = pool.indexOf(startModel);
+      const ordered = [...pool.slice(startIdx), ...pool.slice(0, startIdx)];
+      for (const model of ordered) {
+        const downUntil = _opencodeZenHealth.get(model) ?? 0;
+        if (downUntil > now()) continue;
+        const attemptBody = model === startModel
+          ? body
+          : JSON.stringify({ ...parsedBody, model });
+        try {
+          const raw = await base.post(url, attemptBody, headers);
+          // Inspect for OpenAI-error envelope without throwing — the
+          // wrapper sits BELOW parseResponse, so error envelopes still
+          // come back as raw JSON. looksTransient handles both raw
+          // bodies and parsed-out envelopes.
+          if (looksTransient(raw)) {
+            _opencodeZenHealth.set(model, now() + cooldown);
+            opts.onFailure?.({ model, body: raw });
+            errors.push(`${model}: transient`);
+            continue;
+          }
+          _opencodeZenHealth.delete(model);
+          return raw;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          // Auth / quota are sticky — bubble immediately. No other
+          // pool entry can rescue.
+          if (/unauthorized|invalid[_ -]?api[_ -]?key|forbidden|payment[_ -]?required|insufficient[_ -]?(?:quota|credit)/i.test(msg)) {
+            opts.onFailure?.({ model, cause: err });
+            throw err;
+          }
+          _opencodeZenHealth.set(model, now() + cooldown);
+          opts.onFailure?.({ model, cause: err });
+          errors.push(`${model}: ${msg}`);
+        }
+      }
+      throw new Error(`opencode-zen free pool exhausted: ${errors.join('; ')}`);
+    },
+  };
+}
+
 const PROVIDERS: Readonly<Record<ProviderId, ProviderAdapter>> = {
   groq: GROQ,
   openrouter: OPENROUTER,
@@ -729,6 +992,7 @@ const PROVIDERS: Readonly<Record<ProviderId, ProviderAdapter>> = {
   anthropic: ANTHROPIC,
   cerebras: CEREBRAS,
   'claude-cli': CLAUDE_CLI,
+  'opencode-zen': OPENCODE_ZEN,
 };
 
 /**
@@ -1038,6 +1302,9 @@ const FALLBACK_PAIRS: Readonly<Record<ProviderId, ProviderId | undefined>> = {
   // back to. If the subscription daemon dies, the user picks a different
   // provider in OPENCUES.md.
   'claude-cli': undefined,
+  // opencode-zen has its own pool-walking dispatcher
+  // (dispatchWithFreePool); no cross-provider fallback needed.
+  'opencode-zen': undefined,
 };
 
 /**
@@ -1199,6 +1466,13 @@ export function resolveLLM(opts: ResolveLLMOptions): ResolvedLLM | null {
   }
   const apiKey = opts.apiKeys[provider.envKeyName];
   if (!apiKey) {
+    // Providers that opt into anonymous auth (today: opencode-zen for
+    // the free model pool) resolve with apiKey: '' instead of bailing.
+    // The provider's buildRequest is responsible for omitting the
+    // Authorization header when the key is empty.
+    if (provider.optionalAuth) {
+      return { provider, model: resolvedModel, endpoint, apiKey: '', fallback: null };
+    }
     // Only warn when a provider was EXPLICITLY chosen (any tier set it).
     // If no provider was set and we defaulted to cerebras, the user simply
     // hasn't configured any LLM yet — that's "OpenCues without LLM is

--- a/packages/opencues-core/src/opencode-zen.test.ts
+++ b/packages/opencues-core/src/opencode-zen.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Pin `dispatchWithFreePool` — the pool-walking dispatcher used by
+ * `blank-llm-provider: free` mode. The pool is OPENCODE_ZEN_FREE_POOL
+ * (5 free model ids); the dispatcher walks it on transient failure,
+ * health-caches dead entries for 30s, and bubbles sticky failures
+ * (auth/quota) immediately.
+ *
+ * These tests pin the contract every blank-class source depends on
+ * when the user is in free mode. Drift breaks the free pool silently
+ * — a source either calls a dead model and gets nothing, or it bubbles
+ * a quota error that should have surfaced via ProviderHealth.
+ *
+ * Run via: vitest run src/opencode-zen.test.ts  (or `npm run test`)
+ */
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import {
+  dispatchWithFreePool,
+  _resetOpencodeZenHealthForTesting,
+  getOpencodeZenHealth,
+  OPENCODE_ZEN_FREE_POOL,
+  type HttpAdapterShape,
+  type ChatRequest,
+} from './llm-provider';
+
+function makeReq(overrides: Partial<ChatRequest> = {}): ChatRequest {
+  return {
+    model: 'big-pickle',
+    messages: [{ role: 'user', content: 'hi' }],
+    ...overrides,
+  };
+}
+
+function makeAdapter(seq: Array<{ status?: number; body: string } | Error>): HttpAdapterShape & { calls: Array<{ url: string; body: string }> } {
+  const calls: Array<{ url: string; body: string }> = [];
+  let i = 0;
+  return {
+    calls,
+    post: async (url, body) => {
+      calls.push({ url, body });
+      const step = seq[i++];
+      if (step === undefined) throw new Error(`adapter ran out of scripted responses (call ${i})`);
+      if (step instanceof Error) throw step;
+      // Simulate the OpenAI-shape parseResponse layer: errors in body bubble as throws.
+      const data = JSON.parse(step.body);
+      if (data.error || data.code) {
+        throw new Error(`provider error: ${data.error?.message ?? data.message ?? 'unknown'} (code=${data.code ?? '?'})`);
+      }
+      return step.body;
+    },
+  };
+}
+
+describe('dispatchWithFreePool — pool walking', () => {
+  it('returns first-model success without walking', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const adapter = makeAdapter([
+      { body: JSON.stringify({ choices: [{ message: { content: 'ok' } }] }) },
+    ]);
+    const result = await dispatchWithFreePool(adapter, makeReq(), { apiKey: '' });
+    assert.strictEqual(result, 'ok');
+    assert.strictEqual(adapter.calls.length, 1);
+    const sentBody = JSON.parse(adapter.calls[0].body) as { model: string };
+    assert.strictEqual(sentBody.model, OPENCODE_ZEN_FREE_POOL[0]);
+  });
+
+  it('skips a model that 429s and succeeds on the next', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const adapter = makeAdapter([
+      new Error('429 too many requests'),
+      { body: JSON.stringify({ choices: [{ message: { content: 'rescued' } }] }) },
+    ]);
+    const result = await dispatchWithFreePool(adapter, makeReq(), { apiKey: '' });
+    assert.strictEqual(result, 'rescued');
+    assert.strictEqual(adapter.calls.length, 2);
+    const secondBody = JSON.parse(adapter.calls[1].body) as { model: string };
+    assert.strictEqual(secondBody.model, OPENCODE_ZEN_FREE_POOL[1]);
+  });
+
+  it('walks past TWO dead models and succeeds on the third', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const adapter = makeAdapter([
+      new Error('server error 503'),
+      new Error('overloaded'),
+      { body: JSON.stringify({ choices: [{ message: { content: 'third time' } }] }) },
+    ]);
+    const result = await dispatchWithFreePool(adapter, makeReq(), { apiKey: '' });
+    assert.strictEqual(result, 'third time');
+    assert.strictEqual(adapter.calls.length, 3);
+  });
+
+  it('treats empty response as a transient failure and walks', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const adapter = makeAdapter([
+      { body: JSON.stringify({ choices: [{ message: { content: '' } }] }) },
+      { body: JSON.stringify({ choices: [{ message: { content: 'now we got it' } }] }) },
+    ]);
+    const result = await dispatchWithFreePool(adapter, makeReq(), { apiKey: '' });
+    assert.strictEqual(result, 'now we got it');
+    assert.strictEqual(adapter.calls.length, 2);
+  });
+
+  it('bubbles 401 immediately (auth = sticky, no other model would help)', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const adapter = makeAdapter([
+      new Error('unauthorized: invalid_api_key'),
+    ]);
+    await assert.rejects(
+      () => dispatchWithFreePool(adapter, makeReq(), { apiKey: 'bad' }),
+      /unauthorized/i,
+    );
+    assert.strictEqual(adapter.calls.length, 1, 'should NOT walk pool on auth failure');
+  });
+
+  it('bubbles 402 / payment_required immediately (quota = sticky)', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const adapter = makeAdapter([
+      new Error('payment_required: out of credit'),
+    ]);
+    await assert.rejects(
+      () => dispatchWithFreePool(adapter, makeReq(), { apiKey: '' }),
+      /payment_required|credit/i,
+    );
+    assert.strictEqual(adapter.calls.length, 1);
+  });
+
+  it('throws synthesized pool-exhausted error when every model fails transiently', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const pool = ['a', 'b', 'c'];
+    const adapter = makeAdapter([
+      new Error('overloaded'),
+      new Error('overloaded'),
+      new Error('overloaded'),
+    ]);
+    await assert.rejects(
+      () => dispatchWithFreePool(adapter, makeReq(), { apiKey: '' }, { pool }),
+      /pool exhausted/i,
+    );
+    assert.strictEqual(adapter.calls.length, 3);
+  });
+
+  it('skips models in health cool-down', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const pool = ['m1', 'm2', 'm3'];
+    const now = (() => {
+      let t = 1_000;
+      return () => t;
+    })();
+    // First call: m1 fails. m1 cooled down. m2 succeeds.
+    const adapter1 = makeAdapter([
+      new Error('overloaded'),
+      { body: JSON.stringify({ choices: [{ message: { content: 'first' } }] }) },
+    ]);
+    const r1 = await dispatchWithFreePool(adapter1, makeReq(), { apiKey: '' }, { pool, now, cooldownMs: 30_000 });
+    assert.strictEqual(r1, 'first');
+    // Health cache should now contain m1.
+    const health = getOpencodeZenHealth(now);
+    assert.ok(health.some(h => h.model === 'm1'), 'm1 should be in cool-down');
+
+    // Second call shortly after: m1 should be SKIPPED, request goes to m2 directly.
+    const adapter2 = makeAdapter([
+      { body: JSON.stringify({ choices: [{ message: { content: 'second' } }] }) },
+    ]);
+    const r2 = await dispatchWithFreePool(adapter2, makeReq(), { apiKey: '' }, { pool, now, cooldownMs: 30_000 });
+    assert.strictEqual(r2, 'second');
+    const sentBody = JSON.parse(adapter2.calls[0].body) as { model: string };
+    assert.strictEqual(sentBody.model, 'm2', 'should have skipped m1 and gone to m2');
+  });
+
+  it('health cool-down expires after cooldownMs', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const pool = ['m1', 'm2'];
+    let t = 1_000;
+    const now = () => t;
+    const adapter = makeAdapter([
+      new Error('overloaded'),
+      { body: JSON.stringify({ choices: [{ message: { content: 'a' } }] }) },
+    ]);
+    await dispatchWithFreePool(adapter, makeReq(), { apiKey: '' }, { pool, now, cooldownMs: 5_000 });
+    assert.ok(getOpencodeZenHealth(now).some(h => h.model === 'm1'));
+    t += 6_000;
+    // After expiry, getOpencodeZenHealth returns empty (filters expired entries).
+    assert.strictEqual(getOpencodeZenHealth(now).length, 0);
+  });
+
+  it('onFailure callback fires once per failed attempt', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const failures: Array<{ model: string; cause?: unknown }> = [];
+    const adapter = makeAdapter([
+      new Error('overloaded'),
+      new Error('overloaded'),
+      { body: JSON.stringify({ choices: [{ message: { content: 'k' } }] }) },
+    ]);
+    await dispatchWithFreePool(adapter, makeReq(), { apiKey: '' }, {
+      onFailure: info => failures.push({ model: info.model, cause: info.cause }),
+    });
+    assert.strictEqual(failures.length, 2);
+    assert.strictEqual(failures[0].model, OPENCODE_ZEN_FREE_POOL[0]);
+    assert.strictEqual(failures[1].model, OPENCODE_ZEN_FREE_POOL[1]);
+  });
+
+  it('marks a previously-failed model healthy on success (deletes from cache)', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const pool = ['m1', 'm2'];
+    let t = 1_000;
+    const now = () => t;
+    // First call: m1 fails, m2 wins.
+    const a1 = makeAdapter([
+      new Error('overloaded'),
+      { body: JSON.stringify({ choices: [{ message: { content: 'a' } }] }) },
+    ]);
+    await dispatchWithFreePool(a1, makeReq(), { apiKey: '' }, { pool, now, cooldownMs: 30_000 });
+    assert.ok(getOpencodeZenHealth(now).some(h => h.model === 'm1'));
+
+    // Wait past cool-down then a successful m1 call should clear its cache entry.
+    t += 31_000;
+    const a2 = makeAdapter([
+      { body: JSON.stringify({ choices: [{ message: { content: 'b' } }] }) },
+    ]);
+    await dispatchWithFreePool(a2, makeReq(), { apiKey: '' }, { pool, now, cooldownMs: 30_000 });
+    assert.strictEqual(getOpencodeZenHealth(now).length, 0);
+  });
+});
+
+describe('OPENCODE_ZEN provider adapter shape', () => {
+  it('omits Authorization header when apiKey is empty (anonymous free-mode)', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const captured: Array<Record<string, string>> = [];
+    const adapter: HttpAdapterShape = {
+      post: async (_url, _body, headers) => {
+        captured.push(headers);
+        return JSON.stringify({ choices: [{ message: { content: 'ok' } }] });
+      },
+    };
+    await dispatchWithFreePool(adapter, makeReq(), { apiKey: '' });
+    assert.strictEqual(captured.length, 1);
+    assert.strictEqual(captured[0].Authorization, undefined, 'should NOT send Authorization on empty key');
+    assert.strictEqual(captured[0]['Content-Type'], 'application/json');
+  });
+
+  it('sends Authorization: Bearer when apiKey is set', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const captured: Array<Record<string, string>> = [];
+    const adapter: HttpAdapterShape = {
+      post: async (_url, _body, headers) => {
+        captured.push(headers);
+        return JSON.stringify({ choices: [{ message: { content: 'ok' } }] });
+      },
+    };
+    await dispatchWithFreePool(adapter, makeReq(), { apiKey: 'sk-zen-xxx' });
+    assert.strictEqual(captured[0].Authorization, 'Bearer sk-zen-xxx');
+  });
+
+  it('targets the canonical zen endpoint', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const urls: string[] = [];
+    const adapter: HttpAdapterShape = {
+      post: async (url) => {
+        urls.push(url);
+        return JSON.stringify({ choices: [{ message: { content: 'ok' } }] });
+      },
+    };
+    await dispatchWithFreePool(adapter, makeReq(), { apiKey: '' });
+    assert.strictEqual(urls[0], 'https://opencode.ai/zen/v1/chat/completions');
+  });
+
+  it('uses bare model ids (not opencode/ prefix — verified May 2026 against live endpoint)', async () => {
+    _resetOpencodeZenHealthForTesting();
+    const bodies: string[] = [];
+    const adapter: HttpAdapterShape = {
+      post: async (_url, body) => {
+        bodies.push(body);
+        return JSON.stringify({ choices: [{ message: { content: 'ok' } }] });
+      },
+    };
+    await dispatchWithFreePool(adapter, makeReq(), { apiKey: '' });
+    const sent = JSON.parse(bodies[0]) as { model: string };
+    assert.ok(!sent.model.includes('/'), `model id should not contain slash; got ${sent.model}`);
+  });
+});

--- a/packages/opencues-core/src/sources/build-sources.ts
+++ b/packages/opencues-core/src/sources/build-sources.ts
@@ -27,7 +27,7 @@ import { FluidBlankSource, type FluidBlankSourceConfig } from './fluid-blank-sou
 import { TransformBlankSource, type TransformBlankSourceConfig } from './transform-blank-source';
 import { ConfigIntentSource, type ConfigIntentSourceConfig } from './config-intent-source';
 import { SentenceCueSource, type SentenceCueSourceConfig } from './sentence-cue-source';
-import { resolveLLM, getProvider, withFallback, type ResolvedLLM } from '../llm-provider';
+import { resolveLLM, getProvider, withFallback, withFreePool, type ResolvedLLM } from '../llm-provider';
 
 /**
  * Per-feature provider/model/endpoint trio. Each LLM-driven source
@@ -76,6 +76,28 @@ export interface BuildSourcesOptions {
   globalProvider?: string;
   globalModel?: string;
   globalEndpoint?: string;
+  /**
+   * Provider routing for BLANK-CLASS sources only (FluidBlank /
+   * TransformBlank / ConfigIntent / keyword BlankSource). Sits BETWEEN
+   * per-feature and global in the precedence chain — overrides
+   * `globalProvider` for blank-class sources only. Cue-class sources
+   * (ConfigSource word-cues, SentenceCueSource) ignore it entirely.
+   *
+   * Set from OPENCUES.md `blank-llm-provider:`. The runtime translates
+   * the special value `'free'` → `'opencode-zen'` before passing here;
+   * other ProviderId values flow through verbatim. `'inherit'` (the
+   * default) collapses to undefined — falls through to globalProvider.
+   *
+   * The structural rule: NEVER let cue-class sources resolve to
+   * `opencode-zen` via this path — OpenCode Zen's free-tier ToS says
+   * inputs may be used for training, and cues run automatically on
+   * user prose (not opt-in like blanks). The build-sources factory
+   * enforces this by reading blankGlobalProvider only at blank-class
+   * call sites.
+   */
+  blankGlobalProvider?: string;
+  blankGlobalModel?: string;
+  blankGlobalEndpoint?: string;
   /** Per-feature defaults read from OPENCUES.md root frontmatter. */
   wordCues?: FeatureLLMSetting;
   fluidBlank?: FeatureLLMSetting;
@@ -266,6 +288,13 @@ export function buildSourcesFromConfig(
   const apiKeys = options.apiKeys ?? {};
   const globalProvider = options.globalProvider;
   const globalModel = options.globalModel;
+  // blank-class override tier. `inherit` from the scalar has already
+  // been collapsed to undefined by the runtime; only concrete values
+  // (or 'free' pre-translation) reach us. Defensive: empty/inherit are
+  // treated as undefined here too.
+  const rawBlankProvider = options.blankGlobalProvider?.toLowerCase();
+  const blankGlobalProvider = (!rawBlankProvider || rawBlankProvider === 'inherit') ? undefined : rawBlankProvider;
+  const blankGlobalModel = options.blankGlobalModel;
   // Universal-Integration profile: when the host can't cycle (chrome's
   // normal `<input>` / `<textarea>` branch), drop everything that
   // presents alternatives the user picks between. Default true keeps
@@ -278,18 +307,48 @@ export function buildSourcesFromConfig(
    * Resolve the provider/model/endpoint/key tuple for one source given
    * its per-source override (frontmatter) and a per-feature default.
    * Returns null when no api key is available — caller skips the source.
+   *
+   * `isBlankClass: true` opts the source into the blank-class provider
+   * override tier (blankGlobalProvider) when set. Cue-class sources
+   * MUST pass false (or omit) so they never accidentally route through
+   * the free pool — see BuildSourcesOptions.blankGlobalProvider for the
+   * trust-boundary rationale.
    */
-  function resolveFor(featureSetting: FeatureLLMSetting | undefined, perSource?: SourceConfig): ResolvedLLM | null {
+  function resolveFor(featureSetting: FeatureLLMSetting | undefined, perSource?: SourceConfig, isBlankClass?: boolean): ResolvedLLM | null {
+    // When the blank-class provider override fires, the global `llm-model`
+    // would otherwise leak into resolveLLM as the model for the
+    // overridden provider — e.g. `blank-llm-provider: free` +
+    // `llm-model: gpt-oss-120b` would try to ask opencode-zen for a
+    // model that doesn't exist there. If the user hasn't set a
+    // matching `blank-llm-model`, pass undefined so resolveLLM picks
+    // the provider's defaultModel (big-pickle for opencode-zen).
+    const useBlankOverride = isBlankClass && !!blankGlobalProvider;
+    const effectiveGlobalProvider = useBlankOverride ? blankGlobalProvider : globalProvider;
+    const effectiveGlobalModel = useBlankOverride
+      ? (blankGlobalModel ?? undefined)
+      : globalModel;
     return resolveLLM({
       providerOverride: perSource?.provider,
       modelOverride: perSource?.model,
       endpointOverride: perSource?.endpoint,
       featureProvider: featureSetting?.provider,
       featureModel: featureSetting?.model,
-      globalProvider,
-      globalModel,
+      globalProvider: effectiveGlobalProvider,
+      globalModel: effectiveGlobalModel,
       apiKeys,
     });
+  }
+
+  /**
+   * Pick the right HTTP-adapter wrapper for a resolved blank-class
+   * source. When the resolved provider is `opencode-zen`, we wrap with
+   * `withFreePool` so transient failures walk the free-pool model list
+   * (and sticky auth/quota errors bubble up for ProviderHealth). Other
+   * providers get the standard `withFallback` (groq↔cerebras).
+   */
+  function wrapAdapterForBlank(resolved: ResolvedLLM) {
+    if (resolved.provider.id === 'opencode-zen') return withFreePool(options.httpAdapter);
+    return withFallback(options.httpAdapter, resolved.fallback);
   }
 
   function fallbackForLog(label: string, providerName: string): void {
@@ -443,14 +502,14 @@ export function buildSourcesFromConfig(
   // the slot. See config-intent-source.ts for the bench-validated
   // prompt + trust boundary.
   if (options.enableConfigIntent) {
-    const resolved = resolveFor(options.configIntent);
+    const resolved = resolveFor(options.configIntent, undefined, true);
     if (!resolved) {
-      fallbackForLog('config-intent', options.configIntent?.provider || globalProvider || 'groq');
+      fallbackForLog('config-intent', options.configIntent?.provider || blankGlobalProvider || globalProvider || 'groq');
     } else if (!options.applyOpencuesScalar) {
       options.log?.('buildSources: skipping config-intent — no applyOpencuesScalar callback provided');
     } else {
       sources.push(new ConfigIntentSource({
-        httpAdapter: withFallback(options.httpAdapter, resolved.fallback),
+        httpAdapter: wrapAdapterForBlank(resolved),
         provider: resolved.provider,
         endpoint: resolved.endpoint,
         apiKey: resolved.apiKey,
@@ -469,12 +528,12 @@ export function buildSourcesFromConfig(
   // Cedes to keyword-bound BlankSource when a registered blank would
   // claim the slot (keyword within blankProximity of the `_`).
   if (options.enableFluidBlank) {
-    const resolved = resolveFor(options.fluidBlank);
+    const resolved = resolveFor(options.fluidBlank, undefined, true);
     if (!resolved) {
-      fallbackForLog('fluid-blank', options.fluidBlank?.provider || globalProvider || 'groq');
+      fallbackForLog('fluid-blank', options.fluidBlank?.provider || blankGlobalProvider || globalProvider || 'groq');
     } else {
       sources.push(new FluidBlankSource({
-        httpAdapter: withFallback(options.httpAdapter, resolved.fallback),
+        httpAdapter: wrapAdapterForBlank(resolved),
         provider: resolved.provider,
         endpoint: resolved.endpoint,
         apiKey: resolved.apiKey,
@@ -496,12 +555,12 @@ export function buildSourcesFromConfig(
   // BlankSource if applicable AND only claims when the surrounding text
   // starts with an imperative verb (heuristic in supports()).
   if (options.enableTransformBlank) {
-    const resolved = resolveFor(options.transformBlank);
+    const resolved = resolveFor(options.transformBlank, undefined, true);
     if (!resolved) {
-      fallbackForLog('transform-blank', options.transformBlank?.provider || globalProvider || 'groq');
+      fallbackForLog('transform-blank', options.transformBlank?.provider || blankGlobalProvider || globalProvider || 'groq');
     } else {
       sources.push(new TransformBlankSource({
-        httpAdapter: withFallback(options.httpAdapter, resolved.fallback),
+        httpAdapter: wrapAdapterForBlank(resolved),
         provider: resolved.provider,
         endpoint: resolved.endpoint,
         apiKey: resolved.apiKey,

--- a/packages/opencues-runtime/src/modules/config-loader.ts
+++ b/packages/opencues-runtime/src/modules/config-loader.ts
@@ -137,6 +137,20 @@ export interface OpenCuesState {
    *   space) for users who DO want to trigger a blank.
    */
   readonly blankTriggerMode: 'immediate' | 'spaced';
+  /**
+   * Separate provider for blank-class sources (FluidBlank / TransformBlank
+   * / ConfigIntent / keyword blanks). `inherit` (default) reuses
+   * `llm-provider`. `free` routes blanks through OpenCode Zen's free
+   * pool — no API key, but providers train on data. Cues + auditors
+   * are unaffected.
+   *
+   * Stored as the raw scalar string (not a typed union) because the set
+   * of valid provider ids is owned by `@opencues/core`'s ProviderId
+   * union — pinning the union here would force config-loader to import
+   * that and create a circular structural dependency. Resolver maps
+   * 'free' → 'opencode-zen' at dispatch time.
+   */
+  readonly blankLlmProvider: string;
   /** Raw key→value of every top-level scalar in the frontmatter. */
   readonly settings: ReadonlyMap<string, string>;
   /**
@@ -160,6 +174,7 @@ export const DEFAULT_OPENCUES_STATE: OpenCuesState = {
   ambientContextMode: 'off',
   userContextMode: 'off',
   blankTriggerMode: 'immediate',
+  blankLlmProvider: 'inherit',
   settings: new Map(),
   definitions: new Map(),
 };
@@ -198,6 +213,18 @@ export function parseOpenCuesMd(content: string): OpenCuesState {
     : 'off';
   const blankTriggerMode: 'immediate' | 'spaced' =
     get('blank-trigger-mode', 'immediate').toLowerCase() === 'spaced' ? 'spaced' : 'immediate';
+  // blank-llm-provider — `inherit` (default), `free` (opencode-zen
+  // pool), or any concrete provider id. Stored raw; resolver translates
+  // `free` → `opencode-zen` at dispatch time. Unknown values fall back
+  // to `inherit` rather than silently picking an invalid provider —
+  // protects users from typos that would otherwise silently disable all
+  // blanks.
+  const blankProviderRaw = get('blank-llm-provider', 'inherit').toLowerCase();
+  const VALID_BLANK_PROVIDERS = new Set([
+    'inherit', 'free',
+    'groq', 'openrouter', 'gemini', 'openai', 'anthropic', 'cerebras', 'claude-cli', 'opencode-zen',
+  ]);
+  const blankLlmProvider = VALID_BLANK_PROVIDERS.has(blankProviderRaw) ? blankProviderRaw : 'inherit';
   // Menu definitions: registry-derived by default, with optional
   // file-level overrides. The @opencues/core FEATURES + MENU_TUNABLES
   // registry is the single source of truth; defaults/OPENCUES.md ships
@@ -210,7 +237,7 @@ export function parseOpenCuesMd(content: string): OpenCuesState {
   // Tests keep shipping mock `settings:` blocks; they get the
   // file-driven definitions, identical to the pre-refactor behaviour.
   const definitions = mergeDefinitions(getMenuDefinitions(), parseSettingsBlock(lines));
-  return { voiceMode, debugMode, tipsMode, cursorNavigate, ambientContextMode, userContextMode, blankTriggerMode, settings, definitions };
+  return { voiceMode, debugMode, tipsMode, cursorNavigate, ambientContextMode, userContextMode, blankTriggerMode, blankLlmProvider, settings, definitions };
 }
 
 /**
@@ -491,6 +518,11 @@ export class ConfigLoader {
         return v === 'safe' ? 'safe' : v === 'raw' ? 'raw' : 'off';
       })(),
       blankTriggerMode: (get('blank-trigger-mode', 'immediate').toLowerCase() === 'spaced' ? 'spaced' : 'immediate') as 'immediate' | 'spaced',
+      blankLlmProvider: ((): string => {
+        const v = get('blank-llm-provider', 'inherit').toLowerCase();
+        const VALID = new Set(['inherit', 'free', 'groq', 'openrouter', 'gemini', 'openai', 'anthropic', 'cerebras', 'claude-cli', 'opencode-zen']);
+        return VALID.has(v) ? v : 'inherit';
+      })(),
       settings: newSettings as ReadonlyMap<string, string>,
       definitions: cur.definitions,
     };

--- a/packages/opencues-runtime/src/modules/provider-health.scenarios.test.ts
+++ b/packages/opencues-runtime/src/modules/provider-health.scenarios.test.ts
@@ -1,0 +1,239 @@
+// End-to-end failure-state scenarios — the user-visible path that
+// proves the ProviderHealth → Statusline wiring + the free-pool walker
+// surface real LLM failures instead of silently no-op'ing.
+//
+// Why this file (and not unit tests in each module): the May 2026
+// agentic-harness incident found a Cerebras account that had been out
+// of credits for weeks while every cue source silently returned
+// nothing — the unit tests on each individual source PASSED, but the
+// user journey ("blank fires → fails → user sees nothing") was never
+// exercised end-to-end. These scenarios pin THAT journey.
+
+import { describe, it, expect } from 'vitest';
+import { Statusline, type StatuslinePayload } from './statusline';
+import { ProviderHealth, classifyProviderError } from './provider-health';
+import { HighlightState } from '../state/highlight-state';
+import { DynDefs } from '../state/dyn-defs';
+import { MockAdapter } from '../../testing/mock-adapter';
+
+function setup(opts: { transientTtlMs?: number } = {}) {
+  const adapter = new MockAdapter();
+  adapter.pushText('hello world');
+  const hlState = new HighlightState();
+  const dynDefs = new DynDefs();
+  const ph = new ProviderHealth({ transientTtlMs: opts.transientTtlMs ?? 5_000 });
+  const statusline = new Statusline(
+    adapter,
+    hlState,
+    dynDefs,
+    { exportPath: '/tmp/test-status.json' },
+    undefined, undefined, undefined, undefined,
+    ph,
+  );
+  statusline.subscribe();
+  return { adapter, hlState, dynDefs, statusline, ph };
+}
+
+// MockAdapter.writeFile resolves synchronously after a microtask boundary
+// (it's `async fn() { map.set(...) }`). One `await Promise.resolve()` is
+// enough to drain its `.then(...)` handler — using setImmediate would
+// hang under fake timers, and we avoid fake timers here so failures don't
+// leak between scenarios.
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function latestSnapshot(adapter: MockAdapter): StatuslinePayload | undefined {
+  const snaps = adapter.events.filter(e => e.type === 'statusline.snapshot');
+  return snaps[snaps.length - 1]?.body as StatuslinePayload | undefined;
+}
+
+describe('ProviderHealth + Statusline — end-to-end failure surface', () => {
+  it('SCENARIO: free-pool 401 → sticky auth error → statusline payload carries it', async () => {
+    const { adapter, hlState, statusline, ph } = setup();
+
+    // 1. Healthy starting state — no error in payload.
+    hlState.activate(0, 'hello world');
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    expect(latestSnapshot(adapter)?.providerError).toBeNull();
+
+    // 2. Simulate a free-pool dispatch failing with 401 (bad API key
+    //    on a paid model). dispatchWithFreePool/withFreePool would have
+    //    bubbled this Error; the source's catch block routes it via
+    //    classifyProviderError → ph.report.
+    ph.reportFrom({
+      status: 401,
+      body: '{"error":"invalid_api_key"}',
+      provider: 'opencode-zen',
+      model: 'big-pickle',
+    });
+
+    // 3. Force a re-render — host's forceRender → onRender → maybeWrite.
+    adapter.forceRender?.();
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+
+    const snap = latestSnapshot(adapter);
+    expect(snap?.providerError).toBeTruthy();
+    expect(snap?.providerError?.kind).toBe('auth');
+    expect(snap?.providerError?.sticky).toBe(true);
+    expect(snap?.providerError?.provider).toBe('opencode-zen');
+    expect(snap?.providerError?.message).toMatch(/bad.*key/i);
+  });
+
+  it('SCENARIO: out-of-credits (402) classifies as quota — surfaces to statusline', async () => {
+    const { adapter, hlState, statusline, ph } = setup();
+    hlState.activate(0, 'hello world');
+
+    // Cerebras-shaped 402 response (the exact bug from the May 2026
+    // incident): root-level message+code instead of nested error envelope.
+    ph.reportFrom({
+      status: 402,
+      body: '{"message":"Payment required.","code":"payment_required","type":"payment_required_error"}',
+      provider: 'cerebras',
+    });
+
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    const snap = latestSnapshot(adapter);
+    expect(snap?.providerError?.kind).toBe('quota');
+    expect(snap?.providerError?.sticky).toBe(true);
+  });
+
+  it('SCENARIO: rate-limit auto-clears after TTL — user sees error briefly, then it goes away', async () => {
+    // 50ms real TTL — bus's setTimeout cleanly resolves; no fake timers
+    // (those tangle with the writeFile microtask flushing in this file).
+    const { adapter, hlState, statusline, ph } = setup({ transientTtlMs: 50 });
+    hlState.activate(0, 'hello world');
+
+    ph.reportFrom({ status: 429, body: 'too many requests', provider: 'groq' });
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    expect(latestSnapshot(adapter)?.providerError?.kind).toBe('rate-limit');
+    expect(latestSnapshot(adapter)?.providerError?.sticky).toBe(false);
+
+    // Wait past the TTL — bus clears itself.
+    await new Promise(r => setTimeout(r, 100));
+    expect(ph.current()).toBeNull();
+    // Re-render so the now-null state mirrors into the payload.
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    expect(latestSnapshot(adapter)?.providerError).toBeNull();
+  });
+
+  it('SCENARIO: user fixes the API key → ph.clear() → next render shows no error', async () => {
+    const { adapter, hlState, statusline, ph } = setup();
+    hlState.activate(0, 'hello world');
+
+    ph.reportFrom({ status: 401, provider: 'opencode-zen' });
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    expect(latestSnapshot(adapter)?.providerError?.kind).toBe('auth');
+
+    // User edits OPENCUES.md with a fresh key → caller clears the bus.
+    ph.clear();
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    expect(latestSnapshot(adapter)?.providerError).toBeNull();
+  });
+
+  it('SCENARIO: model-missing (404) — sticky, carries model name in message', async () => {
+    const { adapter, hlState, statusline, ph } = setup();
+    hlState.activate(0, 'hello world');
+
+    ph.reportFrom({
+      status: 404,
+      body: 'Model big-pickle not found',
+      provider: 'opencode-zen',
+      model: 'big-pickle',
+    });
+
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    const snap = latestSnapshot(adapter);
+    expect(snap?.providerError?.kind).toBe('model-missing');
+    expect(snap?.providerError?.sticky).toBe(true);
+    expect(snap?.providerError?.message).toContain('big-pickle');
+  });
+
+  it('SCENARIO: a successful call after a failure can clear the error explicitly', async () => {
+    const { adapter, hlState, statusline, ph } = setup();
+    hlState.activate(0, 'hello world');
+
+    ph.reportFrom({ status: 503, provider: 'groq' });
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    expect(latestSnapshot(adapter)?.providerError?.kind).toBe('outage');
+
+    // Source resolves a request successfully → caller can opt to clear.
+    ph.clear();
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    expect(latestSnapshot(adapter)?.providerError).toBeNull();
+  });
+
+  it('PROPERTY: statusline payload omits providerError when no health bus wired', async () => {
+    const adapter = new MockAdapter();
+    adapter.pushText('hello');
+    const hlState = new HighlightState();
+    const dynDefs = new DynDefs();
+    // No ProviderHealth passed.
+    const statusline = new Statusline(adapter, hlState, dynDefs, { exportPath: '/tmp/x.json' });
+    statusline.subscribe();
+    hlState.activate(0, 'hello');
+    statusline.maybeWrite({ text: 'hello', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+    // Field is absent (not null) when no bus is wired — back-compat for
+    // existing hosts that haven't added the ProviderHealth surface yet.
+    expect('providerError' in (latestSnapshot(adapter) ?? {})).toBe(false);
+  });
+
+  it('PROPERTY: errors during one render do not break subsequent renders', async () => {
+    const { adapter, hlState, statusline, ph } = setup();
+    hlState.activate(0, 'hello world');
+
+    // First failure.
+    ph.reportFrom({ status: 401, provider: 'groq' });
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+
+    // Second, different failure of the same kind (overwrites).
+    ph.reportFrom({ status: 403, provider: 'openai' });
+    statusline.maybeWrite({ text: 'hello world', cursor: 0, externalHighlights: [] });
+    await flushMicrotasks();
+
+    const snap = latestSnapshot(adapter);
+    expect(snap?.providerError?.provider).toBe('openai');
+    expect(snap?.providerError?.message).toMatch(/forbidden/i);
+  });
+});
+
+describe('classifyProviderError ↔ free-pool walker integration', () => {
+  it('PROPERTY: walker onFailure callback can feed straight into ProviderHealth.reportFrom', () => {
+    const ph = new ProviderHealth();
+    // Simulate the shape the withFreePool / dispatchWithFreePool walker
+    // emits via its `onFailure` callback. The integration contract is
+    // that classifyProviderError accepts that shape directly.
+    const ev = classifyProviderError({
+      cause: new Error('overloaded: server_error'),
+      provider: 'opencode-zen',
+      model: 'big-pickle',
+    });
+    expect(ev?.kind).toBe('outage');
+    if (ev) ph.report(ev);
+    expect(ph.current()?.kind).toBe('outage');
+    expect(ph.current()?.model).toBe('big-pickle');
+  });
+
+  it('PROPERTY: auth failure from walker bubbles via reportFrom as sticky', () => {
+    const ph = new ProviderHealth();
+    ph.reportFrom({
+      cause: new Error('unauthorized: invalid_api_key'),
+      provider: 'opencode-zen',
+    });
+    expect(ph.current()?.kind).toBe('auth');
+    expect(ph.current()?.sticky).toBe(true);
+  });
+});

--- a/packages/opencues-runtime/src/modules/provider-health.test.ts
+++ b/packages/opencues-runtime/src/modules/provider-health.test.ts
@@ -1,0 +1,254 @@
+// Failure-state UX taxonomy + bus behaviour.
+//
+// These tests pin the contract the status line + every provider error
+// path depends on. Drift in classification is silently visible to the
+// user (wrong error wording, sticky events that should auto-clear, or
+// vice versa) — keep the matrix exhaustive.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  classifyProviderError,
+  ProviderHealth,
+  type ProviderHealthEvent,
+} from './provider-health';
+
+describe('classifyProviderError', () => {
+  describe('happy path', () => {
+    it('returns null on 200 with no body', () => {
+      expect(classifyProviderError({ status: 200 })).toBeNull();
+    });
+    it('returns null on empty input', () => {
+      expect(classifyProviderError({})).toBeNull();
+    });
+  });
+
+  describe('auth — sticky', () => {
+    it('classifies HTTP 401 as auth/sticky', () => {
+      const ev = classifyProviderError({ status: 401, body: '{"error":"unauthorized"}', provider: 'groq' });
+      expect(ev?.kind).toBe('auth');
+      expect(ev?.sticky).toBe(true);
+      expect(ev?.provider).toBe('groq');
+    });
+    it('classifies HTTP 403 as auth/sticky with different message', () => {
+      const ev = classifyProviderError({ status: 403 });
+      expect(ev?.kind).toBe('auth');
+      expect(ev?.sticky).toBe(true);
+      expect(ev?.message).toMatch(/forbidden/i);
+    });
+    it('classifies "invalid api key" in cause as auth (no status)', () => {
+      const ev = classifyProviderError({ cause: new Error('invalid_api_key') });
+      expect(ev?.kind).toBe('auth');
+      expect(ev?.sticky).toBe(true);
+    });
+    it('classifies "authentication failed" body without status as auth', () => {
+      const ev = classifyProviderError({ body: 'authentication failed' });
+      expect(ev?.kind).toBe('auth');
+    });
+  });
+
+  describe('quota — sticky, wins over rate-limit', () => {
+    it('classifies HTTP 402 as quota/sticky', () => {
+      const ev = classifyProviderError({ status: 402 });
+      expect(ev?.kind).toBe('quota');
+      expect(ev?.sticky).toBe(true);
+    });
+    it('classifies "insufficient_quota" body as quota even on 429', () => {
+      const ev = classifyProviderError({ status: 429, body: '{"code":"insufficient_quota"}' });
+      expect(ev?.kind).toBe('quota');
+      expect(ev?.sticky).toBe(true);
+    });
+    it('classifies "out of credit" body as quota', () => {
+      const ev = classifyProviderError({ body: 'You are out of credit. Add billing to continue.' });
+      expect(ev?.kind).toBe('quota');
+    });
+    it('classifies "payment_required" body as quota', () => {
+      const ev = classifyProviderError({ body: '{"error":"payment_required"}' });
+      expect(ev?.kind).toBe('quota');
+    });
+  });
+
+  describe('rate-limit — transient, not sticky', () => {
+    it('classifies HTTP 429 (plain) as rate-limit/non-sticky', () => {
+      const ev = classifyProviderError({ status: 429, body: 'Too many requests' });
+      expect(ev?.kind).toBe('rate-limit');
+      expect(ev?.sticky).toBe(false);
+    });
+    it('classifies "rate_limit" body alone as rate-limit', () => {
+      const ev = classifyProviderError({ body: '{"error":{"code":"rate_limit_exceeded"}}' });
+      expect(ev?.kind).toBe('rate-limit');
+    });
+  });
+
+  describe('outage — transient, not sticky', () => {
+    it('classifies 500 as outage', () => {
+      const ev = classifyProviderError({ status: 500 });
+      expect(ev?.kind).toBe('outage');
+      expect(ev?.sticky).toBe(false);
+      expect(ev?.message).toContain('500');
+    });
+    it('classifies 503 as outage', () => {
+      const ev = classifyProviderError({ status: 503 });
+      expect(ev?.kind).toBe('outage');
+    });
+    it('classifies ECONNREFUSED as outage (network)', () => {
+      const ev = classifyProviderError({ cause: new Error('connect ECONNREFUSED 127.0.0.1:443') });
+      expect(ev?.kind).toBe('outage');
+      expect(ev?.message).toMatch(/network/);
+    });
+    it('classifies ENOTFOUND as outage', () => {
+      const ev = classifyProviderError({ cause: new Error('getaddrinfo ENOTFOUND api.groq.com') });
+      expect(ev?.kind).toBe('outage');
+    });
+    it('classifies "service unavailable" body as outage', () => {
+      const ev = classifyProviderError({ body: 'Service Unavailable' });
+      expect(ev?.kind).toBe('outage');
+    });
+  });
+
+  describe('model-missing — sticky', () => {
+    it('classifies 404 + "model" in body as model-missing', () => {
+      const ev = classifyProviderError({ status: 404, body: 'Model big-pickle not found', model: 'big-pickle' });
+      expect(ev?.kind).toBe('model-missing');
+      expect(ev?.sticky).toBe(true);
+      expect(ev?.message).toContain('big-pickle');
+    });
+    it('classifies "model X is not supported" without status as model-missing', () => {
+      const ev = classifyProviderError({ body: 'Model opencode/big-pickle is not supported', model: 'opencode/big-pickle' });
+      expect(ev?.kind).toBe('model-missing');
+    });
+    it('does NOT misclassify bare 404 with no model hint', () => {
+      const ev = classifyProviderError({ status: 404, body: 'Not Found' });
+      expect(ev?.kind).not.toBe('model-missing');
+    });
+  });
+
+  describe('precedence', () => {
+    it('quota wins over rate-limit when 429 + insufficient_quota', () => {
+      const ev = classifyProviderError({ status: 429, body: 'insufficient_quota' });
+      expect(ev?.kind).toBe('quota');
+    });
+    it('auth (HTTP status) wins over body-text model-missing', () => {
+      // Real case: 401 response that also includes a model error message
+      // (server-side composes errors before checking auth).
+      const ev = classifyProviderError({ status: 401, body: 'Model X is not supported' });
+      expect(ev?.kind).toBe('auth');
+    });
+  });
+
+  describe('metadata pass-through', () => {
+    it('carries provider + model on the event', () => {
+      const ev = classifyProviderError({ status: 401, provider: 'opencode-zen', model: 'big-pickle' });
+      expect(ev?.provider).toBe('opencode-zen');
+      expect(ev?.model).toBe('big-pickle');
+    });
+  });
+});
+
+describe('ProviderHealth bus', () => {
+  it('reports + reads current event', () => {
+    const ph = new ProviderHealth();
+    ph.report({ kind: 'auth', message: 'bad key', sticky: true, at: 0 });
+    expect(ph.current()?.kind).toBe('auth');
+  });
+
+  it('stamps event.at via injected now()', () => {
+    const ph = new ProviderHealth({ now: () => 12345 });
+    ph.report({ kind: 'auth', message: 'bad key', sticky: true, at: 0 });
+    expect(ph.current()?.at).toBe(12345);
+  });
+
+  it('clear() removes the current event', () => {
+    const ph = new ProviderHealth();
+    ph.report({ kind: 'auth', message: 'bad key', sticky: true, at: 0 });
+    ph.clear();
+    expect(ph.current()).toBeNull();
+  });
+
+  it('notifies subscribers on report + clear', () => {
+    const ph = new ProviderHealth();
+    const seen: Array<ProviderHealthEvent | null> = [];
+    ph.subscribe(ev => seen.push(ev));
+    ph.report({ kind: 'auth', message: 'x', sticky: true, at: 0 });
+    ph.clear();
+    expect(seen).toHaveLength(2);
+    expect(seen[0]?.kind).toBe('auth');
+    expect(seen[1]).toBeNull();
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    const ph = new ProviderHealth();
+    const fn = vi.fn();
+    const unsub = ph.subscribe(fn);
+    ph.report({ kind: 'auth', message: 'x', sticky: true, at: 0 });
+    expect(fn).toHaveBeenCalledTimes(1);
+    unsub();
+    ph.report({ kind: 'outage', message: 'y', sticky: false, at: 0 });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto-clears non-sticky events after transientTtlMs', () => {
+    vi.useFakeTimers();
+    try {
+      const ph = new ProviderHealth({ transientTtlMs: 5_000 });
+      ph.report({ kind: 'rate-limit', message: 'slow down', sticky: false, at: 0 });
+      expect(ph.current()?.kind).toBe('rate-limit');
+      vi.advanceTimersByTime(5_001);
+      expect(ph.current()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT auto-clear sticky events', () => {
+    vi.useFakeTimers();
+    try {
+      const ph = new ProviderHealth({ transientTtlMs: 5_000 });
+      ph.report({ kind: 'auth', message: 'bad key', sticky: true, at: 0 });
+      vi.advanceTimersByTime(60_000);
+      expect(ph.current()?.kind).toBe('auth');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a fresh report cancels the pending auto-clear of the previous one', () => {
+    vi.useFakeTimers();
+    try {
+      const ph = new ProviderHealth({ transientTtlMs: 5_000 });
+      ph.report({ kind: 'rate-limit', message: 'first', sticky: false, at: 0 });
+      vi.advanceTimersByTime(3_000);
+      ph.report({ kind: 'outage', message: 'second', sticky: false, at: 0 });
+      vi.advanceTimersByTime(3_000);
+      // First's 5s window would have elapsed (3+3=6s) but second's
+      // window is only 3s in — should still be visible.
+      expect(ph.current()?.message).toBe('second');
+      vi.advanceTimersByTime(2_500);
+      expect(ph.current()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reportFrom classifies + reports in one call', () => {
+    const ph = new ProviderHealth();
+    const ev = ph.reportFrom({ status: 401, provider: 'groq' });
+    expect(ev?.kind).toBe('auth');
+    expect(ph.current()?.kind).toBe('auth');
+  });
+
+  it('reportFrom returns null on healthy input without touching state', () => {
+    const ph = new ProviderHealth();
+    const ev = ph.reportFrom({ status: 200 });
+    expect(ev).toBeNull();
+    expect(ph.current()).toBeNull();
+  });
+
+  it('a throwing subscriber does not break the bus for other subscribers', () => {
+    const ph = new ProviderHealth();
+    const good = vi.fn();
+    ph.subscribe(() => { throw new Error('bad subscriber'); });
+    ph.subscribe(good);
+    ph.report({ kind: 'auth', message: 'x', sticky: true, at: 0 });
+    expect(good).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/opencues-runtime/src/modules/provider-health.ts
+++ b/packages/opencues-runtime/src/modules/provider-health.ts
@@ -1,0 +1,248 @@
+// ProviderHealth — classification + bus for LLM-provider failures.
+//
+// LLM call failures used to surface as silent no-ops (sources caught the
+// throw and returned `{results:[], error}`; nothing rendered to the user).
+// In May 2026 the agentic harness found a Cerebras account that had been
+// out of credits for weeks while every cue source quietly returned
+// nothing — fluid-blank looked "broken" but the actual failure was 402.
+//
+// This module owns the failure taxonomy + a tiny event bus the status
+// line subscribes to. Sources / providers call `classifyProviderError`
+// with whatever signal they have (HTTP status + body, or a thrown
+// Error), get back a `ProviderHealthEvent` or null, and forward
+// non-null events into `ProviderHealth.report`.
+//
+// The taxonomy is intentionally small (five kinds) — it's a UX-budget
+// constraint, not a debugging surface. A status line that shows seven
+// different failure modes is the same as no status line.
+
+export type ProviderHealthKind =
+  | 'auth'           // 401/403 — bad or missing key. Sticky.
+  | 'quota'          // 402 / insufficient_quota / out of credit. Sticky.
+  | 'rate-limit'     // 429 transient. Auto-clears.
+  | 'outage'         // 5xx, network error, empty body. Auto-clears on next success.
+  | 'model-missing'; // 404 / "model not supported". Sticky (config issue).
+
+/**
+ * A single classified failure event. The status line renders sticky
+ * events until the underlying condition clears (next successful call
+ * for outage / rate-limit; explicit config-edit for auth / quota /
+ * model-missing — those don't clear themselves).
+ */
+export interface ProviderHealthEvent {
+  readonly kind: ProviderHealthKind;
+  /** Short, human-readable. Fits in a status line. */
+  readonly message: string;
+  /**
+   * Sticky events survive until clear() is called explicitly (config
+   * fix). Non-sticky events auto-clear after `transientTtlMs` (default
+   * 10s) on their own.
+   */
+  readonly sticky: boolean;
+  readonly provider?: string;
+  readonly model?: string;
+  /** Epoch ms. Set by the ProviderHealth bus, not by callers. */
+  readonly at: number;
+}
+
+export interface ClassifyInput {
+  /** HTTP status if available. Many call sites only have the body. */
+  readonly status?: number;
+  /** Response body or error message. The bulk of classification lives here. */
+  readonly body?: string;
+  /**
+   * A thrown Error (from the provider or HTTP adapter). Its `.message`
+   * is searched as a fallback for the body regexes. Most useful for
+   * network errors (ECONNREFUSED etc.) where there's no HTTP response.
+   */
+  readonly cause?: unknown;
+  readonly provider?: string;
+  readonly model?: string;
+}
+
+/**
+ * Classify a failure signal. Returns null when the input looks healthy
+ * (no error indicators found) — callers should treat null as "report
+ * nothing, the call succeeded".
+ *
+ * Precedence rules:
+ *   1. Quota signals win over rate-limit (402 / insufficient_quota are
+ *      more specific than a generic 429 — recovery requires a config
+ *      change, not a wait).
+ *   2. Auth status (401/403) wins over body-text classification — if
+ *      the server says auth failed, body content is secondary.
+ *   3. Model-missing requires both a 404 status AND a body hint OR
+ *      explicit text like "model X is not supported" — bare 404 from
+ *      a network proxy isn't a model-missing event.
+ */
+export function classifyProviderError(input: ClassifyInput): ProviderHealthEvent | null {
+  const status = input.status;
+  const body = (input.body ?? '').toString();
+  const causeMsg = input.cause instanceof Error ? input.cause.message : '';
+  const combined = body || causeMsg;
+  const lower = combined.toLowerCase();
+
+  // 2xx with no body indicator = healthy.
+  if (status !== undefined && status >= 200 && status < 300 && !combined) return null;
+
+  // Network errors come through as Error instances with no HTTP status.
+  const isNetworkErr = !status && /econnrefused|enotfound|etimedout|econnreset|network|fetch failed/i.test(causeMsg);
+  if (isNetworkErr) {
+    return mk('outage', `network: ${shorten(causeMsg)}`, false, input);
+  }
+
+  // 1. Quota — most specific, check first.
+  if (status === 402 || /\b402\b|payment[_ -]?required|insufficient[_ -]?(?:quota|credit|balance)|out[_ -]?of[_ -]?credit/i.test(combined)) {
+    return mk('quota', 'out of credits / payment required', true, input);
+  }
+
+  // 2. Auth.
+  if (status === 401 || status === 403) {
+    const detail = status === 403 ? 'forbidden — key lacks access' : 'bad / missing API key';
+    return mk('auth', detail, true, input);
+  }
+  if (!status && /unauthorized|invalid[_ -]?api[_ -]?key|authentication[_ -]?(?:failed|error)|invalid token/i.test(lower)) {
+    return mk('auth', 'bad / missing API key', true, input);
+  }
+
+  // 3. Model-missing — sticky config issue.
+  if (status === 404 && /model/i.test(combined)) {
+    return mk('model-missing', `model unavailable: ${input.model ?? '?'}`, true, input);
+  }
+  if (/model\s+\S+\s+is\s+not\s+supported|unknown\s+model|model\s+not\s+found/i.test(lower)) {
+    return mk('model-missing', `model unavailable: ${input.model ?? '?'}`, true, input);
+  }
+
+  // 4. Rate-limit (transient).
+  if (status === 429 || /\b429\b|too[_ -]?many[_ -]?requests|rate[_ -]?limit/i.test(combined)) {
+    return mk('rate-limit', 'rate-limited', false, input);
+  }
+
+  // 5. Outage — 5xx, transient body markers, empty body where one was expected.
+  if (status !== undefined && status >= 500 && status < 600) {
+    return mk('outage', `provider ${status}`, false, input);
+  }
+  if (/server[_ -]?error|service[_ -]?unavailable|overloaded|timeout|queue[_ -]?(?:exceeded|full)/i.test(lower)) {
+    return mk('outage', 'provider unavailable', false, input);
+  }
+  if (status === undefined && !combined) return null;
+  if (combined.trim() === '' && status === undefined) return null;
+
+  // Unknown failure shape — treat as outage with the raw message so the
+  // user at least sees SOMETHING rather than a silent dead-cue.
+  if (combined) {
+    return mk('outage', shorten(combined), false, input);
+  }
+  return null;
+}
+
+function mk(
+  kind: ProviderHealthKind,
+  message: string,
+  sticky: boolean,
+  input: ClassifyInput,
+): ProviderHealthEvent {
+  return {
+    kind,
+    message,
+    sticky,
+    provider: input.provider,
+    model: input.model,
+    at: 0, // overwritten by ProviderHealth.report — callers shouldn't trust this
+  };
+}
+
+function shorten(s: string): string {
+  const trimmed = s.trim().replace(/\s+/g, ' ');
+  return trimmed.length > 120 ? trimmed.slice(0, 117) + '...' : trimmed;
+}
+
+export interface ProviderHealthOptions {
+  /** ms a non-sticky event lingers before auto-clearing. Default 10_000. */
+  readonly transientTtlMs?: number;
+  /** Injectable clock for tests. */
+  readonly now?: () => number;
+}
+
+/**
+ * Tiny pub-sub for the latest provider-health event. The status line
+ * subscribes; sources / the resolver call `report`. Only the most recent
+ * event is retained — this is a UX surface, not an audit log.
+ *
+ * Sticky events stay until `clear()` or until a fresh non-sticky event
+ * arrives of the same kind that the caller treats as resolution.
+ * Non-sticky events auto-clear after `transientTtlMs`.
+ */
+export class ProviderHealth {
+  private _current: ProviderHealthEvent | null = null;
+  private _clearTimer: ReturnType<typeof setTimeout> | null = null;
+  private _subs = new Set<(ev: ProviderHealthEvent | null) => void>();
+  private readonly _ttl: number;
+  private readonly _now: () => number;
+
+  constructor(opts: ProviderHealthOptions = {}) {
+    this._ttl = opts.transientTtlMs ?? 10_000;
+    this._now = opts.now ?? (() => Date.now());
+  }
+
+  current(): ProviderHealthEvent | null {
+    return this._current;
+  }
+
+  /**
+   * Push a new event. Always overwrites the previous current — even
+   * sticky → non-sticky transitions. Callers decide policy by what
+   * they classify in the first place.
+   */
+  report(ev: ProviderHealthEvent): void {
+    const stamped: ProviderHealthEvent = { ...ev, at: this._now() };
+    this._current = stamped;
+    this._armAutoClear(stamped);
+    this._notify();
+  }
+
+  /** Explicit clear (sticky events; "I fixed it"). */
+  clear(): void {
+    if (this._clearTimer) { clearTimeout(this._clearTimer); this._clearTimer = null; }
+    if (this._current === null) return;
+    this._current = null;
+    this._notify();
+  }
+
+  /**
+   * Convenience: classify + report in one call. Returns the classified
+   * event (or null if the input looked healthy). Callers writing
+   * defensive error paths can ignore the return.
+   */
+  reportFrom(input: ClassifyInput): ProviderHealthEvent | null {
+    const ev = classifyProviderError(input);
+    if (ev) this.report(ev);
+    return ev;
+  }
+
+  /** Subscribe to current-event changes. Returns an unsubscribe fn. */
+  subscribe(fn: (ev: ProviderHealthEvent | null) => void): () => void {
+    this._subs.add(fn);
+    return () => this._subs.delete(fn);
+  }
+
+  private _armAutoClear(ev: ProviderHealthEvent): void {
+    if (this._clearTimer) { clearTimeout(this._clearTimer); this._clearTimer = null; }
+    if (ev.sticky) return;
+    this._clearTimer = setTimeout(() => {
+      // Only clear if this is still the current event (a newer report
+      // would have overwritten + re-armed).
+      if (this._current && this._current.at === ev.at) {
+        this._current = null;
+        this._clearTimer = null;
+        this._notify();
+      }
+    }, this._ttl);
+  }
+
+  private _notify(): void {
+    for (const fn of this._subs) {
+      try { fn(this._current); } catch { /* swallow — one bad subscriber shouldn't take the others down */ }
+    }
+  }
+}

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -395,10 +395,35 @@ export class Resolver {
       apiKey: this.options.apiKey,
       endpoint: settings.get('llm-endpoint') ?? this.options.endpoint,
       defaultModel: settings.get('llm-model') ?? this.options.defaultModel,
-      // Global tier (read once per build).
-      globalProvider: settings.get('llm-provider'),
+      // Global tier (read once per build). `llm-provider: free` is
+      // rejected here — `free` is a blank-only opt-in (see
+      // `blank-llm-provider`). Routing cues + auditors through the
+      // OpenCode Zen free pool would leak prose to a provider that
+      // trains on inputs; we refuse rather than silently allow it.
+      globalProvider: (() => {
+        const raw = settings.get('llm-provider');
+        if (raw?.toLowerCase() === 'free') {
+          this.adapter.log('warn', 'llm-provider: free is blank-only — ignoring (set blank-llm-provider: free instead). Cues + auditors fall back to inherit.');
+          return undefined;
+        }
+        return raw;
+      })(),
       globalModel: settings.get('llm-model') ?? this.options.defaultModel,
       globalEndpoint: settings.get('llm-endpoint') ?? this.options.endpoint,
+      // Blank-class override tier — applies only to FluidBlank /
+      // TransformBlank / ConfigIntent / keyword BlankSource (the
+      // user-opt-in `_` surface). Cues + auditors never read these.
+      // `free` is translated to `opencode-zen` (the underlying provider
+      // adapter id); other values flow through verbatim. `inherit`
+      // falls through to globalProvider at the resolveFor layer.
+      blankGlobalProvider: (() => {
+        const v = this.configLoader.opencuesState.blankLlmProvider;
+        if (v === 'free') return 'opencode-zen';
+        if (v === 'inherit') return undefined;
+        return v;
+      })(),
+      blankGlobalModel: settings.get('blank-llm-model'),
+      blankGlobalEndpoint: settings.get('blank-llm-endpoint'),
       // Per-feature tier.
       wordCues: featureLLM(settings, 'word-cues'),
       fluidBlank: featureLLM(settings, 'fluid-blank'),

--- a/packages/opencues-runtime/src/modules/statusline.ts
+++ b/packages/opencues-runtime/src/modules/statusline.ts
@@ -16,6 +16,7 @@ import type { ConfigLoader } from './config-loader';
 import type { SpanFillState } from '../state/span-fill';
 import type { SelectorSatelliteState } from '../state/selector-satellite';
 import type { AgentTaskState } from '../state/agent-task';
+import type { ProviderHealth, ProviderHealthEvent } from './provider-health';
 import { splitWords } from './navigation';
 
 export interface StatuslineOptions {
@@ -57,6 +58,20 @@ export interface StatuslinePayload {
   /** Agent-task indicator. When armed, contains a truncated form of the
    *  current task prompt (last ~40 chars). null when no task is armed. */
   agentTask?: string | null;
+  /**
+   * Current ProviderHealth event, if any — sticky errors (auth /
+   * quota / model-missing) stay until cleared; transient (rate-limit /
+   * outage) auto-clear after the bus's TTL. The shell consumer renders
+   * this as a prefix like `[opencues: bad / missing API key]` so the
+   * user has visible feedback when LLM calls are silently failing.
+   */
+  providerError?: {
+    readonly kind: ProviderHealthEvent['kind'];
+    readonly message: string;
+    readonly sticky: boolean;
+    readonly provider?: string;
+    readonly model?: string;
+  } | null;
 }
 
 export class Statusline {
@@ -88,17 +103,40 @@ export class Statusline {
      * `[task: ...]` so the user can see which agent is running.
      */
     private agentTaskState?: AgentTaskState,
+    /**
+     * Optional. When provided, the latest event from the bus is
+     * mirrored into StatuslinePayload.providerError on every render.
+     * Subscribing to the bus also triggers an immediate re-render so
+     * sticky errors (auth/quota) appear without waiting for the user
+     * to type — without this the user wouldn't see the error until
+     * the next keystroke.
+     */
+    private providerHealth?: ProviderHealth,
   ) {}
+
+  /** Unsub fn for the ProviderHealth bus. Null when no health bus wired. */
+  private _phUnsub: (() => void) | null = null;
 
   subscribe(): void {
     this._unsub = this.adapter.onRender(ctx => {
       this.maybeWrite(ctx);
       return null;
     });
+    // Mirror ProviderHealth changes into the statusline immediately —
+    // sticky errors should be visible without the user having to type.
+    // The host adapter may not expose a synchronous redraw, so we just
+    // ask for one via forceRender if available; otherwise the next
+    // keystroke's onRender will pick up the new state.
+    if (this.providerHealth) {
+      this._phUnsub = this.providerHealth.subscribe(() => {
+        try { this.adapter.forceRender?.(); } catch { /* host may not support force-render */ }
+      });
+    }
   }
 
   unsubscribe(): void {
     if (this._unsub) { this._unsub(); this._unsub = null; }
+    if (this._phUnsub) { this._phUnsub(); this._phUnsub = null; }
   }
 
   /** Exposed for testing — build the payload from current state + render ctx. */
@@ -263,9 +301,25 @@ export class Statusline {
     return '…' + prompt.slice(-MAX);
   }
 
+  /** Snapshot the current ProviderHealth event into the payload shape. */
+  private currentProviderError(): StatuslinePayload['providerError'] {
+    if (!this.providerHealth) return undefined;
+    const ev = this.providerHealth.current();
+    if (!ev) return null;
+    return {
+      kind: ev.kind, message: ev.message, sticky: ev.sticky,
+      provider: ev.provider, model: ev.model,
+    };
+  }
+
   private maybeWrite(ctx: RenderContext): void {
     if (!this.adapter.capabilities.includes('file-write')) return;
-    const payload = this.buildPayload(ctx);
+    // Always re-merge providerError so it appears even when buildPayload
+    // returned an `active: false` early branch. Cleaner than threading
+    // through every return — health is orthogonal to highlight state.
+    const built = this.buildPayload(ctx);
+    const providerError = this.currentProviderError();
+    const payload: StatuslinePayload = providerError !== undefined ? { ...built, providerError } : built;
     // Strip timestamp before content-comparison so identical-state renders
     // don't trigger writes purely because of clock change.
     const { timestamp: _t, ...stable } = payload;

--- a/tests/benchmarks/BENCHMARKS.md
+++ b/tests/benchmarks/BENCHMARKS.md
@@ -95,6 +95,18 @@ openai  chat-latest      100.0% / 1529 / $12.80   98.5% / 2249 / $17.26   99.3% 
 
 ★ = best cost-per-correct in the bench.
 
+**Free pool — OpenCode Zen (`blank-llm-provider: free`) — 30-case fluid-blank fused, anonymous, 1500ms throttle:**
+
+| Model | Accuracy | Per-case ms | Cost | Notes |
+|---|---|---|---|---|
+| `nemotron-3-super-free`      | **86.7%** (26/30) | 14002 | **$0** | NVIDIA terms; "trial use only — not for production / sensitive data". Slow but accurate. |
+| `deepseek-v4-flash-free`     | 46.7% (14/30)     | 4990  | $0     | Fast but mediocre; ToS says inputs may be used to train the model. |
+| `big-pickle`                 | 40.0% (12/30)     | 5064  | $0     | A stealth deepseek-v4-flash variant; same speed, worse accuracy. Same data-use clause as deepseek. |
+| ~~`qwen3.6-plus-free`~~      | —                 | —     | —      | Promotion ended May 2026; now requires paid OpenCode Go subscription. |
+| ~~`minimax-m2.5-free`~~      | —                 | —     | —      | Promotion ended May 2026; now requires paid OpenCode Go subscription. |
+
+**Source:** [`tests/results/opencode-zen-free/`](../results/opencode-zen-free/). 30-case slice of the canonical 137-case fluid-blank suite (`--limit 30`), `--parallel 1`, `OPENCUES_OPENCODE_ZEN_DELAY_MS=1500`. Free models are **blank-only**: the runtime refuses `llm-provider: free` at startup because cues + auditors run on prose automatically and the free-tier ToS allows training on inputs. Pool ordering in `OPENCODE_ZEN_FREE_POOL` (`packages/opencues-core/src/llm-provider.ts`) is accuracy-desc; the runtime walks it on transient failure and 30s-cools-down failing models. Re-bench when the live `/v1/models` set changes.
+
 ---
 
 ## Thinking-budget grid — which reasoning level fits which pipeline

--- a/tests/benchmarks/fluid-blank/groq.ts
+++ b/tests/benchmarks/fluid-blank/groq.ts
@@ -3,11 +3,12 @@
  * transform-blank/groq.ts — five providers behind one chat() interface,
  * selected via OPENCUES_BENCH_PROVIDER:
  *
- *   gemini-flash-lite   → ./gemini       (Gemini 3.1 Flash Lite)
- *   cerebras-gpt-oss    → ./cerebras     (gpt-oss-120b on Cerebras)
- *   claude-haiku        → ./claude       (Claude Haiku 4.5)
- *   openai-nano         → ./openai       (gpt-5.4-nano)
- *   (unset / anything)  → ./groq-impl    (Groq + gpt-oss-120b, default)
+ *   gemini-flash-lite   → ./gemini        (Gemini 3.1 Flash Lite)
+ *   cerebras-gpt-oss    → ./cerebras      (gpt-oss-120b on Cerebras)
+ *   claude-haiku        → ./claude        (Claude Haiku 4.5)
+ *   openai-nano         → ./openai        (gpt-5.4-nano)
+ *   opencode-zen        → ./opencode-zen  (free pool — model via OPENCUES_OPENCODE_ZEN_MODEL)
+ *   (unset / anything)  → ./groq-impl     (Groq + gpt-oss-120b, default)
  */
 
 import * as groqImpl from './groq-impl';
@@ -15,6 +16,7 @@ import * as geminiImpl from './gemini';
 import * as cerebrasImpl from './cerebras';
 import * as claudeImpl from './claude';
 import * as openaiImpl from './openai';
+import * as opencodeZenImpl from './opencode-zen';
 
 function pickImpl() {
   switch (process.env.OPENCUES_BENCH_PROVIDER) {
@@ -22,6 +24,7 @@ function pickImpl() {
     case 'cerebras-gpt-oss':  return cerebrasImpl;
     case 'claude-haiku':      return claudeImpl;
     case 'openai-nano':       return openaiImpl;
+    case 'opencode-zen':      return opencodeZenImpl;
     default:                  return groqImpl;
   }
 }

--- a/tests/benchmarks/fluid-blank/opencode-zen.ts
+++ b/tests/benchmarks/fluid-blank/opencode-zen.ts
@@ -1,0 +1,117 @@
+/**
+ * Minimal OpenCode Zen client — OpenAI-compatible chat completions at
+ * `https://opencode.ai/zen/v1/chat/completions`. Same `chat()` signature
+ * as groq-impl.ts so the bench runner can swap via env var.
+ *
+ * Set OPENCUES_BENCH_PROVIDER=opencode-zen to route here.
+ * Override the model via OPENCUES_OPENCODE_ZEN_MODEL (default: big-pickle).
+ *
+ * Free-tier models do NOT require an API key — verified May 2026.
+ * Paid models need OPENCODE_ZEN_API_KEY. The adapter sends the
+ * Authorization header only when the key is present.
+ *
+ * NON-AGGRESSIVE THROTTLE: a per-request sleep gates anonymous traffic
+ * so a sequential 137-case sweep doesn't trip the shared rate limit
+ * (anonymous users almost certainly share a low TPM bucket). Default
+ * 1500ms; tune via OPENCUES_OPENCODE_ZEN_DELAY_MS (set to 0 for
+ * full-speed once we know the limit).
+ *
+ * IMPORTANT: bare model IDs (no `opencode/` prefix). The opencode.ai
+ * docs say `opencode/<id>` but the live endpoint 401s on the prefixed
+ * form. The /v1/models GET returns bare IDs which is what we use.
+ */
+
+import * as https from 'https';
+
+const ENDPOINT = 'https://opencode.ai/zen/v1/chat/completions';
+export const MODEL = process.env.OPENCUES_OPENCODE_ZEN_MODEL ?? 'big-pickle';
+
+// API key is optional — free models authenticate anonymously.
+const API_KEY = process.env.OPENCODE_ZEN_API_KEY ?? '';
+
+// Throttle between requests. Default 1500ms keeps anonymous sweeps below
+// what looks like a shared rate-limit ceiling (no documented number, so
+// be polite). Override via OPENCUES_OPENCODE_ZEN_DELAY_MS=0 once we
+// have data on the actual limit.
+const DELAY_MS = (() => {
+  const raw = process.env.OPENCUES_OPENCODE_ZEN_DELAY_MS;
+  if (raw === undefined) return 1500;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 1500;
+})();
+
+// Use a single keep-alive socket — parallel anonymous requests are likely
+// to be rate-limited as one bucket, so there's no win to multi-socket.
+const agent = new https.Agent({ keepAlive: true, maxSockets: 1 });
+
+export interface ChatMessage { role: 'system' | 'user' | 'assistant'; content: string; }
+export interface ChatResult { text: string; latencyMs: number; }
+
+let _lastCallAt = 0;
+async function throttle(): Promise<void> {
+  if (DELAY_MS === 0) return;
+  const elapsed = Date.now() - _lastCallAt;
+  const wait = DELAY_MS - elapsed;
+  if (wait > 0) await new Promise(r => setTimeout(r, wait));
+  _lastCallAt = Date.now();
+}
+
+export async function chat(
+  messages: ChatMessage[],
+  opts: { temperature?: number; maxTokens?: number; seed?: number; reasoning?: 'none' | 'low' | 'medium' | 'high' } = {},
+): Promise<ChatResult> {
+  await throttle();
+
+  const body = JSON.stringify({
+    model: MODEL,
+    messages,
+    temperature: opts.temperature ?? 0,
+    max_tokens: opts.maxTokens ?? 512,
+    seed: opts.seed ?? 42,
+    reasoning_effort: opts.reasoning ?? 'low',
+  });
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Content-Length': String(Buffer.byteLength(body)),
+  };
+  if (API_KEY) headers.Authorization = `Bearer ${API_KEY}`;
+
+  const t0 = Date.now();
+  const data = await new Promise<string>((resolve, reject) => {
+    const u = new URL(ENDPOINT);
+    const req = https.request({
+      hostname: u.hostname,
+      path: u.pathname,
+      method: 'POST',
+      headers,
+      agent,
+    }, (res) => {
+      let buf = '';
+      res.on('data', (c: Buffer) => { buf += c; });
+      res.on('end', () => resolve(buf));
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+  const latencyMs = Date.now() - t0;
+
+  let parsed: any;
+  try { parsed = JSON.parse(data); } catch { throw new Error(`Bad OpenCode Zen response: ${data.slice(0, 200)}`); }
+  if (parsed.error || (parsed.message && parsed.code)) {
+    const msg = parsed.error?.message ?? parsed.message ?? JSON.stringify(parsed);
+    // Soft-fail rate-limit + parse so one bad response doesn't kill a
+    // sequential sweep; the case is counted as bail/empty by the parser.
+    if (/parsing|could not be parsed|rate.?limit|too many requests/i.test(msg)) {
+      return { text: '', latencyMs };
+    }
+    throw new Error(`OpenCode Zen error: ${msg}`);
+  }
+
+  const text = parsed.choices?.[0]?.message?.content ?? '';
+  return { text, latencyMs };
+}
+
+export const sysUser = (system: string, user: string): ChatMessage[] =>
+  [{ role: 'system', content: system }, { role: 'user', content: user }];

--- a/tests/benchmarks/fluid-blank/run.ts
+++ b/tests/benchmarks/fluid-blank/run.ts
@@ -86,6 +86,8 @@ interface Args {
   bench?: 'factual' | 'math' | 'unit' | 'color' | 'http' | 'roman' | 'translation' | 'spelling';
   mode: Mode;
   parallel: number;
+  /** Cap on cases to run (after filters). For directional sweeps against slow / throttled providers. */
+  limit?: number;
 }
 
 function parseArgs(): Args {
@@ -111,6 +113,14 @@ function parseArgs(): Args {
         process.exit(2);
       }
       out.parallel = v;
+    }
+    else if (args[i] === '--limit') {
+      const v = parseInt(args[++i], 10);
+      if (Number.isNaN(v) || v < 1) {
+        console.error(`--limit must be a positive integer, got: ${args[i]}`);
+        process.exit(2);
+      }
+      out.limit = v;
     }
     else if (args[i] === '--mode') {
       const v = args[++i];
@@ -437,7 +447,8 @@ async function main() {
     : filter.bench ? `${filter.bench.toUpperCase()}-BENCH (${benchCases[filter.bench].length})`
     : filter.holdout ? 'HOLDOUT'
     : 'main';
-  const selected = filterCases(allCases, filter);
+  const filtered = filterCases(allCases, filter);
+  const selected = filter.limit ? filtered.slice(0, filter.limit) : filtered;
   if (selected.length === 0) {
     console.error(`No cases matched filter ${JSON.stringify(filter)}`);
     process.exit(2);

--- a/tests/benchmarks/transform-blank/groq.ts
+++ b/tests/benchmarks/transform-blank/groq.ts
@@ -4,10 +4,11 @@
  * Default: re-exports `chat` / `sysUser` / `MODEL` from `./groq-impl`
  * (Groq + gpt-oss-120b). Switch via OPENCUES_BENCH_PROVIDER:
  *
- *   gemini-flash-lite   → ./gemini       (Gemini 3.1 Flash Lite)
- *   cerebras-gpt-oss    → ./cerebras     (gpt-oss-120b on Cerebras)
- *   claude-haiku        → ./claude       (Claude Haiku 4.5)
- *   openai-nano         → ./openai       (gpt-5.4-nano)
+ *   gemini-flash-lite   → ./gemini        (Gemini 3.1 Flash Lite)
+ *   cerebras-gpt-oss    → ./cerebras      (gpt-oss-120b on Cerebras)
+ *   claude-haiku        → ./claude        (Claude Haiku 4.5)
+ *   openai-nano         → ./openai        (gpt-5.4-nano)
+ *   opencode-zen        → ./opencode-zen  (free pool — model via OPENCUES_OPENCODE_ZEN_MODEL)
  *
  * Same chat() signature, same workload — apples-to-apples model
  * comparison without touching the benchmark's other source files.
@@ -18,6 +19,7 @@ import * as geminiImpl from './gemini';
 import * as cerebrasImpl from './cerebras';
 import * as claudeImpl from './claude';
 import * as openaiImpl from './openai';
+import * as opencodeZenImpl from './opencode-zen';
 
 function pickImpl() {
   switch (process.env.OPENCUES_BENCH_PROVIDER) {
@@ -25,6 +27,7 @@ function pickImpl() {
     case 'cerebras-gpt-oss':  return cerebrasImpl;
     case 'claude-haiku':      return claudeImpl;
     case 'openai-nano':       return openaiImpl;
+    case 'opencode-zen':      return opencodeZenImpl;
     default:                  return groqImpl;
   }
 }

--- a/tests/benchmarks/transform-blank/opencode-zen.ts
+++ b/tests/benchmarks/transform-blank/opencode-zen.ts
@@ -1,0 +1,117 @@
+/**
+ * Minimal OpenCode Zen client — OpenAI-compatible chat completions at
+ * `https://opencode.ai/zen/v1/chat/completions`. Same `chat()` signature
+ * as groq-impl.ts so the bench runner can swap via env var.
+ *
+ * Set OPENCUES_BENCH_PROVIDER=opencode-zen to route here.
+ * Override the model via OPENCUES_OPENCODE_ZEN_MODEL (default: big-pickle).
+ *
+ * Free-tier models do NOT require an API key — verified May 2026.
+ * Paid models need OPENCODE_ZEN_API_KEY. The adapter sends the
+ * Authorization header only when the key is present.
+ *
+ * NON-AGGRESSIVE THROTTLE: a per-request sleep gates anonymous traffic
+ * so a sequential 137-case sweep doesn't trip the shared rate limit
+ * (anonymous users almost certainly share a low TPM bucket). Default
+ * 1500ms; tune via OPENCUES_OPENCODE_ZEN_DELAY_MS (set to 0 for
+ * full-speed once we know the limit).
+ *
+ * IMPORTANT: bare model IDs (no `opencode/` prefix). The opencode.ai
+ * docs say `opencode/<id>` but the live endpoint 401s on the prefixed
+ * form. The /v1/models GET returns bare IDs which is what we use.
+ */
+
+import * as https from 'https';
+
+const ENDPOINT = 'https://opencode.ai/zen/v1/chat/completions';
+export const MODEL = process.env.OPENCUES_OPENCODE_ZEN_MODEL ?? 'big-pickle';
+
+// API key is optional — free models authenticate anonymously.
+const API_KEY = process.env.OPENCODE_ZEN_API_KEY ?? '';
+
+// Throttle between requests. Default 1500ms keeps anonymous sweeps below
+// what looks like a shared rate-limit ceiling (no documented number, so
+// be polite). Override via OPENCUES_OPENCODE_ZEN_DELAY_MS=0 once we
+// have data on the actual limit.
+const DELAY_MS = (() => {
+  const raw = process.env.OPENCUES_OPENCODE_ZEN_DELAY_MS;
+  if (raw === undefined) return 1500;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 1500;
+})();
+
+// Use a single keep-alive socket — parallel anonymous requests are likely
+// to be rate-limited as one bucket, so there's no win to multi-socket.
+const agent = new https.Agent({ keepAlive: true, maxSockets: 1 });
+
+export interface ChatMessage { role: 'system' | 'user' | 'assistant'; content: string; }
+export interface ChatResult { text: string; latencyMs: number; }
+
+let _lastCallAt = 0;
+async function throttle(): Promise<void> {
+  if (DELAY_MS === 0) return;
+  const elapsed = Date.now() - _lastCallAt;
+  const wait = DELAY_MS - elapsed;
+  if (wait > 0) await new Promise(r => setTimeout(r, wait));
+  _lastCallAt = Date.now();
+}
+
+export async function chat(
+  messages: ChatMessage[],
+  opts: { temperature?: number; maxTokens?: number; seed?: number; reasoning?: 'none' | 'low' | 'medium' | 'high' } = {},
+): Promise<ChatResult> {
+  await throttle();
+
+  const body = JSON.stringify({
+    model: MODEL,
+    messages,
+    temperature: opts.temperature ?? 0,
+    max_tokens: opts.maxTokens ?? 512,
+    seed: opts.seed ?? 42,
+    reasoning_effort: opts.reasoning ?? 'low',
+  });
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Content-Length': String(Buffer.byteLength(body)),
+  };
+  if (API_KEY) headers.Authorization = `Bearer ${API_KEY}`;
+
+  const t0 = Date.now();
+  const data = await new Promise<string>((resolve, reject) => {
+    const u = new URL(ENDPOINT);
+    const req = https.request({
+      hostname: u.hostname,
+      path: u.pathname,
+      method: 'POST',
+      headers,
+      agent,
+    }, (res) => {
+      let buf = '';
+      res.on('data', (c: Buffer) => { buf += c; });
+      res.on('end', () => resolve(buf));
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+  const latencyMs = Date.now() - t0;
+
+  let parsed: any;
+  try { parsed = JSON.parse(data); } catch { throw new Error(`Bad OpenCode Zen response: ${data.slice(0, 200)}`); }
+  if (parsed.error || (parsed.message && parsed.code)) {
+    const msg = parsed.error?.message ?? parsed.message ?? JSON.stringify(parsed);
+    // Soft-fail rate-limit + parse so one bad response doesn't kill a
+    // sequential sweep; the case is counted as bail/empty by the parser.
+    if (/parsing|could not be parsed|rate.?limit|too many requests/i.test(msg)) {
+      return { text: '', latencyMs };
+    }
+    throw new Error(`OpenCode Zen error: ${msg}`);
+  }
+
+  const text = parsed.choices?.[0]?.message?.content ?? '';
+  return { text, latencyMs };
+}
+
+export const sysUser = (system: string, user: string): ChatMessage[] =>
+  [{ role: 'system', content: system }, { role: 'user', content: user }];

--- a/tests/results/opencode-zen-free/SUMMARY.md
+++ b/tests/results/opencode-zen-free/SUMMARY.md
@@ -1,0 +1,72 @@
+# OpenCode Zen free-pool — fluid-blank sweep (2026-05-23)
+
+30-case slice of the canonical 137-case fluid-blank suite (`--limit 30`),
+`--mode fused`, `--parallel 1`, `OPENCUES_OPENCODE_ZEN_DELAY_MS=1500`,
+anonymous (no `OPENCODE_ZEN_API_KEY`). Judge pinned to Groq
+`gpt-oss-120b` per the standard bench convention.
+
+## Results
+
+| Model | Accuracy | Per-case latency | Wall-clock | Status |
+|---|---|---|---|---|
+| `nemotron-3-super-free`  | **86.7%** (26/30) | 14002ms | 420.8s | live |
+| `deepseek-v4-flash-free` | 46.7% (14/30)     | 4990ms  | 153.2s | live |
+| `big-pickle`             | 40.0% (12/30)     | 5064ms  | 155.0s | live |
+| `qwen3.6-plus-free`      | —                 | —       | —      | **retired** → paid OpenCode Go |
+| `minimax-m2.5-free`      | —                 | —       | —      | **retired** → paid OpenCode Go |
+
+The two retired models returned `HTTP 402` with body
+`"Free promotion has ended for <X>. You can continue using the model by
+subscribing to OpenCode Go - https://opencode.ai/go"`. The runtime's
+`withFreePool` wrapper bubbles these as quota errors via
+`ProviderHealth` (sticky); the bench harness logs `FATAL` and exits
+non-zero, but the sweep driver continues to the next model.
+
+## How to reproduce
+
+```bash
+mkdir -p tests/results/opencode-zen-free
+for M in nemotron-3-super-free deepseek-v4-flash-free big-pickle; do
+  OPENCUES_BENCH_PROVIDER=opencode-zen \
+    OPENCUES_OPENCODE_ZEN_MODEL=$M \
+    OPENCUES_OPENCODE_ZEN_DELAY_MS=1500 \
+    npx tsx tests/benchmarks/fluid-blank/run.ts --mode fused --parallel 1 --limit 30 \
+    > tests/results/opencode-zen-free/$M.log 2>&1
+done
+./tests/results/opencode-zen-free/summarize.sh
+```
+
+`*.log` is gitignored — re-run to populate. `summarize.sh` is the
+committed survival path.
+
+## Pool ordering (consequence)
+
+`OPENCODE_ZEN_FREE_POOL` in `packages/opencues-core/src/llm-provider.ts`
+is ordered accuracy-desc:
+
+```ts
+export const OPENCODE_ZEN_FREE_POOL: readonly string[] = [
+  'nemotron-3-super-free',
+  'deepseek-v4-flash-free',
+  'big-pickle',
+];
+```
+
+The retired entries are dropped — the runtime's 30s health cache would
+have skipped them on the next call anyway, but ordering the list off
+real data avoids burning a request on a dead model first.
+
+## Caveats
+
+- **30-case slice, not full 137.** Directional signal only — re-run
+  with `--limit 137` (or drop the flag) for strict parity with the
+  paid matrix in `BENCHMARKS.md`. ~30 min for nemotron alone at the
+  current throttle.
+- **Anonymous shared rate-limit.** 1500ms throttle was a guess —
+  worked across this sweep with zero rate-limit errors, but the
+  actual limit isn't documented. Lower the delay cautiously.
+- **Same `/v1/models` set may change.** Two of five free models
+  retired between the docs being written (early May 2026) and this
+  bench (2026-05-23). Re-check live list via
+  `curl https://opencode.ai/zen/v1/models` before relying on a
+  specific entry.

--- a/tests/results/opencode-zen-free/summarize.sh
+++ b/tests/results/opencode-zen-free/summarize.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Summarize the opencode-zen free-pool fluid-blank sweep.
+#
+# Re-create the raw logs by running:
+#   /tmp/run-zen-sweep.sh
+# or, per model:
+#   OPENCUES_BENCH_PROVIDER=opencode-zen \
+#     OPENCUES_OPENCODE_ZEN_MODEL=<model> \
+#     OPENCUES_OPENCODE_ZEN_DELAY_MS=1500 \
+#     npx tsx tests/benchmarks/fluid-blank/run.ts --mode fused --parallel 1 --limit 30 \
+#     > tests/results/opencode-zen-free/<model>.log 2>&1
+#
+# *.log is gitignored — re-run to populate.
+set -euo pipefail
+DIR="$(dirname "$0")"
+
+printf '%-30s %-12s %-12s %-12s %-10s\n' "Model" "Total-pass" "Per-case" "Wall-clock" "Status"
+printf '%-30s %-12s %-12s %-12s %-10s\n' "-----" "----------" "--------" "----------" "------"
+
+for f in "$DIR"/*.log; do
+  base=$(basename "$f" .log)
+  [[ "$base" == "_progress" ]] && continue
+  clean=$(sed 's/\x1b\[[0-9;]*m//g' "$f")
+  total=$(echo "$clean" | grep -E "^Total:" | head -1 || true)
+  modelavg=$(echo "$clean" | grep -E "^Avg model" | head -1 || true)
+  wall=$(echo "$clean" | grep -E "^Wall-clock total:" | head -1 || true)
+  fatal=$(echo "$clean" | grep -E "^FATAL:" | head -1 || true)
+
+  if [[ -n "$fatal" ]]; then
+    status="RETIRED"
+    if [[ "$fatal" == *"Go"* ]]; then status="→ paid Go"; fi
+    printf '%-30s %-12s %-12s %-12s %-10s\n' "$base" "—" "—" "—" "$status"
+    continue
+  fi
+
+  tot_pct=$(echo "$total" | grep -oE '\([0-9.]+%\)' | head -1 || echo "?")
+  per_ms=$(echo "$modelavg" | grep -oE 'per case\): [0-9]+ms' | grep -oE '[0-9]+ms' || echo "?")
+  wall_s=$(echo "$wall" | grep -oE '[0-9]+\.[0-9]+s' | head -1 || echo "?")
+
+  printf '%-30s %-12s %-12s %-12s %-10s\n' "$base" "$tot_pct" "$per_ms" "$wall_s" "live"
+done


### PR DESCRIPTION
## Summary

Adds a separate provider for blank-class sources (FluidBlank / TransformBlank / ConfigIntent) — opt-in via `blank-llm-provider: <id>` in OPENCUES.md — plus the underlying OpenCode Zen adapter that makes `blank-llm-provider: free` work anonymously with zero account.

Three pieces, one PR (they only make sense together):

1. **`blank-llm-provider` scalar** — separate provider routing for blanks vs cues. Trust boundary enforced: `llm-provider: free` (the cue path) is **refused at startup** because cues run on prose automatically and the free-tier ToS allows training on inputs.
2. **OpenCode Zen adapter + free pool** — new `opencode-zen` provider in `@opencues/core`. Anonymous auth via `optionalAuth: true` on `ProviderAdapter`. `withFreePool` wrapper walks `OPENCODE_ZEN_FREE_POOL` on transient failures, 30s-cools-down dead entries, bubbles auth/quota immediately.
3. **`ProviderHealth` failure-state UX** — new bus + 5-kind taxonomy (`auth` / `quota` / `rate-limit` / `outage` / `model-missing`). Statusline mirrors the current event; sticky errors stay until config fix, transient auto-clear after 10s. Applies to **all** providers, not just free.

## Bench evidence

30-case fluid-blank fused, anonymous, 1500ms throttle. Full table + repro in [`tests/results/opencode-zen-free/SUMMARY.md`](tests/results/opencode-zen-free/SUMMARY.md):

| Model | Accuracy | Per-case latency | Status |
|---|---|---|---|
| `nemotron-3-super-free` | **86.7%** (26/30) | 14002ms | live |
| `deepseek-v4-flash-free` | 46.7% (14/30) | 4990ms | live |
| `big-pickle` | 40.0% (12/30) | 5064ms | live |
| `qwen3.6-plus-free` | — | — | **retired** → paid OpenCode Go |
| `minimax-m2.5-free` | — | — | **retired** → paid OpenCode Go |

`OPENCODE_ZEN_FREE_POOL` ordering reflects accuracy-desc; two retired entries dropped.

Free's best (nemotron) sits between paid mid (`gpt-5.4-mini` at 80.3%) and the 99% tier (cerebras/groq/claude). 53× slower than the paid frontier — free mode is for shipping the feature working with zero setup, not for parity.

## Test plan

- [x] `@opencues/core`: 97 vitest pass + 26 node:test pass (15 new `opencode-zen.test.ts` covering pool walking, anonymous auth, bare-model-id quirk)
- [x] `@opencues/runtime`: 1313 pass (34 new `provider-health.test.ts` covering the taxonomy + bus, 10 new `provider-health.scenarios.test.ts` covering the end-to-end statusline surface)
- [x] Live in OpenCode headless: fluid-blank / transform-blank / config-intent route to `opencode-zen`; sentence-cues + word-cues stay on `cerebras/gpt-oss-120b`. Trust boundary holds end-to-end.
- [x] Free-mode boots with zero `OPENCODE_ZEN_API_KEY` set (live-confirmed via `OPENCUES.md` set to `blank-llm-provider: free`).

## Known follow-ups (not in this PR)

- Re-run the full 137-case fluid-blank suite against the 3 working free models for strict parity with the paid matrix (~30 min nemotron alone).
- Doctor diagnostic for free-mode footgun warning ("blanks routed through free pool; cues + auditors still need a paid key").
- Run the failure-state UX live (yank network → confirm status line shows `outage`). Unit + scenario tests cover the path; haven't manually verified the live render yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)