### PR TITLE
docs(blog): re-render 5 posts + polish rules in CLAUDE.md

### DIFF
--- a/docs/blog/CLAUDE.md
+++ b/docs/blog/CLAUDE.md
@@ -38,6 +38,22 @@ Wilfred's voice on long-form pieces (mechanics essays, blog posts). This is *dif
 - Mix technical and casual registers — "extract value", "grok", "rapidly iterate" alongside "bums", "neigh endless", "chin up".
 - Recurring metaphor families: fighting-game frames (`start-up frames` / `active window duration` / `end-lag` — see canonical names below), `flow`, `in the zone`, gaming/RPG framings.
 
+### Plain-language substitutions
+
+Engineering jargon undercuts the post for non-engineering readers. Substitute throughout:
+
+- *buffer* → *text* / *draft* / *document* / *text input* (pick whichever fits)
+- *arm / armed / arming* (the agent) → *start* / *starting*
+- *disarm* → *stop*
+- *pulse* (the loop iteration) → *run*
+- *debounce* (in prose; keep in code) → *pause* / *brief pause* / *<N>ms pause in typing*
+- *DSL* → *special syntax*
+- *imperative shape* → *paired with an instruction*
+- *free-form* (describing user-facing behaviour) → *plain lookup*
+- *formal register* → *more formal tone*
+
+The principle: if the word would feel out of place in *The Economist*'s tech section, find a plainer one. Code identifiers stay backticked and exact; prose around them gets translated.
+
 ### Rhetorical moves
 
 - Question → answer. "Ok, but how does it work?", "How tight is tight?".
@@ -63,6 +79,11 @@ Wilfred's voice on long-form pieces (mechanics essays, blog posts). This is *dif
 - Imperatives with **both** subject and object implicit. *"Activate by typing in any prompt with cue sources installed"* leaves both *who* (the user) and *what* (the cues) unstated. The reader has to infer them. In activation lines, definitions, or other foundational positions, name at least one — and if it's a foundational sentence, name both: *"Cues activate automatically as the user types in any prompt with cue sources installed."*
 - Circular qualifications. *"Any **non-blocking** cue must use a different modality"* loads the conclusion into the premise — *non-blocking* is what the rule is establishing, so qualifying the subject with it makes the rule tautological. Drop the qualifier and let the rule stand: *"Any cue must use a different modality."* Same applies any time a rule's subject already names its outcome.
 - Declarative absolutes where the post is making a normative argument. *"This **is** the foundational rule for AI HCI"* asserts the rule already governs the field; the post's actual claim is *"this **should be** a foundational rule when designing AI HCIs."* The same pattern applies to *"where AI HCI **goes** next"* vs *"where AI HCI **should go** next"*. When the prose argues for a direction, use *should* / *ought*. Reserve *is* / *will* for fact-claims the post can defend.
+- Self-announcing meta-narrative. *"The post claims this is X"*, *"The post opened on Y"*, *"This is one place where the Z framing earns its keep"* all refer to the post talking about itself. The section heading or the prose above already does that work; the announcement is throat-clearing. Drop it and let the next sentence carry the thesis directly.
+- Aphorisms that require unpacking. If a pull-quote needs to be parsed before the reader gets it, the body has already failed to establish the idea (or the aphorism is too clever for its own good). *"Anywhere the work is the surface, the teaching can live with the work"* required mental gymnastics and was deleted in favour of the prose above it. Cut, don't explain.
+- Unverified specific numbers. Latency figures, percentages, throughput claims must come from a current benchmark or shipped constant. If you can't trace the number to a bench file or a config default, soften to a qualitative range (*"typically sub-second on fast providers"* / *"a few hundred milliseconds"*). Specific numbers without provenance read as authoritative but cannot be defended; readers who know the codebase will spot the gap.
+- Costs the user isn't paying. *"The user is paying ~365ms per run for the agent's presence"* implies the user waits on each run; with a background process triggered after a typing pause, they don't. Don't frame background latency as user-paid time.
+- Soft-rejected security claims. Don't write *"the agent does not need per-feature permission prompts, sandbox escapes, or undo machinery"* — OpenCues has all of these (sensitive-field block, bwrap/sandbox-exec, output sanitisation, rate quota, secrets whitelist; see `docs/architecture/security-audit.md`). The defensible safety boundary for Inline Agents is structural: LLM output has no side-effect channel (no MCP tools, no agentic actions), so the worst case is user-visible text the user sees before submitting. Name the structural property, not the absence of mechanisms.
 
 ---
 
@@ -124,6 +145,29 @@ Generic uses of *cue* / *prompt* / *agent* in lowercase are fine when not naming
 - Use **resolve / resolved** in technical descriptions (mechanism sections, *Ownership lock*, *Visible failure*, *How blanks resolve*).
 - Use **fill in the blank** only when explicitly invoking the schoolchild idiom or the marketing framing (e.g. the *Lineage: fill in the blank* section title).
 - The two terms describe the same physical action; the choice signals register. Default to *resolve* unless the marketing/cultural reference is doing real work.
+
+## Describing OpenCues mechanics accurately
+
+Three concrete claims this blog tree has gotten wrong in the past. Verify each before re-using.
+
+### Inline Agents — edits are live, not proposals
+
+The agent applies its edits directly to the user's text and dims the *new* word so the change is visible. There is no accept gesture; ignoring the dim is acceptance. Only reverting is an action.
+
+- Don't describe agent edits as *"proposals the user has not yet committed"*, *"suggestions to accept"*, or *"changes the user can apply"*. They're applied.
+- Don't claim Google Docs Suggestions parallel works because both require an *"accept click"* — Suggestions does, Inline Agents doesn't. The inverted default is the real distinction.
+- The reverting gesture is **two keys**: `Ctrl+Alt+Left/Right` to navigate the cue-selection indicator to the dimmed word, then `Ctrl+Alt+Down` to cycle it back to the original. The indicator is decoupled from the cursor by default. Never write *"one keystroke to revert"*.
+
+### Inline Agents — granularity is arbitrary-span, not per-word
+
+The runtime word-diffs the LLM's full-document rewrite into hunks, and hunks can span a single word, a phrase, a sentence, or a paragraph. The cache is also whole-document (skip-on-stable on `(snapshot, task, cursor)` plus an LRU keyed on `windowWords + auditorSignature + cursor + task + snapshot`), not per-word.
+
+- Don't say *"per-word grain"* or *"per-word cache"* — both are stale references to a retired architecture.
+- Don't say the EDITS prompt format is current; it was retired with the per-edit `Judge` pipeline. Current shipping format is full-document rewrite with a `[CURSOR]` sentinel.
+
+### Submit gesture is host-specific
+
+A draft's *"final commit"* depends on the host. In a chat input, `Enter` submits. In a multi-line email body, `Enter` is a newline and clicking *Send* submits. In a form, posting submits. Don't write *"the user presses Enter, the way they would in any text field"* — that's wrong in most text fields. Use the formula: *"the user submits the draft, however the host handles submission (`Enter` in a chat input, Send in an email client, posting a form)"*.
 
 ## Two-direction model — naming the directions
 
@@ -264,6 +308,10 @@ Before declaring a re-render done, run a backwards audit on the diff. None of th
 - Inconsistent verbs for the same effect. The *Human Interaction* re-render used both *shifts the chat window* and *would push the chat window* for the same chat-window displacement. Same effect → same verb. Search for verb variants describing the same phenomenon before declaring done.
 - Inconsistent shorthand for the same keychord. The *Inline Cues* re-render used *Ctrl+Alt+Up / Ctrl+Alt+Down* in one place and bare *Up / Down* in another for the same cycling action. The bare-arrow shorthand reads as if it might be an unmodified key. Use the full keychord every time the action is named, even when it lengthens the sentence.
 - Subject/verb/complement agreement, especially on plural subjects with singular noun complements. *"Inline cues are a system-to-user signal"* mismatched plural *cues* with singular *signal*. Fix is plural throughout (*"are system-to-user signals"*) or singular subject (*"An inline cue is a system-to-user signal"*). Check every *X are Y* / *X is Y* sentence for agreement, not just verb agreement but noun-complement agreement too.
+- **Code-derived names must match the code.** Filenames (`CUE.md` not `cue.md`), config keys (`agent-debounce-ms` not `agentDebounce`), class/interface names (no fictional `LLMRequest` — the actual surface is a generic provider interface), provider names (*Cerebras* / *Groq*, capitalised), model identifiers (`gpt-oss-120b` backticked, lowercase). Grep the codebase before publishing any of these. If you can't find it, you invented it.
+- **Cross-system comparison rows must distinguish on real differences.** When comparing OpenCues to an analogue (Google Docs Suggestions, RSS, autocomplete, etc.), every row in a `| X | Y |` table must name a property where the two genuinely differ. Don't enumerate properties both systems share — the row tells the reader nothing. Example: *"Granularity is per-marked-edit | Granularity is per-word"* claimed a distinction that doesn't hold (both are arbitrary-span); deleted.
+- **Validate every code-related claim against the actual implementation before publishing.** Architecture evolves; the post's facts shouldn't lag. Re-render passes have caught: per-word vs whole-document cache, stale EDITS/DECISIONS prompt formats, retired Groq default (now Cerebras), wrong filename casing (`cue.md` vs `CUE.md`), invented interface name `LLMRequest`, wrong debounce default (500ms claimed vs 1000ms shipped), unverified latency figures (365ms, 200–500ms, 600ms–1.5s). When in doubt, run an explore agent against `agent-rewrite.ts`, `fluid-blank-source.ts`, `transform-blank-source.ts`, `defaults/OPENCUES.md`, and `docs/architecture/*.md`.
+- **Verb-noun pair must be plausible.** *"empty response returns no edits"* sounds like the response itself is doing the returning. Make the run/agent/runtime the subject of the action: *"if the LLM returns nothing, the run produces no edits"*. Check every sentence where the subject is a state, an error, or a passive thing.
 
 If any of those survive into the re-render, the polish stopped early. Run another pass.
 

--- a/docs/blog/posts/README.md
+++ b/docs/blog/posts/README.md
@@ -2,17 +2,19 @@
 
 Each post is a standalone markdown file, one per section of the original draft.
 
-1. [HCI (Human to computer interface)](hci-human-to-computer-interface.md)
-2. [Human Interaction](human-interaction.md)
-3. [Inline Cues (Continuous Onboarding)](inline-cues-continuous-onboarding.md)
-4. [Inline Prompting (Blank / _)](inline-prompting-blank.md)
-5. [Inline Agents](inline-agents.md)
+Posts marked **(done)** are finished re-renders — STAGING NOTES absorbed or pruned, polishing audit clean per `../CLAUDE.md`. Unmarked posts are still drafts or stubs.
+
+1. [HCI (Human to computer interface)](hci-human-to-computer-interface.md) **(done)**
+2. [Human Interaction](human-interaction.md) **(done)**
+3. [Inline Cues (Continuous Onboarding)](inline-cues-continuous-onboarding.md) **(done)**
+4. [Inline Prompting (Blank / _)](inline-prompting-blank.md) **(done)**
+5. [Inline Agents](inline-agents.md) **(done)**
 6. [What is Invention](what-is-invention.md)
 7. [What is Design](what-is-design.md)
 8. [Naming / AEO (Audio Engine Optimisation) / Trademark](naming-aeo-trademark.md)
 9. [If it works in Terminal it works 'anywhere'](if-it-works-in-terminal.md)
 10. [The Value of Design](the-value-of-design.md)
-11. [Human to Artificial Intelligence Interfaces (HAII)](haii-human-to-ai-interfaces.md)
+11. [Human to Artificial Intelligence Interfaces (HAII)](haii-human-to-ai-interfaces.md) **(done)**
 12. [Flow state](flow-state.md)
 13. [Cross domain pollination & _ shaped people](cross-domain-pollination.md)
 14. [Simplicity](simplicity.md)
@@ -20,3 +22,4 @@ Each post is a standalone markdown file, one per section of the original draft.
 16. [Seamlessly integration](seamlessly-integration.md)
 17. [The Value of Community](the-value-of-community.md)
 18. [Principles of HCI](principles-of-hci.md)
+19. [Disruption](disruption.md)

--- a/docs/blog/posts/haii-human-to-ai-interfaces.md
+++ b/docs/blog/posts/haii-human-to-ai-interfaces.md
@@ -1,53 +1,22 @@
-# Human to Artificial Intelligence Interfaces (HAII)
+---
+title: Human-to-AI Interfaces (HAII)
+date: 2026-05-24
+description: HAII is to AI what HCI is to computers. A sister discipline with its own constraints, affordances, and failure modes, and a manifesto for treating it that way.
+tags: [hci, haii, manifesto, harness, discipline]
+cross_links: [hci-human-to-computer-interface, human-interaction, inline-cues-continuous-onboarding, inline-prompting-blank, inline-agents, cross-domain-pollination]
+---
 
-As a HCI (Human to Computer Interface) specialist I would like to encourage more development in the cross-section of HCI x AI.
+# Human-to-AI Interfaces (HAII)
 
-I call it HAII! (Human to Artificial Intelligence Interfaces)
+HAII (Human-to-AI Interface) is the design discipline concerned with how a human extracts value from an AI system. The interface, the harness, the prompt scaffolding, the output rendering, the error handling: everything that sits between the user and the model.
 
-The means through which we extract value through LLM models is not just by pinging the raw model, it is often through various harnesses which have be bolted ontop of developed natively to further augment the LLM models underneath.
-
-By developing new HAII we unlock new value from our existing models thus reducing the need for developing smarter, more costly models which tax our environment.
-(Bunch of waffle about benefits of extending current models)
-
-We have a swath of OpenSource models and models which can run locally however the harnesses we have designed have not been optimised to utilise them and deliver value in a reliable way that makes a user not feel an itch to reach for a smart more expensive model.
-
-I would like to challenge engineers and designers around the world to not settle for the status quo, regardless of how good, well funded it is but to ponder what the future could be.
-
-> Bewilderment is the enemy of invention.
-
-We should use the tools of today to build the tools of tomorrow.
+I coined the term to make the discipline investible. As a HCI (Human to Computer Interface) specialist of seven years at Command Stick, I have watched the AI industry default to "the chat box" because the field has no shared vocabulary for anything else. Naming the discipline is the first step to expanding it.
 
 ---
 
-## STAGING NOTES (not yet formatted)
+### Why HAII is its own discipline
 
-### A. Fill `(Bunch of waffle about benefits of extending current models)`
-
-The concrete benefits of investing in harness-level work over model-level work:
-
-- **Token efficiency.** A better harness on a 70B model can match worse harnesses on 200B+ models for the same task. Empirical: the 3-pass transform-blank pipeline went from 19% (single-call) to 86–90% accuracy *on the same model*. That is a model-class jump achieved by harness redesign alone.
-- **Environmental cost.** Training a frontier model is expensive in water, electricity, and compute. Better harnesses make existing trained models more capable without retraining. The carbon math here is straightforward — re-using inference is dramatically cheaper than re-training.
-- **Latency.** "Output tokens dominate latency" is a harness-level lesson, not a model-level one. The EDITS-format change in the agent-task loop cut latency 30% and made it 5× faster on 200-word docs — without changing models.
-- **Privacy.** A good harness on a local model > an okay harness on a frontier cloud model, *for the user's purposes*. Better harness work shifts the local-vs-cloud trade-off in favour of "stays on your machine."
-- **Cost to user.** $0/month to run a Phi-class or Llama-class model locally with the right harness. $20+/month for a frontier cloud product. Cost asymmetry of two orders of magnitude, often for the same delivered value.
-- **Democratisation.** The frontier-model race is funded by ~5 organisations on the planet. Harness work is open to anyone with a laptop and an API key. The contributors who can move HAII forward outnumber the contributors who can move model capability forward by something like four orders of magnitude.
-- **Iteration speed.** Harness changes ship in hours; model changes ship in months. The whole feedback loop (idea → benchmark → deploy → measure) is days at the harness layer and quarters at the model layer.
-
-The point is not that frontier models don't matter — they do, and improvements there compound. The point is that the *ratio* of investment in models vs harnesses is currently lopsided. Most of the value users feel from "AI got better" came from harness improvements, not model improvements, and we are nowhere near the ceiling of what harnesses can do.
-
-### B. The HAII coinage elevated as a defined term
-
-The post coins HAII but does not define it crisply. A working definition worth pinning at the top:
-
-> HAII (Human to Artificial Intelligence Interface) — the design discipline concerned with how a human extracts value from an AI system. The interface, harness, prompt scaffolding, output rendering, error handling, and interaction grammar that sit between the user and the model.
-
-HAII is to AI what HCI is to computers — a sister discipline, not a subset, even though every HAII is technically also an HCI. The reason it deserves its own name is that the constraints, affordances, and failure modes are genuinely different (see C and K below).
-
-This blog series is, in effect, an extended HAII case study: cues + blanks as the spine, and OpenCues as the worked implementation.
-
-### C. HCI / HAII relationship sharpened
-
-HAII is *technically* a subset of HCI — AI systems are computer systems, so any interface to an AI is an interface to a computer. But the everyday assumptions of HCI break in HAII territory:
+HAII is technically a subset of HCI. AI systems are computer systems, so any interface to an AI is also an interface to a computer. But the everyday assumptions of HCI break in HAII territory:
 
 | Property | Classical HCI | HAII |
 |---|---|---|
@@ -59,117 +28,63 @@ HAII is *technically* a subset of HCI — AI systems are computer systems, so an
 | Latency budget | ~100ms or it feels broken | 200ms–10s, often visible to user |
 | Cost per interaction | Effectively zero | Non-trivial, varies by model |
 
-Each row is a design assumption HCI baked in over four decades that HAII has to consciously *unbake*. A HAII designer cannot reach for "the system always responds the same way" or "latency is invisible if it's under 100ms" or "the system never says something untrue." The whole grammar has to be re-derived.
+Each row is an assumption HCI baked in over four decades that HAII has to consciously *unbake*. A HAII designer cannot reach for *"the system always responds the same way"* or *"latency is invisible if it's under 100ms"* or *"the system never says something untrue"*. The whole grammar has to be re-derived.
 
 This is why HAII is its own thing rather than a chapter in the HCI textbook. It is operating on a substrate the textbook did not anticipate.
 
-### D. Concrete harness-level wins — worked examples
+### Where value compounds
 
-Empirical results from the OpenCues codebase that show what HAII work actually achieves:
+Much of what users feel as "AI got better" has come from harness work, not just from new model capability. Better prompts, narrower jobs, smarter caching, sequential composition instead of single-shot: these compound dramatically without retraining anything.
 
-- **Narrow jobs > wide jobs.** The 3-pass transform-blank pipeline (EXTRACT → APPLY → VERIFY) outperforms single-call by ~70 percentage points on the same model. Splitting the work, not improving the model, is what unlocked the accuracy.
-- **Sequential composition for "X and Y" instructions.** Asking ONE LLM call to "pluralize AND make past tense" → 47% accuracy. Splitting into two sequential calls → 73%. The model handles one transform at a time much better than two; the harness orchestrates.
-- **Output tokens dominate latency.** A 320-line prompt with short output beats a 60-line prompt with long output. Implication: optimise for output efficiency, not input compression.
-- **EDITS vs DECISIONS format (agent-task).** The harness asks the model to emit only edits (not "verdict per word"). Result: 97–100% pass rate vs 93–97%, 30% lower median latency, **5× faster on 200-word docs at 100% recall vs 25%**. Same model, harness change.
-- **Always-claim + LLM classifier > heuristic gating.** Earlier transform-blank versions used a regex/keyword heuristic to decide whether to fire. Brittle. Switching to "always claim + let the LLM say NONE" added one ~400ms call per non-transform `_` but eliminated a class of misclassifications. Cleanliness gain bought with a known latency cost.
-- **Soft-fail on rate limit.** Catch in the client, return empty, let the next debounce be the implicit retry. No retry loop inside `runOnce` — that would compound rate-limit failures. UX consequence: user sessions don't crash on transient failures.
-- **Reserve reasoning headroom in `max_tokens`.** Earlier `max_tokens` floor was 128; long-text accuracy dropped 85% → 50% on truncation. Floor of 768 fixed it. Lesson: when using `reasoning_effort: 'low'`, you need budget for *both* reasoning + output, not just output.
+The ratio of effort spent on models versus harnesses is currently lopsided. A handful of organisations on the planet have the resources to push the model frontier. Many orders of magnitude more contributors can push the harness frontier. The press coverage goes to the first group; the experienced quality gains go to the second.
 
-Every one of these is a harness-level decision that changed user-felt quality without touching the model. None of them required GPUs.
+A few directional lessons from the OpenCues codebase that show what harness work actually achieves:
 
-### E. The bewilderment quote, grounded in Musashi
+- **Narrow jobs beat wide jobs.** In the transform-blank benchmark on `gpt-oss-120b`, splitting a single LLM call into a multi-pass pipeline outperformed the single-call version substantially. The same lesson applies to instruction composition: asking one call to do "X and Y" performed worse than splitting into two sequential calls.
+- **Output tokens dominate latency.** A long input prompt with short output is faster than a short input prompt with long output. Optimise for output efficiency, not input compression.
 
-The pull-quote at the end is a direct read of Miyamoto Musashi's *Book of the Void* (see post #6 for the fuller treatment). Musashi's distinction:
+Every one of these is a harness-level decision that changed user-felt quality without touching the model.
 
-- **Bewilderment** = mistaking "I don't know what's there" for the void.
-- **The void** = the un-built thing, surfaced by deeply knowing what *is* there.
+### Local models as the opportunity
 
-Engineers and designers tackling AI face Musashi's bewilderment constantly. They do not know what a HAII *could* be, so they default to the only AI HCI they have seen: a chat box. The chat box is not the void. It is the bewilderment. It is the shape we reach for when we have not yet mapped what is actually possible.
+There is a swath of open-source models, many of which run on consumer hardware. gpt-oss, Llama 4, Qwen 3, Phi-4, Gemma 3, Mistral Small, Mixtral, DeepSeek R1. The gap is not that local models don't exist; the gap is that the harnesses on top of them have not been optimised for the smaller-model regime.
 
-The discipline this post is calling for — "not settling for the status quo" — is Musashi's discipline applied to HAII. Know the prior art (the chat box, the autocomplete pop-up, the IDE assistant pane) deeply enough that the *gaps in it* become visible. The gaps are the void.
+The narrow-jobs lesson matters more on local models, not less. A weaker model fed wide prompts hallucinates and bails. The same weaker model fed narrow single-purpose prompts in a multi-pass pipeline performs dramatically better, because each step is something it can do, even if the whole task is not.
 
-OpenCues' two-direction model is one attempt at one of those gaps. It is not the only one. The whole point of HAII as a discipline is that there are many more gaps to surface, and most are still un-named.
+### The status quo
 
-### F. The two-direction model as the most concrete HAII primitive shipped so far
-
-This post is the manifesto; the rest of the blog series is the demonstration. Worth surfacing here as the spine:
-
-> Two directions of intent on text. **Cues** (system → user) — the LLM offers alternatives the user did not ask for. **Blanks** (user → system) — the user places `_` to summon a value. Same character, infinite uses, dispatched contextually.
-
-This is one HAII primitive. There are obviously others, and the field is wide open. But naming this one in the manifesto post grounds the abstract call-to-action — "develop new HAII" — in something concrete that already exists, ships, and works in production.
-
-### G. Status quo critique unpacked
-
-What "the status quo" actually looks like, listed explicitly so it can be challenged item by item:
+What "the status quo" looks like, listed explicitly so it can be challenged item by item:
 
 - **Chat as the default HCI.** Every new AI product ships a chat box because every previous AI product shipped a chat box.
 - **Provider lock-in.** The model and the product are bundled. Switching the model is a re-purchase of the product.
 - **Cloud-only.** Most products do not work without a network connection.
 - **No inline editing.** Output appears in a separate panel; the user copies it back.
-- **No ownership locks.** The user cannot trust accepted suggestions to stay accepted; the model can re-edit them.
 - **Latency exposed, not masked.** The user watches the spinner.
-- **Single-modal turn-based input.** Type, send, wait, read, type again. No interleaved cues, no in-flight steering.
-- **Settings via dialog.** Configuration is a separate UI surface, not the artifact the user is in.
-- **No revertibility at granularity.** Accept all or reject all; per-word revert is rare.
-- **No different-modality non-blocking cues.** The model cannot signal "I am uncertain" without taking a turn.
+- **Single-modal, turn-based input.** Type, send, wait, read, type again. No interleaved cues, no in-flight steering.
+- **No per-word revertibility.** Accept all or reject all; granular revert is rare.
 
-Each of these is a design choice — not a constraint of LLMs. Each one is open territory for HAII work to challenge.
+Each of these is a design choice, not a constraint of LLMs. Each one is open territory for HAII work to challenge.
 
-### H. Concrete challenges to fellow engineers and designers
+### Tools of today, building tools of tomorrow
 
-What to actually go work on:
+OpenCues is built with what OpenCues offers. Claude Code edits the runtime; LLM-as-judge runs the benchmarks; the prompts are tuned with the model in the loop. The same primitives that help the end user help the developer iterate.
 
-- **Build a HAII for a specialised tool.** Voice transcription editor. In-game chat copilot. Calendar input. Mobile keyboard. AR text input. Each substrate has different constraints; each yields different primitives.
-- **Replace one chat panel in your product with an inline primitive.** Even one. Pick a feature where users currently switch to a chat surface and think about what `_`, dim+cycle, or in-place edit could do for that feature instead.
-- **Run benchmarks on your harness.** Document the deltas. Share the experiment logs.
-- **Author cue/blank packs for a domain you know deeply.** Legal, medical, financial, gaming, music production, accounting, copywriting. Each domain has vocabulary and conventions that a domain expert can encode and an LLM cannot infer.
-- **Port OpenCues to a new substrate.** The runtime is host-agnostic. Each new host opens a new class of users to inline primitives.
-- **Optimise a known harness for local models.** Take a working pattern (transform-blank, agent-task) and tune it for a 7B local model. Surface what breaks, what stays, what needs rethinking.
-- **Write the post-mortem.** When your harness ships and fails, write up *why*. The field has very little of this material.
+### A two-direction model on text
 
-### I. Local models as a HAII opportunity, expanded
+One concrete HAII primitive, demonstrated by the rest of this series:
 
-The post mentions this. The expansion worth making explicit:
+> **Cues** (LLM → user): the system surfaces useful information directly in the user's text.
+>
+> **Blanks** (user → LLM): the user places `_` to request assistance, answered in place.
 
-- **Architecture is already substrate-agnostic.** OpenCues calls the model through an `LLMRequest` interface with `endpoint`, `model`, `apiKey` as config inputs. Local providers (`llama.cpp`, `ollama`, `vllm`, `mlx`) can plug in by satisfying the interface. The runtime does not care.
-- **The gap is not "local models don't exist."** Phi-3, Llama-3.1-8B, Qwen-2.5, Gemma — all run on consumer hardware. The gap is that the *harnesses* on top of them have not been optimised for the smaller-model regime.
-- **The narrow-jobs lesson matters MORE on local models.** A weaker model fed wide prompts hallucinates and bails. The same weaker model fed narrow single-purpose prompts in a 3-pass pipeline performs dramatically better, because each step is something it can do, even if the whole task is not.
-- **Latency budgets are tighter on local models.** TTFT is faster (no network round-trip) but per-token speed is often slower. The harness has to be designed around this profile (fewer output tokens per call, more parallel calls, more aggressive caching).
+### Looking forward
 
-The opportunity: a harness that makes a local 8B model feel as good as a cloud 70B model for inline primitives. This is not an unrealistic target; the harness lessons that already exist suggest it is reachable.
+I would like to challenge engineers and designers around the world not to settle for the status quo (however good or well-funded it is) and to ponder what the future could be. The status quo persists because alternatives are invisible. Make alternatives visible by shipping, benchmarking, naming, and sharing, and the status quo becomes negotiable.
 
-### J. Tools of today, building tools of tomorrow — the bootstrap angle
+> Bewilderment is the enemy of invention.
 
-Worth making explicit because it is itself a HAII pattern:
+We should use the tools of today to build the tools of tomorrow.
 
-OpenCues is being built using OpenCues' substrate. Claude Code writes a chunk of the runtime code. The benchmark suites run via LLM-as-judge. Prompt design itself is iterated with help from the model. The transform-blank prompts were tuned against the transform-blank benchmark with the model in the loop.
+---
 
-The tool is being bootstrapped on the substrate it serves. That is a HAII pattern in itself — *AI as developer tool*, separate from AI as end-user tool. The same primitives (cues, blanks, in-place editing, narrow-jobs split) that help the end user also help the developer building the next iteration.
-
-The "tools of today to build the tools of tomorrow" line is not a slogan; it is a description of the actual development loop.
-
-### K. Why HAII is genuinely its own discipline (not HCI applied to AI)
-
-AI introduces capabilities and failure modes HCI never had to deal with:
-
-- **Output is generated, not retrieved.** Classical HCI assumed the system returned predetermined responses. AI returns synthesised ones. Every HCI principle about predictability has to be re-evaluated.
-- **Behaviour shifts between sessions.** A user's mental model of "what the system does when I press X" breaks when the model gets upgraded. HCI assumed the system was stable.
-- **Both input and output can be ambiguous and long-form.** HCI optimised for narrow inputs (clicks, short text fields) and narrow outputs (status messages, short results). AI accepts paragraphs and emits paragraphs.
-- **The system can be wrong in plausible ways.** A confidently-stated wrong answer is a failure mode HCI did not have to design for. Verification, ownership locks, revertibility — all needed.
-- **Latency is variable by design.** Classical HCI strived for sub-100ms response. AI routinely takes 200ms-10s. New patterns needed: optimistic UI, in-place markers, async patterns where the user keeps moving.
-- **Calls are expensive.** Free clicks are over. Every interaction has a cost; harness design has to balance UX and economics.
-- **The system can take initiative.** The agent-task pattern (system edits the user's text on its own schedule) has no analogue in classical HCI. Designing for "when does the system act on its own?" is new.
-
-Each of these is genuinely new territory. Calling the discipline "HCI" obscures the size of the new design space. Calling it HAII names it and makes it investible.
-
-### L. The community-first angle — what "not settling" looks like
-
-Practical answer to "how do engineers and designers contribute":
-
-- **The OpenCues runtime is open-source.** Anyone can read it, fork it, port it.
-- **Cue and blank authoring is folder-drop with hot-reload.** No code, no build, no deploy. Drop a `cue.md` in `~/.cues/cues/<name>/`; the next keystroke picks it up. Lowest possible barrier to "I made a thing that works."
-- **Community packs are the distribution path.** Domain experts can publish curated cue/blank libraries; users install them. The system was designed for this from day one (the `host-compat`, `match:`, `keywords:` fields, the `opencues import` CLI).
-- **Benchmarks are the evidence layer.** OpenCues' transform-blank and agent-task benchmark suites are public. New harness ideas can be tested against the same suites; results are comparable across contributors.
-- **Naming the discipline (HAII) matters.** Once a discipline has a name, contributors can find each other. This post is partially that naming move.
-
-The status quo persists because alternatives are invisible. Make alternatives visible — by shipping, benchmarking, naming, sharing — and the status quo becomes negotiable.
+See Also: [HCI](hci-human-to-computer-interface.md) · [Human Interaction](human-interaction.md) · [Inline Cues](inline-cues-continuous-onboarding.md) · [Inline Prompting](inline-prompting-blank.md) · [Inline Agents](inline-agents.md) · [Cross-domain Pollination](cross-domain-pollination.md)

--- a/docs/blog/posts/hci-human-to-computer-interface.md
+++ b/docs/blog/posts/hci-human-to-computer-interface.md
@@ -3,12 +3,12 @@ title: HCI (Human to Computer Interface)
 date: 2026-05-06
 description: HCI is any means through which we interface with a computer. The sharpest framework I know for evaluating one is borrowed from fighting games.
 tags: [hci, framework, fighting-games, foundational]
-cross_links: [inline-cues-continuous-onboarding, inline-prompting-blank, inline-agents, cross-domain-pollination, seamlessly-integration]
+cross_links: [human-interaction, inline-cues-continuous-onboarding, inline-prompting-blank, inline-agents, cross-domain-pollination, seamlessly-integration]
 ---
 
 # HCI (Human to Computer Interface)
 
-A human-to-computer interface is any means through which we interface with a computer system, not just hardware. Sliders, dials, buttons, widgets, touchscreens, keyboards, chat windows, dropdown menus, command palettes, swipe gestures, swipe-to-type: all are HCIs, all were invented by someone, all were chosen over alternatives.
+A human-to-computer interface is any means by which we interact with a computer system, not just hardware. Sliders, dials, buttons, widgets, touchscreens, keyboards, chat windows, dropdown menus, command palettes, swipe gestures, swipe-to-type: all are HCIs, all were invented by someone, all were chosen over alternatives.
 
 I have spent seven years inventing and patenting HCIs at Command Stick, across desktop, mobile, tablet, and smartwatch platforms. The work taught me to evaluate HCIs more rigorously than my discipline typically does, and that rigour came from an unexpected place.
 
@@ -46,7 +46,7 @@ How long the HCI's process actually takes to finish, from the moment the user in
 
 A blocking modal is the canonical bad case: the user initiates the action and is prevented from doing anything else until it completes. Active window duration cannot be circumvented with background processes. If the user needs the result to proceed, they are still waiting for it to return. Allowing them to keep typing while the operation runs softens the perceived cost but does not shorten the actual duration. The operation's time-to-completion governs how soon the user can move onto the next task.
 
-Reducing active window duration is the HCI design decision that lets the user get onto their next task sooner, and extends where the HCI can be applied (as does optimising start-up frames and end-lag).
+Reducing active window duration is the HCI design decision that lets the user move onto their next task sooner, and extends where the HCI can be applied (as does optimising start-up frames and end-lag).
 
 ### End-lag
 
@@ -96,4 +96,4 @@ We are entering an era where the substrate is shifting again. LLMs unlock a clas
 
 ---
 
-See Also: [Inline Cues](inline-cues-continuous-onboarding.md) · [Inline Prompting](inline-prompting-blank.md) · [Inline Agents](inline-agents.md) · [Cross-domain Pollination](cross-domain-pollination.md) · [Seamless Integration](seamlessly-integration.md)
+See Also: [Human Interaction](human-interaction.md) · [Inline Cues](inline-cues-continuous-onboarding.md) · [Inline Prompting](inline-prompting-blank.md) · [Inline Agents](inline-agents.md) · [Cross-domain Pollination](cross-domain-pollination.md) · [Seamless Integration](seamlessly-integration.md)

--- a/docs/blog/posts/human-interaction.md
+++ b/docs/blog/posts/human-interaction.md
@@ -10,7 +10,7 @@ cross_links: [hci-human-to-computer-interface, inline-cues-continuous-onboarding
 
 Humans don't really take turns. While one person speaks, the other steers via nods, expressions, micro-vocalisations, and glances at the door. The resulting conversation feels fluent because the listener never has to wait their turn to be heard.
 
-Current LLM chat strips all of this away. The user types, submits, waits, reads, types, submits. As Head of HCI (Human to Computer Interface) at Command Stick, I find this gap fascinating, and pivotal to where AI HCI should go next.
+Current LLM chat strips all of this away. The user types, submits, waits, reads, types, submits. As Head of HCI (Human to Computer Interface) at Command Stick, I find this gap fascinating, and I believe it is pivotal to where AI HCI should go next.
 
 ---
 
@@ -33,7 +33,7 @@ Each is sub-second, non-blocking, and on a different modality from the speaker's
 
 Humans have already invented digital versions of this pattern. The reactions in WhatsApp let you respond to a message without producing a new message that shifts the chat window. Typing indicators ("Wilfred is typing...") signal that someone is composing without producing a chat message of their own. Read receipts mark acknowledgement without requiring a reply. Google Docs presence cursors show another user's caret moving in real time, on a separate visual layer, without disturbing the document.
 
-The pattern extends into single-user software too. Spell-check red squiggles since the 1990s, Grammarly underlines, IDE inlay hints, Copilot ghost text, browser address-bar autocomplete, search-engine "did you mean...?" suggestions: each is a system → user cue that lives in a separate visual layer and is fully ignore-able. The user takes the suggestion or not, with no commitment cost on either side.
+The pattern extends into single-user software too. Spell-check red squiggles (since the 1990s), Grammarly underlines, IDE inlay hints, Copilot ghost text, browser address-bar autocomplete, search-engine "did you mean...?" suggestions: each is a system → user cue that lives in a separate visual layer and is fully ignorable. The user takes the suggestion or not, with no commitment cost on either side.
 
 Each of these surfaces shares a structural property: the cue lives outside the user's primary input channel. It steers without blocking.
 
@@ -49,13 +49,13 @@ We have regressed from human conversation rather than matched it. Faux turn-base
 
 ### Why non-blocking cues work: the modality rule
 
-Underneath the examples is one mechanism. Two people speaking at the same time produces chaos. Two people texting each other in real time produces interleaved confusion. But one person speaking and the other nodding produces *steered* communication, because nodding doesn't occupy the audio channel.
+Underneath the examples is one mechanism. Two people speaking at the same time produce chaos. Two people texting each other in real time produce interleaved confusion. But one person speaking and the other nodding produces *steered* communication, because nodding doesn't occupy the audio channel.
 
 The same principle explains why the WhatsApp reaction works and why a "👍" sent as a message would not. The reaction lives in a separate visual layer attached to the original message. The same emoji sent as a message would shift the chat window and demand attention from the recipient as they composed their reply.
 
 This should be a foundational rule when designing AI HCIs:
 
-> To create an optimal experience, any cue between a user and an AI system should use a different modality than the user's primary input channel.
+> To create an optimal experience, any cue between a user and an AI system should use a different modality from the user's primary input channel.
 
 If the user is typing, the system's cue can be a visual mark, an underline, a status-line note. It cannot be a popup that takes focus. If the user is speaking, the system's cue can be visual or haptic. It cannot be audio that competes with the user's voice. The modality rule is what separates a cue that helps from a cue that interrupts.
 

--- a/docs/blog/posts/inline-agents.md
+++ b/docs/blog/posts/inline-agents.md
@@ -1,141 +1,130 @@
+---
+title: Inline Agents
+date: 2026-05-24
+description: An LLM that edits the user's draft continuously, in place, on every pause-in-typing. The continuous extension of Inline Prompting.
+tags: [hci, agents, blanks, mechanic, continuous-editing]
+cross_links: [hci-human-to-computer-interface, human-interaction, inline-prompting-blank, inline-cues-continuous-onboarding, seamlessly-integration]
+---
+
 # Inline Agents
 
-Upon stumbling across the HCI needed to enable Inline prompting I wondered what is the natural final form of this technology.
+Inline Agents run an LLM continuously over the user's draft, editing in place on every pause in typing. The user starts the agent with one phrase, keeps writing, and the agent's edits appear as dimmed words in the same text.
 
-Being an avid Claude Code user I wondered what would an "Inline Agent", what capabilities could it have and how could it help a user by creating a 'Google Docs' always available assistant.
+The starting gesture is `agentically <task> _`. From that point on, every pause sends the surrounding text to the LLM with that task as the prompt. Any edits the LLM makes are applied directly to the text and dimmed so the change is visible. To revert an edit, the user navigates to the dimmed word with `Ctrl+Alt+Left/Right` and cycles back to the original with `Ctrl+Alt+Down`.
 
-My desire was to build off the UI-less foundation of Inline-prompting by having the experience purely defined inline thus maintaining the wide scope of areas it could be deployed.
-
-One of my initial fears was as per usual with agents… this thing could go 'south'. How do you design an agent system which can be maximally ambitious whilst limiting it in some fundamental way.
-
-My conclusion was to 'NEVER' allow the agent to press 'enter'. It does not solve every security issue but it does provide one fundamental limitation and scopes the security vulnerabilities somewhat…
-
-The idea of an Inline Agent is an agent which exists within a body text and can be provided a 'task' to perform continuously as you are working on a document. E.g.
-
-- (List example usecases of an inline agent)
-
-I am excited to work with the community to expand the concept of Inline Agents into the 'Google Doc-ifying' of every input box.
-
-We have a lot of work to do in terms of developing the harness, means of benchmarking but I believe this technology can become the ultimate 'co-pilot' and assistance which can follow you everywhere **without** being tied to any specific provider. In the future (or if someone sends a PR) I imagine Inline prompting and Inline Agents running off local agents assuming they're fast enough on TTFT (Time to first token).
-
-(Explaination of the structure of Inline Agents)
-
-I view Inline Agents as a paradigm shift in terms of how we view working with AI. It is working alongside us 'natively' within the same format and user interface we use to perform a task. The complexity is obfuscated behind a Blank. We are attempting to take the best aspects of Inline Prompting and turn it into an lightweight agentic process which can be used anywhere **cheaply**.
-One of the great learnings I have from working within the terminal is the appreciation for the initial simplicity of the apps/ interfaces I was met with as adopting agentic tools. When multiple humans are interfacing via Google Docs, we do not 'need' advanced user interfaces, we 'can' leave inline comments and it is on the human's judgement to determine the task at hand and execute it. I aspire for Inline Agents to capture that natural human simplicity and naturally fit into our lives where appropriate.
-
-Side note: Now is an awesome time to become an inventor, the communities on reddit, twitter etc are so eager to adopt new technologies and work together to build better tools for all. I have never been more excited to utilise my skills an inventor to contribute to the opensource.
+[Inline Prompting](inline-prompting-blank.md) gave the user a way to summon one LLM response per `_`. Inline Agents keep the LLM running continuously, re-checking the user's text on every pause in typing.
 
 ---
 
-## STAGING NOTES (not yet formatted)
+### Prior to Inline Agents
 
-### A. Example use-cases of an Inline Agent
+Existing agentic tools live on a separate surface. A chat panel. A side window. A modal review pane. The user types in their document, switches to the panel, describes the task, waits, reads the agent's response, copies the output, switches back, pastes, edits. Every round trip costs the user two context switches: one out of the work, one back into it.
 
-A reasonably complete list of armed-task shapes the system handles today, each generalised from the same loop with no per-case code changes:
+The cost is paid even when the agent's contribution is small. Fixing one typo by routing through a chat panel costs more than retyping the word by hand. Most users skip the round trip and accept the typos. The example is trivial; the friction it exposes is not.
 
-- `agentically correct spelling _` — typos get fixed on every pause-in-typing
-- `agentically convert to british english _` — `colour`, `harbour`, `realise` propagated through the doc
-- `agentically use inclusive language _` — pronoun and term substitutions
-- `agentically polish for LinkedIn _` — register shift toward professional tone
-- `agentically be more concise (twitter-style) _` — compression + word economy
-- `agentically translate days to spanish _` — `Monday → lunes`, etc., everywhere they appear
-- `agentically use medical terminology consistently _`
-- `agentically use legal precision _`
-- `agentically fix grammar _`
-- `agentically maintain past tense _`
+The deeper issue is that the agent's edits live somewhere else. The user has to leave the work, look at a diff, accept or reject items in a review surface, and return. There is no way for the agent and the user to work in the same text at the same time.
 
-Composed tasks via accumulation:
+### With Inline Agents
 
-```
-agentically correct spelling _              →  prompt = "correct spelling"
-add task fix grammar _                      →  prompt = "correct spelling AND fix grammar"
-add task convert to british english _       →  prompt = "correct spelling AND fix grammar
-                                                AND convert to british english"
-```
+The user starts a task in the text they are already in (`agentically correct spelling _`) and continues typing. The agent runs in the background after a brief pause. When it decides on an edit, it applies the edit immediately and dims the new word so the change is visible. There is no accept gesture; ignoring the dim is acceptance. To revert an edit, the user navigates the cue-selection indicator to the dimmed word with `Ctrl+Alt+Left/Right` and cycles back to the original with `Ctrl+Alt+Down`. The user never left the document; the agent never asked them to.
 
-Every pulse sends the *full accumulated prompt*. The LLM applies all sub-tasks in one pass. This avoids the "task A and task B edit the same word differently" coordination problem that parallel-tasks would cause.
+The trigger phrase itself is wiped from the text when the agent starts, the same way [Inline Prompting](inline-prompting-blank.md) wipes its summon words. What remains is the user's draft, plus a `[task: correct spelling]` line in the status display.
 
-The benchmark suite proved this generalises across all of the above with **no code changes**. Everything is in the prompt.
+---
 
-### B. The structure of Inline Agents
+### The four trigger phrases
 
-The four trigger phrases (the entire user-facing surface):
+The entire user-facing surface of Inline Agents is four phrases. There is no special syntax, no flags, no configuration.
 
-| You type | What it does |
+| Gesture | What it does |
 |---|---|
-| `agentically <X> _` | Replace the active task with `<X>`. Status line lights up `[task: <X>]`. The trigger phrase is wiped from the buffer (same WIPE pattern fluid blank uses). |
-| `add task <X> _` | Append: prompt becomes `<old> AND <X>`. Cache invalidates so the whole doc is re-evaluated against the new prompt. |
-| `stop task _` | Disarm. Status line clears. Existing dimmed edits stay in the buffer — the user reverts any individually if they want. |
-| `current task _` | Substitute the current prompt at `_` so the user can see what is armed. |
+| `agentically <X> _` | Start the agent on task `<X>`. Wipe the trigger phrase. Status display lights up `[task: <X>]`. |
+| `add task <X> _` | Append `<X>` to the active task. Prompt becomes `<old> AND <X>`. The whole document is re-evaluated against the new prompt. |
+| `stop task _` | Stop the agent. Status display clears. Existing dimmed edits remain in the text; the user reverts any individually if they want. |
+| `current task _` | Print the active task at `_` so the user can see what is running. |
 
-What runs under the hood:
+Task composition is by accumulation, not by parallel agents. `agentically correct spelling _` followed by `add task fix grammar _` becomes one prompt: `correct spelling AND fix grammar`. Every run sends the full accumulated prompt. The LLM applies all sub-tasks in one pass. This avoids the *task A and task B edit the same word differently* coordination problem that parallel tasks would create.
 
-- A **debounced loop** subscribed to text-change. Reuses the resolver's existing 500ms debounce — there is one clock for the whole system, not multiple competing heartbeats.
-- A **per-word evaluation cache** keyed by `(taskId, textHash)`. A word that was already evaluated under the current task and whose text has not changed is skipped.
-- A **cursor-adjacency exclusion** — the word the user is currently typing is never sent to the LLM (see H below).
-- An **ownership exclusion** — words owned by other sources (fluid blank, transform blank, keyword-bound blank, multi-word static cycling) are skipped. The agent never touches positions another source claims.
-- The **edit pass** asks the LLM "given this prompt and these candidate words, return the edits." The LLM returns a list of `{wordIndex, originalWord, editedWord}` tuples (or empty).
-- Each edit lands as a `WordDef` in the existing dim-render pipeline. Cycling Down on any edit reverts to `alternatives[0]` (the original word) — same primitive used everywhere else in OpenCues.
+### The cursor-adjacency rule
 
-### C. Why the existing architecture absorbed Inline Agents almost for free
+One of the key UX details. The agent never edits the word the user is currently typing.
 
-This is the strongest single architectural insight in the project. From the architecture reference:
+```
+I have somm con|
+  → agent fixes "somm" to "some"; skips "con" (still being typed)
 
-> The agent's edits are *indistinguishable from any other LLM source's results* at the data-structure level. They live as `WordDef` entries in `DynDefs`, get dimmed by `DimRender`, get skipped by the Resolver's 4-condition filter, get reverted via cycling. **Zero new ownership machinery required** — just plug into existing primitives.
+I have somm concerns|
+  → agent evaluates "concerns" normally; no fix needed
+```
 
-What this means concretely: the agent feature did not require any new visual code, any new cycling code, any new ownership code, any new state-management code. The runtime's primitives were already generic enough. The only new pieces:
+Without this rule, the agent fights the user's typing. It autocorrects partial words mid-keystroke, creating a tug-of-war between the user's intention and the agent's interpretation. This exclusion is small and specific, but it is the rule that makes the agent feel cooperative instead of adversarial.
 
-- A state singleton holding the active task prompt and per-word evaluation cache.
-- A loop module subscribing to text-change.
-- Three new EXTRACT verdicts so transform-blank routes task-arming inputs to the agent.
+### Track changes without the review pane
 
-Everything else — visibility, cycling, ownership, filtering — was already there for the cues, fluid blanks, transform blanks. It was doing structural work in a way the original designers did not have to plan for. **A two-direction framework that holds the right shape makes new affordances multiply** without proportional code growth.
+Existing AI-edit features imitate Word's review pane: a separate surface where the user sits down to triage agent suggestions. Inline Agents do the same job without the surface.
 
-### D. Sharpen "never press enter" — the irreducible safety primitive
+- Edits are dimmed inline. The user sees them in the flow of their text.
+- Reverting an edit is two keys: navigate to the dim with `Ctrl+Alt+Left/Right`, then cycle back with `Ctrl+Alt+Down`. No *right-click → reject suggestion*. No popup confirming the rejection.
+- There is no *approve all* or *reject all* modal. Each edit lands automatically; reverting is the only per-word gesture the user needs. The whole draft is committed when the user submits it, however the host handles submission (`Enter` in a chat input, Send in an email client, posting a form).
+- Triage happens as the user composes; there is no separate review session.
 
-The post mentions this in passing. It deserves to be elevated because it is the actual security boundary, not a pragmatic limit:
+Google Docs Suggestions established the per-edit grain and the live-update flow; Inline Agents extend the same model into every text field, with an LLM as the proposer rather than another human.
 
-The agent edits *in place* in the user's text. The user is *always* the one who finally commits the action — by hitting Enter, by sending the message, by submitting the form. The agent's edits are *proposals the user has not yet committed*.
+### The agent never presses Enter: the safety boundary
 
-This is meaningfully different from the standard agentic-tool design:
+The agent edits in place in the user's draft. The user is the one who finally commits the action by pressing `Enter`, by sending the message, by submitting the form. Until then, every change the agent has made lives only in the user's unsent draft.
 
-- **Standard agents** can take terminal actions, send messages, modify files, commit code, hit external APIs. The blast radius is whatever the agent's tools allow.
-- **Inline Agents** edit text in a buffer the user has not yet submitted. The blast radius is "the user's draft, which they have not sent yet."
+This is meaningfully different from standard agentic-tool design.
 
-The boundary is not "limit the agent's tools." It is **"the agent never crosses the surface where the user's draft becomes a committed action."**
+- **Standard agents** can run terminal commands, send messages, modify files, commit code, call external APIs. The blast radius is whatever the agent's tools allow.
+- **Inline Agents** edit text in a draft the user has not yet submitted. The blast radius is the user's draft, which they have not sent yet.
 
-This is also why the agent does not need separate per-feature permission prompts, sandbox escapes, or undo machinery. The user's draft is the undo. If they do not like an edit, they revert it (Down). If they do not like the whole batch, they do not press Enter.
+The safety boundary is not *limiting the agent's tools*; it is *never letting the agent cross the surface where the user's draft becomes a committed action*.
 
-### E. Track-changes via cycling, not via review-and-accept UI
+### Remembering what has been checked
 
-Inline Agents productise "track changes" without the modal review step. From the post's "Google Doc-ifying" framing, this is the concrete UX move:
+This is the mechanism that makes the agent feel coherent across edits and prompt changes.
 
-- Edits are dimmed inline. The user sees them in the flow of their text, not in a side panel.
-- Reverting an edit is one keystroke (Down on a dimmed word). No "right-click → reject suggestion." No popup confirming the rejection.
-- There is no "approve all" or "reject all" modal. The user makes per-word decisions by *moving the cursor*. Pressing Enter at the end is the only commit.
-- There is no "review session" surface where the user sits down to triage agent suggestions. Triage happens *as the user is composing*.
+The agent compares the current document to the last one it processed. If the text, the task, and the cursor position are all unchanged, the agent skips the run entirely. If any of them differ, the agent checks a small cache of recent rewrites for an exact match before calling the LLM. Things that force a re-run:
 
-This is a real shift. Most "AI track-changes" UIs imitate Word's review pane — a separate surface where the user sits down to triage. Inline Agents do triage in the typing flow itself.
+1. **Document text changed** → recompute.
+2. **Task changed** (via `agentically` or `add task`) → recompute.
+3. **Cursor moved** to a different sentence → recompute. The same word can need different edits depending on the sentence it sits in.
 
-### F. The 3-axis framework applied to Inline Agents
+The auditor list and the window-size setting also invalidate the cache when they change, though they rarely do.
 
-(Using the framing from post #1, the proper read of the three axes for Inline Agents.)
+Practical consequence: when the user runs `correct spelling` for a while, then types `add task fix humour _`, the task no longer matches and the agent re-reads the entire document on the next run. The user gets the right behaviour without thinking about it.
 
-- **Start-up frames** — one phrase to arm: `agentically <task> _`. The user does not leave the document to issue the arming. They do not switch to a chat panel, an agent dashboard, or a settings page. The arming happens in the same buffer they were already typing in.
-- **Active window** — once armed, the agent runs in the background on the debounce. The user keeps typing. They are not prevented from doing other things while the agent thinks. Edits arrive into the dim layer, not into the user's typing flow.
-- **Cool-down (end-lag)** — edits land in the document the user is already in. Reverting an edit is one keystroke. Stopping the agent (`stop task _`) takes one phrase, in-line. There is no agent-dismiss UI, no return-to-region navigation, no separate surface to close. The user's region of interest *never changes*.
+### Lightweight: the latency budget
 
-This is the strongest pass of the framework so far. Standard chat-panel agents fail all three axes (you switch surface to start, you wait while it runs, you switch back when it finishes). Inline Agents pass all three because they *never leave the buffer*.
+What "lightweight" means in practice:
 
-### G. Google Docs Suggestions as the lineage
+- **Cadence:** the agent runs after a 1000ms pause in typing by default (configurable via `agent-debounce-ms`).
+- **Per-run latency:** typically a few hundred milliseconds on Cerebras (`gpt-oss-120b`), depending on document size.
+- **Apply-side validation:** the runtime diffs the LLM's rewrite against the buffer it sent, then drops any edit hunk that overlaps text the user typed while the LLM was generating. Rewrites that come back identical, empty, or suspiciously truncated are rejected outright.
+- **Soft-fail:** if the LLM returns nothing or hits a rate limit, the run produces no edits. The next pause is the implicit retry. There is no retry loop inside the run, since that would compound rate-limit failures.
 
-The post invokes "Google Docs always-available assistant" as the aspiration. The closest existing analogue is more specific: **Google Docs Suggestions mode**.
+### Stop semantics: no auto-revert
 
-In Suggestions mode:
-- A proposer marks alternatives in a separate visual layer (strike-through + inline new text + colour).
-- The accepter reviews per-item, per-position.
-- The proposer's marks are non-blocking — the accepter keeps writing while the marks accumulate.
-- Accepting or rejecting a single suggestion is a single click.
+`stop task _` clears the active task and stops the agent. The `[task: ...]` line in the status display disappears. **Existing dimmed edits remain in the text.** The user can revert any individual edit by navigating to the dimmed word with `Ctrl+Alt+Left/Right` and pressing `Ctrl+Alt+Down` to cycle it back to the original.
+
+The principle: don't auto-revert. While the task ran, the user could revert any individual edit; not doing so is implicit consent. Rolling back on stop would erase those consents.
+
+---
+
+### The mechanism
+
+The user-facing surface isn't the only interesting part of Inline Agents. The runtime is too.
+
+The agent's edits are indistinguishable from any other LLM source's results at the data-structure level. They use the same data structure as every other cue. They get dimmed by the same render pipeline that dims [Inline Cues](inline-cues-continuous-onboarding.md). They get skipped by the same ownership filter that protects resolved `_` results. They get reverted via the same cycling primitive the user already knows from word cues.
+
+Adding the Inline Agents feature did not require new visual code, new cycling code, new ownership code, or new state-management code. The runtime's primitives were already generic enough. The agent added a small piece of state (the active task and a small rewrite cache), a routine that listens for text changes, and three new routes that send task-starting phrases to the agent. Everything else was already there.
+
+> A two-direction framework that holds the right shape makes new affordances multiply without proportional code growth.
+
+### Lineage: Google Docs Suggestions
+
+Google Docs Suggestions is the closest existing analogue. A proposer marks alternatives in a separate visual layer; the accepter reviews per-item; the proposer's marks are non-blocking so the accepter keeps writing while marks accumulate; accepting or rejecting a single suggestion is one click.
 
 Inline Agents extend the same pattern with three changes:
 
@@ -143,150 +132,31 @@ Inline Agents extend the same pattern with three changes:
 |---|---|
 | Proposer is another human | Proposer is an LLM |
 | Visual layer is strike-through + colour | Visual layer is the dim |
-| Granularity is per-marked-edit | Granularity is per-word |
-| Trigger is "I'll suggest this" | Trigger is `agentically <task> _` |
+| Default state is the original (suggestion pending) | Default state is the edit applied (original cyclable back) |
+| Acceptance is an explicit click | Acceptance is doing nothing; only reverting is an action |
+| Trigger is *"I'll suggest this"* | Trigger is `agentically <X> _` |
 | Lives in Google Docs | Lives in any text input across any host |
 
-Naming the lineage grounds the "Google Doc-ifying" framing as something already understood, not something aspirational.
+The lineage matters because the per-edit grain and the live-update flow are already familiar to anyone who has used Suggestions mode. Two things are new: the inverted default (edits are live, only reverting is an action) and the in-line starting gesture (`agentically <X> _`).
 
-### H. The cursor-adjacency rule
+### HCI 3-Axis Analysis
 
-The single most important UX detail. The agent never edits the word the user is currently typing.
+Scoring Inline Agents against the HCI (Human to Computer Interface) 3-Axis Analysis:
 
-```
-User types:    I have somm con
-                                ^cursor here
-                                cursor-adjacent word = "con"
+- **Start-up frames:** one phrase to start (`agentically <X> _`). The user does not leave the document to issue the command. No chat panel to switch to, no agent dashboard, no settings page.
+- **Active window duration:** once started, the agent runs in the background after a brief pause in typing. The user keeps typing. They are not prevented from doing other things while the agent thinks. Edits arrive in the dim layer, not in the typing flow.
+- **End-lag:** edits appear in the document the user is already in. Reverting an edit is two keys: navigate to the dim, then cycle back. Stopping the agent (`stop task _`) is one phrase in-line. There is no agent-dismiss UI, no return-to-region navigation, no separate surface to close.
 
-Agent runs:    candidates excludes "con" entirely
-  - May edit "somm" → "some"
-  - Does NOT touch "con" (might become "concerns", "conservatives", "context", ...)
+Standard chat-panel agents incur heavy frames on all three axes: the user switches to another surface to start, waits while the agent runs, and switches back when it finishes. Inline Agents collapse all three because they never leave the text the user is already writing in.
 
-User keeps typing → "concerns"
-Next debounce: candidates now include "concerns" (cursor moved past it)
-  - Agent reads "concerns" in context — no fix needed
-```
+### Looking forward
 
-Without this rule, the agent fights the user's typing — autocorrecting partial words mid-keystroke, creating a tug-of-war between the user's intention and the agent's interpretation. The cursor-adjacency exclusion is small and specific but it is the rule that makes the agent feel cooperative instead of adversarial.
+Inline Agents are the continuous extension of Inline Prompting. Same primitive, same routing surface, same `_` summon, held active across keystrokes rather than running once per `_`.
 
-### I. Per-task invalidation cache
+What I want to see next is local-model integration. The LLM call goes through a generic provider interface, so adding a local provider is a configuration change, not a runtime change. Consumer hardware running quantised 3B-8B models is within striking distance of the sub-second TTFT (Time to First Token) the agent needs to feel snappy. The agent following the user across hosts is already real; the agent running entirely on the user's machine is the next step.
 
-The mechanism that makes the agent feel coherent across edits and prompt changes:
+I am excited to work with the community to extend `Google Doc-ifying` to every input box.
 
-```
-A word is "already evaluated" if and only if:
-  state.evaluations.has(i)
-  AND state.evaluations.get(i).taskId === state.taskId
-  AND state.evaluations.get(i).textHash === currentTextHash
-```
+---
 
-Three ways the cache invalidates:
-
-1. **Word text changed** → re-evaluate that word
-2. **Task changed** (arm or appendToPrompt) → re-evaluate the whole doc
-3. **Task cleared** → loop does not run at all
-
-Practical consequence: when the user runs `correct spelling` for a while, then types `add task fix humour _`, the agent re-reads the *entire* document on the next pulse because every word's cached `taskId` no longer matches. The user gets the right behaviour without thinking about it.
-
-### J. Single growing prompt, not parallel tasks
-
-A deliberate simplification: there is *one* active task at a time. The user grows it with `add task`. There are not multiple parallel tasks running with their own scopes.
-
-Why: parallel tasks would create the "task A says change X to Y, task B says change X to Z, the same word gets edited twice with conflicting outputs" coordination problem. Resolving it requires per-task ownership tracking, conflict resolution, priority decisions — a whole agent-orchestration layer.
-
-The single-growing-prompt design avoids the entire problem class. Every pulse sends the full accumulated prompt. The LLM applies all sub-tasks in one pass and resolves conflicts internally.
-
-This is the same "narrow jobs are easier than wide jobs" insight from the transform-blank pipeline carried into multi-task territory: ask one prompt to satisfy all constraints rather than running multiple competing prompts.
-
-### K. Latency / debounce — grounding "lightweight"
-
-The post claims this is a "lightweight agentic process." Concrete numbers:
-
-- **Loop cadence** — 500ms debounce. Same clock as the main resolver. One pulse fires the agent's evaluation pass.
-- **Per-pulse latency** — ~365ms median in the production EDITS prompt format on Groq.
-- **EDITS vs DECISIONS empirical win** — the EDITS format (only emit lines for actual edits) beat the original DECISIONS format (one verdict per candidate, KEEP or edit) on every dimension: 97-100% pass rate vs 93-97%, 30% lower latency, 5× faster on 200-word docs at 100% recall vs 25%. Output tokens dominate latency; emitting only the edits saves tokens proportional to the size of the doc.
-- **Apply-side defence in depth** — the loop re-validates every edit against the live text and the candidate set before applying. Defends against the model proposing edits to indices it was not asked about.
-- **Soft-fail on rate-limit** — empty response or rate-limit error returns empty edits and logs. Next text-change debounce is the implicit retry. No retry loop inside `runOnce` — that would compound rate-limit failures.
-
-This is what makes "lightweight" substantive instead of marketing. The user is paying ~365ms per debounce pulse for the agent presence, not seconds.
-
-### L. No chat window — the negative-space UX claim
-
-Extends the "no popup" rule from earlier posts. **Inline Agents have no chat panel.** No agent-talks-to-you surface. No conversation log. No assistant icon. No model dropdown. No system-prompt editor. No history viewer.
-
-The agent's presence is exactly two things:
-
-1. The dim words it has edited.
-2. The `[task: ...]` line in the status line.
-
-Everything else is the user's normal text input. The user does not "talk to" the agent. They arm it (`agentically <X> _`), they keep working, the agent edits in the dim layer, the user accepts or reverts by cycling, the user disarms it (`stop task _`).
-
-This is a sharper UX claim than "ultimate co-pilot." Co-pilot typically implies a chat surface. Inline Agents are the co-pilot *minus the chat surface*. The only conversation is the user's own text and the agent's marks on it.
-
-### M. What makes it "the ultimate co-pilot" — concretely
-
-The post claims this. Worth grounding by listing what specifically distinguishes Inline Agents from existing co-pilots:
-
-- **Continuous** — runs on every pause-in-typing, not just on explicit invocation.
-- **In-place** — edits land in the user's draft, not in a side panel.
-- **Ignorable** — the user can ignore every edit; nothing forces engagement.
-- **Revertible** — every edit reverts in one keystroke (Down).
-- **No chat window** — see L above.
-- **Surface-portable** — runs in CC, OC, and Chrome with the same primitives. The co-pilot follows the user across hosts.
-- **Substrate-agnostic** — provider is a config switch, not a build dependency (see N).
-- **Plain-English task definition** — `agentically <task> _` is the entire armed-state syntax. No DSL, no flags, no parameters.
-- **Composable tasks** — `add task <X> _` extends the same prompt rather than spawning a parallel agent.
-- **No commit power** — never crosses the "user submits" boundary (see D).
-
-### N. Substrate portability — not tied to any provider
-
-The post says "without being tied to any specific provider." The mechanism:
-
-- The runtime calls the LLM through a `LLMRequest` interface with `endpoint`, `model`, and `apiKey` as config inputs.
-- Default: Groq (`GROQ_API_KEY`) on `openai/gpt-oss-120b`.
-- Switchable: any OpenAI-compatible endpoint. `OPENAI_API_KEY` works. Anthropic-compatible endpoints with a thin adapter work.
-- Future: local models via the same interface — see O below.
-
-The implication: the user's choice of provider is a *config decision*, not an architectural one. If a better model ships, the user updates one line of config. If a provider's pricing changes, they switch. There is no vendor lock-in built into the architecture.
-
-This is genuinely different from cloud-locked AI tools where the model and the product are the same thing.
-
-### O. Local-model future — what "fast enough" means
-
-The post mentions "if someone sends a PR" for local agents. The TTFT (time to first token) targets that would make this work:
-
-- **Fluid blank** — ~200ms TTFT to feel responsive. The user is staring at a `_` waiting for it to fill.
-- **Transform blank** — ~500ms TTFT acceptable. The whole pipeline is ~1.4s; some of that is reasoning.
-- **Inline Agent** — ~500ms TTFT acceptable, since the user is not waiting on a single pulse — they are typing while it runs. Throughput matters more than latency-per-pulse.
-
-Consumer hardware in 2026 hits these on small models (3B–8B parameter range with quantisation). A local Llama or Phi running through `llama.cpp` or `ollama` is within striking distance for the agent loop today; the fluid blank is closer to the edge.
-
-The architectural prerequisite is there — the `LLMRequest` interface does not care whether the endpoint is local or remote — so a local-model integration is a *config + harness* PR, not a runtime PR.
-
-### P. Stop semantics — no auto-revert
-
-`stop task _`:
-
-- Clears `AgentTaskState` (taskId, prompt, evaluations all reset).
-- Status line `[task: ...]` disappears.
-- **Existing agent edits stay in the buffer** as DynDefs. The user can revert any individual edit via cycling Down. They can also leave them as-is.
-
-The principle: **don't auto-revert — that would be surprising.**
-
-The user already had every opportunity to revert each edit while the task was running, by cycling Down. Their not-having-reverted is implicit consent. Stopping the task is a stop-the-loop action, not a roll-back-everything-the-loop-did action. Roll-back-everything would erase the user's accumulated yes-decisions on each individual edit.
-
-This is the same "respect prior commitments" principle that makes the ownership lock work for blanks (post #4 section I).
-
-### Q. Engineering lesson — EDITS vs DECISIONS (empirical)
-
-Cross-link to post #18 / Principles of HCI material — the agent-task benchmark produced one of the cleanest engineering wins in the project:
-
-- v1 used a **DECISIONS** format: for each candidate word, return one verdict (`KEEP` or an edit). Output proportional to the number of candidates.
-- v2 switched to **EDITS** format: only emit lines for words that need editing. Output proportional to the number of edits, which is usually small.
-- Result: 97-100% pass rate vs 93-97%, 30% lower latency, **5× faster on 200-word docs at 100% recall vs 25%**.
-
-Why DECISIONS lost: at high candidate counts the model spent its output budget reciting `<idx> | <word> | KEEP` lines and ran out of tokens before reaching real edits. The runtime already provides implicit completeness (every candidate that does not appear in the response is recorded as evaluated and won't be re-asked).
-
-The HCI lesson: **output tokens dominate latency, not input tokens.** A prompt that asks the model to emit a verdict for every input word is paying for a long output. A prompt that asks for only the deltas pays for a short one. For a real-time agent the user feels, this difference is the difference between "snappy" and "sluggish."
-
-(Probably belongs in the Principles of HCI post too, but worth noting here as the empirical foundation for "lightweight.")
+See Also: [HCI](hci-human-to-computer-interface.md) · [Human Interaction](human-interaction.md) · [Inline Prompting](inline-prompting-blank.md) · [Inline Cues](inline-cues-continuous-onboarding.md) · [Seamless Integration](seamlessly-integration.md)

--- a/docs/blog/posts/inline-cues-continuous-onboarding.md
+++ b/docs/blog/posts/inline-cues-continuous-onboarding.md
@@ -1,16 +1,16 @@
 ---
 title: Inline Cues (Continuous Onboarding)
 date: 2026-05-06
-description: Inline Cues are a system-to-user signal that teaches the tool in context, while the user uses it. The structural answer to AI-era feature churn outpacing documentation.
+description: Inline Cues are system-to-user signals that teach users about the tool in context, while they use it. The structural answer to AI-era feature churn outpacing documentation.
 tags: [hci, cues, continuous-onboarding, llm, mechanic]
 cross_links: [hci-human-to-computer-interface, human-interaction, inline-prompting-blank, inline-agents, seamlessly-integration]
 ---
 
 # Inline Cues (Continuous Onboarding)
 
-Inline Cues are system-to-user signals embedded in the text the user is already typing. They surface information about the tool in context, while the user is working, without requiring the user to leave the prompt.
+Inline Cues are system-to-user signals layered onto the user's text. They surface information about the tool in context, while the user is working, without requiring the user to leave the prompt.
 
-Cues activate automatically as the user types in any prompt with cue sources installed. Cues surface as dimmed words; navigate between cues with `Ctrl+Alt+Right` / `Ctrl+Alt+Left`, and cycle through a cue's alternative words with `Ctrl+Alt+Up` / `Ctrl+Alt+Down`.
+Cues activate automatically as the user types in any prompt with cue sources installed. Cues surface as dimmed words. Navigate between cues with `Ctrl+Alt+Right` / `Ctrl+Alt+Left`, and cycle through a cue's alternative words with `Ctrl+Alt+Up` / `Ctrl+Alt+Down`.
 
 Claude Code is a new class of HCI (Human to Computer Interface): an agentic CLI tool, or what I call a Human-to-AI Interface (HAII). I have watched it emerge and evolve while moderating [r/ClaudeAI](https://www.reddit.com/r/ClaudeAI) and building Claude Code learning resources at [ClaudeLog.com](https://claudelog.com). That experience has shown me why continuous onboarding is necessary, and I believe Inline Cues are how to deliver it.
 
@@ -18,7 +18,7 @@ Claude Code is a new class of HCI (Human to Computer Interface): an agentic CLI 
 
 ### Prior to Inline Cues
 
-In the past, a developer could read a tool's documentation, internalise how it works, and trust that mental model would be valid for months. Modern agentic tools break that assumption. They are subject to two compounding sources of variance:
+In the past, a developer could read a tool's documentation, internalise how it works, and trust that the mental model would be valid for months. Modern agentic tools break that assumption. They are subject to two compounding sources of variance:
 
 - **Model variance:** the model behind the tool may shift week-to-week as providers update system prompts, alignment, or pricing.
 - **Harness variance:** the tool itself ships features faster than docs can describe them, partly because the tools are now used to build themselves.
@@ -43,9 +43,9 @@ Six months of iteration was gated by a hard set of design constraints. None of t
 - **No interrupting typing.** No popups, no modals, no taking focus. The user keeps typing while the system thinks.
 - **No overloading rendering meanings.** Bold, italic, and underline are already used to indicate meaning. The cue indicator must not collide with those.
 - **Universality.** The solution must work in any text input on any platform: terminal, browser, mobile, IDE.
-- **Felt latency.** A cue that arrives 30ms after the user has moved on is noise; a cue that arrives 5 seconds later is irrelevant.
-- **Ignorable.** A cue the user does not engage with should cost zero. No dismiss action, no follow-up modal.
-- **Cross-domain isolation.** A cue source for legal terminology must not contaminate one for medical terminology. One bad config should not break the whole system.
+- **Perceived latency.** A cue that arrives 30ms after the user has moved on is visual noise; a cue that arrives 5 seconds later is irrelevant.
+- **Ignorable.** A cue the user does not engage with should not interrupt their experience. No dismiss action, no follow-up modal.
+- **Cross-domain isolation.** A cue source for legal terminology must not contaminate one for medical terminology. Sources must not interfere with each other's output.
 - **Discoverable without docs.** The user must be able to learn what cues exist *while using the tool*, not by reading a manual.
 - **Decoupled from cursor position.** The user's cursor is for typing. The cue-selection indicator must be separate so the user can browse cues without losing their place.
 
@@ -61,12 +61,12 @@ The dim is the entry point. Three primitives compose around it:
 
 Editing a word clears its cue and starts fresh; other words in the input keep their state.
 
-Two cue sources cover the space:
+Two main kinds of cue source:
 
 - **Local cues** are static dictionaries of word → tip + alternatives, loaded into RAM at boot and looked up in roughly zero milliseconds.
-- **Remote (LLM) cues** are domain prompts that fire on words matching a regex or keyword list. Latency 200–500ms.
+- **Remote (LLM) cues** are domain prompts that trigger on words matching a regex or keyword list. Latency typically sub-second on fast providers.
 
-A user defines cues by dropping a `cue.md` file into `~/.cues/cues/<name>/`. The frontmatter declares `match:` (regex) or `keywords:` (list); the body is the prompt or a dictionary of words. Folder-based discovery, no registration, hot-reload picks up changes on the next keystroke.
+A user defines cues by dropping a `CUE.md` file into `~/.cues/cues/<name>/`. The frontmatter declares `match:` (regex) or `keywords:` (list); the body is the prompt or a dictionary of words. Folder-based discovery, no registration, hot-reload picks up changes on the next keystroke.
 
 ### Why the dim works
 
@@ -74,15 +74,13 @@ The dim works because it occupies a different modality from the words the user i
 
 ### Continuous onboarding
 
-The post opened on feature churn outpacing documentation. Inline Cues are the structural answer.
+Feature churn outpaces documentation. Inline Cues are the structural answer.
 
 Inline Cues put the teaching surface inside the prompt. The user types a feature name; the dim signals "there is something to know"; navigation surfaces the tip. The user has learnt the feature in context. There is no documentation site to fall behind, because there is no separate documentation site. When the feature changes, a config file updates and every user picks it up on their next keystroke.
 
-For product owners, this same mechanism gives a fast cycle. A `cue.md` file authored today, dropped into a user's `~/.cues/cues/` or shipped via a defaults bundle, becomes a live cue on the next keystroke. No build, no deploy, no restart.
+For product owners, this same mechanism gives a fast cycle. A `CUE.md` file authored today, dropped into a user's `~/.cues/cues/` or shipped via a defaults bundle, becomes a live cue on the next keystroke. No build, no deploy, no restart.
 
 Continuous onboarding generalises beyond the LLM era. It is the answer to *any* fast-moving substrate where the user's mental model is liable to go stale: product features, terminology, deprecations, community best practices.
-
-> Anywhere the work is the surface, the teaching can live with the work.
 
 ### Looking forward
 

--- a/docs/blog/posts/inline-prompting-blank.md
+++ b/docs/blog/posts/inline-prompting-blank.md
@@ -18,17 +18,17 @@ The summoning character is `_` (underscore). Place it where assistance is wanted
 
 ### Prior to Inline Prompting
 
-Until now, cues have been one-directional. The system surfaces alternatives the user did not ask for; the user dims through their text and finds what is offered. But the user could not provide cues to indicate that they needed assistance or additional data whilst constructing their prompt.
+Until now, cues have been one-directional. The system surfaces useful information directly in the user's text; the user navigates through the dimmed words and finds what is offered. But the user could not provide cues to indicate that they needed assistance or additional data whilst constructing their prompt.
 
 A good prompt steers the model. Iterating on the prompt before submission saves tokens that would otherwise be spent on back-and-forth with an expensive model. Tools to improve a prompt do exist, but using one means leaving the prompt, running the draft through the tool, and copying the result back. The friction is high enough that most users skip the improvement step and submit the raw prompt, accepting the token cost as the cheaper-feeling option.
 
-The bigger issue is the contexts where no AI is available at all. A text field on a website. A note app. A messaging client. A form. If the user needs the assistance of AI while writing in any of these, the logical path is to navigate to a separate AI app, ask the question, copy the answer, and paste it back into the original context. The friction is severe enough that most writing tasks that would benefit from AI assistance never get it.
+The bigger issue is the contexts where no AI is available at all. A text field on a website. A note app. A messaging client. A form. If the user needs the assistance of AI while writing in any of these, the logical path is to navigate to a separate AI app, ask the question, copy the answer, and paste it back into the original context. The result: most writing tasks that would benefit from AI assistance never get it.
 
 ### With Inline Prompting
 
 The user types `_` to turn plain text into an Inline Prompt. The system reads the surrounding text, infers what the user needs, and provides it in place. The user has not had to learn anything beyond placing `_` where assistance is wanted.
 
-What used to require leaving the work now happens inside it.
+What used to require leaving the work now happens within it.
 
 ---
 
@@ -36,17 +36,17 @@ What used to require leaving the work now happens inside it.
 
 Three resolution paths handle the space. The user does not pick which one fires; the surrounding text decides.
 
-- **Lookup blanks.** The most common case. An LLM segments the surrounding text into the question and writes the answer back, preserving any template the user wrote. `4 * 12 = _` → `4 * 12 = 48`. `capital of france _` → `Paris`. `capital of france is _` → `capital of france is Paris`. `5 miles in km _` → `8.05`. The model handles whatever shape the question takes. Latency 600ms to 1.5s.
+- **Lookup blanks.** The most common case. An LLM segments the surrounding text into the question and writes the answer back, preserving any template the user wrote. `4 * 12 = _` → `4 * 12 = 48`. `capital of france _` → `Paris`. `capital of france is _` → `capital of france is Paris`. `5 miles in km _` → `8.05`. The model handles whatever shape the question takes. Latency typically sub-second on fast providers.
 - **Keyword-bound blanks.** For known fast paths. `NVDA _` triggers a stock-price API; `volume _` reads OS audio level (and cycling changes it); `weather london _` returns current conditions. Each registered keyword calls a script or live data source. Fast (no LLM in the loop), deterministic, and writable where the source allows.
-- **Transform blanks.** When `_` is paired with an instruction. `<text> make this formal _` rewrites the text in formal register. `<text> pluralize _` puts plural forms throughout. The system detects the instruction, applies it to the preceding text, and clears the trigger phrase.
+- **Transform blanks.** When `_` is paired with an instruction. `<text> make this formal _` rewrites the text in a more formal tone. `<text> pluralize _` makes everything plural. The system detects the instruction, applies it to the preceding text, and clears the trigger phrase.
 
-Dispatch is by priority: a registered keyword wins over a fluid lookup; an imperative shape wins over plain free-form text; free-form lookup is the default.
+Dispatch is by priority: registered keywords first (`volume _`, `NVDA _`), then blanks paired with an instruction (`<text> pluralize _`, `<text> make this formal _`), then plain lookups as the default (`4 * 12 = _`, `capital of france _`).
 
 ### Why `_` is the right primitive
 
 `_` is on every keyboard. Shift-hyphen on QWERTY, present on every smartphone keyboard, every text input on every platform. No special command, no menu, no plugin. The interaction primitive is *typeable*, and that universality is what lets it port from terminal to browser to mobile.
 
-The character also has a second property: it inverts autocomplete.
+The character also has a second property: it flips the autocomplete model.
 
 Traditional autocomplete pops up suggestions while the user types; the user accepts or dismisses. The system is choosing the moment, the position, and the shape of the suggestion. The user is the responder.
 
@@ -56,7 +56,7 @@ Three further properties make the primitive composable:
 
 - **Ownership lock.** Once a `_` is resolved, only the user can clear the result. No LLM cue can overwrite it. Editing the word releases the lock.
 - **Visible failure.** If the system cannot resolve `_`, the `_` stays. There is no silent *system tried, gave up* state. The user sees the gap and knows.
-- **Multiple `_` per input.** A single text input can carry many `_`s, each dispatched independently and resolved in parallel.
+- **Multiple `_` per input.** A single text input can carry many `_`s, each dispatched independently to its own source.
 
 ### Lineage: fill in the blank
 
@@ -66,7 +66,7 @@ Inline Prompting plugs into that pre-loaded mental model. The user does not have
 
 ### HCI 3-Axis Analysis
 
-Scoring Inline Prompting against the HCI 3-Axis Analysis:
+Scoring Inline Prompting against the HCI (Human to Computer Interface) 3-Axis Analysis:
 
 - **Start-up frames:** one keystroke (`_`), placeable inline at any time. No separate AI app to switch to, no separate prompt box to focus, no new UI to learn. The prompt is constructed in the text the user is already writing.
 - **Active window duration:** sub-second to several seconds, depending on which blank fired and the complexity of the task. The user can keep typing while the blank resolves.


### PR DESCRIPTION
## Summary
- Re-render polish passes on 5 blog posts (hci, human-interaction, inline-cues, inline-prompting, inline-agents, haii); README marks them done
- New CLAUDE.md guidance: plain-language substitutions, meta-narrative cuts, code-claim verification, accurate Inline-Agents mechanics (live edits, arbitrary-span granularity, host-specific submit gesture)
- Inline Agents and HAII rewrites are near-total (>90%) to remove stale per-word/EDITS/Judge references and align with current shipping architecture

## Test plan
- [ ] Skim each re-rendered post end-to-end for tone + voice
- [ ] Confirm no em dashes, no "an HCI", no fictional API names
- [ ] Spot-check code-derived names (provider/model IDs, config keys, filenames) against the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)