### PR TITLE
Wipe per-buffer runtime state on undo / redo / paste / IME

### DIFF
--- a/integrations/chrome/src/content.ts
+++ b/integrations/chrome/src/content.ts
@@ -18,6 +18,7 @@ import {
   isNormalInput,
   readTargetText,
   updateRuntimeApiKeys,
+  notifyBufferReplacedExternally,
 } from './opencues-bootstrap';
 import { clearStatusbar } from './runtime-statusbar';
 import { deriveOpenCuesColours } from './derive-colours';
@@ -198,6 +199,41 @@ async function init(): Promise<void> {
     const text = e.dataTransfer?.getData('text') ?? '';
     const n = (text.match(/_/g) || []).length;
     if (n > 0) noteUserUnderscoreInsertion(n);
+  }, true);
+
+  // ─── Buffer-replacing input events: undo / redo / paste / IME commit ──
+  // The post-mutation text reflects content the runtime didn't author,
+  // so every span / DynDef / dim range the runtime tracks is anchored
+  // to a character offset that no longer corresponds to the buffer the
+  // user is now editing. Without a wipe, the next cycle splices on
+  // stale offsets, the next dim repaints a phantom span, or the next
+  // blank fill is silently blocked by a leftover `blankName` entry.
+  //
+  // `beforeinput` fires BEFORE the DOM mutates and carries `inputType`,
+  // which lets us key off the precise trigger instead of guessing from
+  // keydown. Browser-issued events from real user actions always have
+  // `isTrusted: true`; we drop synthetic dispatches from hostile pages
+  // (same security model as the `_`-credit gates above).
+  //
+  // We DO NOT preventDefault — the browser must still perform the
+  // native undo / redo / paste / IME commit. We only reset the runtime's
+  // in-memory state so the post-mutation buffer is treated as a fresh
+  // edit surface. The Resolver re-runs on the next keystroke debounce.
+  //
+  // Companion to `publishTarget` (same wipe, focus-change trigger).
+  // Per-state-object rationale: docs/architecture/universal-integration.md
+  // § "Per-buffer state must reset on focus change".
+  document.addEventListener('beforeinput', (e) => {
+    if (!e.isTrusted) return;
+    const t = (e as InputEvent).inputType;
+    if (
+      t === 'historyUndo' ||
+      t === 'historyRedo' ||
+      t === 'insertFromPaste' ||
+      t === 'insertCompositionText'
+    ) {
+      notifyBufferReplacedExternally();
+    }
   }, true);
 
   // Forward 'input' events from the focused target to the runtime.

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -244,6 +244,43 @@ export function publishTarget(el: HTMLElement | null): void {
   if (bootResult) bootResult.resetBufferState();
 }
 
+/** Called by content.ts when a `beforeinput` event signals the focused
+ *  buffer is about to be mutated outside the runtime's `setText` /
+ *  `pushText` pipeline. The triggering inputTypes today:
+ *
+ *    historyUndo           — Ctrl+Z / Cmd+Z / Edit-menu Undo
+ *    historyRedo           — Ctrl+Shift+Z / Cmd+Shift+Z / Ctrl+Y / Edit-menu Redo
+ *    insertFromPaste       — Ctrl+V / right-click→Paste / middle-click on Linux
+ *                            (paste-event-trusted gating is done upstream)
+ *    insertCompositionText — CJK / IME composition commit (each composed
+ *                            chunk is owned by the browser, not the runtime)
+ *
+ *  In every case the post-mutation text reflects content the runtime
+ *  didn't author, so the per-buffer state objects (`DynDefs`,
+ *  `HighlightState`, `SpanFillState`, `SelectorSatelliteState`) anchor
+ *  to character offsets that no longer correspond to the buffer the
+ *  user is now editing. Without this wipe, the next cycle splices
+ *  against stale offsets, the next dim repaints against a phantom
+ *  span, or the next blank fill blocks on a leftover `blankName`
+ *  entry from before the undo. Same failure class as the focus-change
+ *  bug `publishTarget` fixes, different trigger.
+ *
+ *  Session-scoped state (`AgentTaskState`, `dismissedBlanks`)
+ *  intentionally survives — an armed `agentically X _` task should
+ *  outlive Ctrl+Z so the user can experiment without re-arming. Per-
+ *  state-object rationale: `docs/architecture/universal-integration.md`
+ *  § "Per-buffer state must reset on focus change" (same wipe set
+ *  applies to both triggers).
+ *
+ *  No-op when boot hasn't completed yet (rare race during initial
+ *  attach) or there's no current target (event fired against an
+ *  unattached field).
+ */
+export function notifyBufferReplacedExternally(): void {
+  if (!bootResult) return;
+  bootResult.resetBufferState();
+}
+
 /** Real-time API-key update — called by content.ts when chrome.storage
  *  reports a host-push or popup-save changed the LLM key bag. The
  *  runtime's BootResult exposes `updateApiKeys` which mutates the

--- a/packages/opencues-runtime/adapters/cc/v2.1/boot.test.ts
+++ b/packages/opencues-runtime/adapters/cc/v2.1/boot.test.ts
@@ -164,4 +164,36 @@ describe('boot()', () => {
     const out = result.applyRender('one two three', host.getText(), 0);
     expect(out).toBe('one \x1b[97mtwo\x1b[39m three');
   });
+
+  // ─── resetBufferState contract ──────────────────────────────────────────
+  // Per-band guarantee that the method is wired. Deep wipe-set + journey
+  // assertions live in `src/modules/reset-buffer-state.scenarios.test.ts`.
+  it('exposes resetBufferState as a method', () => {
+    const result = boot(fakeHost());
+    expect(typeof result.resetBufferState).toBe('function');
+  });
+
+  it('resetBufferState is idempotent on a cold boot (no prior state)', () => {
+    const result = boot(fakeHost());
+    expect(() => {
+      result.resetBufferState();
+      result.resetBufferState();
+      result.resetBufferState();
+    }).not.toThrow();
+  });
+
+  it('resetBufferState clears dynDefs populated by a prior cycle', () => {
+    // Integration-flavoured check at the boot-result level: dispatch a
+    // navigation key to populate dynDefs, then reset, then assert dynDefs
+    // is empty via the BootResult's exposed handle.
+    const host = fakeHost('alpha beta gamma');
+    const result = boot(host);
+    result.dispatchKey({ key: 'left', ctrl: true, alt: true }, host.getText(), 0);
+    expect(result.hlState.active).toBe(true);
+
+    result.resetBufferState();
+
+    expect(result.dynDefs.size).toBe(0);
+    expect(result.hlState.active).toBe(false);
+  });
 });

--- a/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
+++ b/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
@@ -28,7 +28,7 @@ import { HighlightState } from '../../../src/state/highlight-state';
 import { DynDefs } from '../../../src/state/dyn-defs';
 import { SpanFillState } from '../../../src/state/span-fill';
 import { DismissedBlanks } from '../../../src/state/dismissed-blanks';
-import { createSourceReclassifier } from '../../../src/boot-common';
+import { createSourceReclassifier, resetSharedBufferState } from '../../../src/boot-common';
 import { SelectorSatelliteState } from '../../../src/state/selector-satellite';
 import { AgentTaskState } from '../../../src/state/agent-task';
 import { applyDirectives } from '../../../src/render-directives';
@@ -172,6 +172,16 @@ export interface BootResult {
    * no handlers are subscribed or the input isn't a string.
    */
   applyRender(rendered: unknown, text: string, cursorOffset: number): unknown;
+
+  /**
+   * Wipe per-buffer runtime state (DynDefs, HighlightState, SpanFill,
+   * SelectorSatellite). Fire whenever an external mutation has invalidated
+   * the runtime's tracked spans — terminal paste, host-level undo, any
+   * write that bypasses the runtime's setText pipeline. Idempotent.
+   * See `resetSharedBufferState` in `src/boot-common.ts` for the full
+   * rationale + state objects deliberately NOT wiped.
+   */
+  resetBufferState(): void;
 }
 
 /**
@@ -718,6 +728,10 @@ export function boot(host: HostInfo): BootResult {
       // it doesn't get flagged as user-typed drift.
       lastSeenText = result.text;
       return result;
+    },
+
+    resetBufferState() {
+      resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
     },
 
     applyRender(rendered, text, cursorOffset) {

--- a/packages/opencues-runtime/adapters/chrome/v1/boot.ts
+++ b/packages/opencues-runtime/adapters/chrome/v1/boot.ts
@@ -25,7 +25,7 @@ import { AgentRewrite } from '../../../src/modules/agent-rewrite';
 import { TTS } from '../../../src/modules/tts';
 import { CursorStateExport } from '../../../src/modules/cursor-state-export';
 import { ConfigLoader } from '../../../src/modules/config-loader';
-import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver } from '../../../src/boot-common';
+import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver, resetSharedBufferState } from '../../../src/boot-common';
 import { EventEmitter } from '../../../src/lib/event-emitter';
 import type {
   CommonHostInfo,
@@ -139,23 +139,31 @@ export interface BootResult {
   onModuleEvent(handler: (type: string, body?: Record<string, unknown>) => void): () => void;
   /**
    * Reset per-buffer runtime state — DynDefs, HighlightState, SpanFill,
-   * BlankLoading frames. Called by chrome's content script when the
-   * focused field changes (focusin / focusout) because chrome's
-   * normal-input mode attaches to many independent `<input>` elements
-   * in one page, each with its own buffer text and word-position
-   * semantics.
+   * SelectorSatellite. Callers are responsible for emitting this signal
+   * whenever the buffer was mutated outside the runtime's setText path,
+   * which invalidates every span / word-index the runtime currently
+   * tracks. Concretely, chrome's content script calls this for:
    *
-   * Without this, a fluid-blank substitution in field A leaves a
-   * `DynDef` at wordIndex 0 with `blankName: 'fluid-blank'`. When the
-   * user focuses field B and types `_`, the Resolver's "don't clobber
-   * blank-bound entries" guard (`if (existing.blankName) continue;`)
-   * silently refuses to substitute in field B because dynDefs[0] is
-   * still B-relevant from field A's leftover state. Bug surfaces as
-   * "first `_` doesn't work, `answer _` does" (different wordIndex).
+   *   - Focused-field switch (focusin / focusout). Chrome's normal-input
+   *     mode attaches to many independent `<input>` elements in one page;
+   *     each is its own buffer with its own word-position semantics.
    *
-   * Native hosts (CC/OC/gemini-cli) work on ONE buffer per session, so
-   * this is a no-op there. Chrome with normal-input mode is the only
-   * caller today; safe to call from any host.
+   *   - Buffer-replacing input events (beforeinput.inputType ∈
+   *     {historyUndo, historyRedo, insertFromPaste, insertCompositionText}).
+   *     Browser-managed undo restores text without restoring the runtime's
+   *     spans; paste / IME commit write text the runtime didn't author.
+   *
+   * Without this, leftover state corrupts the next buffer's behaviour in
+   * non-obvious ways — fluid-blank substitutions blocked by stale
+   * blank-bound DynDefs from a prior field; phantom highlights anchored
+   * to character offsets that no longer exist after an undo; selector-
+   * satellite cycle that resumes against the wrong buffer.
+   *
+   * Implementation lives in `resetSharedBufferState` (boot-common.ts) so
+   * every band wipes the same state objects.
+   *
+   * Idempotent — safe to call repeatedly (focus-change spam, input-event
+   * bursts during paste or IME composition).
    */
   resetBufferState(): void;
   dispose(): void;
@@ -380,35 +388,14 @@ export function boot(host: HostInfo): BootResult {
       return moduleEvents.subscribe(({ type, body }) => handler(type, body));
     },
     resetBufferState() {
-      // Per-buffer state — clear on focused-field switch. Each cleared
-      // object's leakage causes a distinct subtle bug:
-      //
-      //   dynDefs                — leftover word-position entries block
-      //                            legit substitutions in the new buffer
-      //                            ("first `_` doesn't work, `answer _`
-      //                            does" — different wordIndex).
-      //   hlState                — stale highlight pointer renders the
-      //                            wrong word as "current" in the new
-      //                            buffer until the user moves the caret.
-      //   spanFillState          — span-fill blank in flight from buffer
-      //                            A would resolve into buffer B at the
-      //                            same character range.
-      //   selectorSatelliteState — user mid-cycle on a settings selector
-      //                            in A would resume on B (wrong-buffer
-      //                            settings writes).
-      //
-      // NOT cleared (intentionally session-scoped, not buffer-scoped):
-      //   agentTaskState — armed `agentically X _` task survives buffer
-      //                    switches so the user can leave a Gmail draft
-      //                    to check a tab + return without re-arming.
-      //   dismissedBlanks — dismissing `weather _` once stays dismissed
-      //                     in this page until reload.
-      shared.dynDefs.clear();
-      shared.hlState.deactivate();
-      shared.spanFillState.clear();
-      shared.selectorSatelliteState.clear();
+      // Wipe set + rationale lives in boot-common.ts's
+      // `resetSharedBufferState` so every band stays in lockstep.
+      resetSharedBufferState(shared);
       // Reset lastSeen so the next collectRenderDirectives doesn't
-      // diff against a stale snapshot from the prior buffer.
+      // diff against a stale snapshot from the prior buffer. This
+      // piece is local to the chrome boot closure (each band tracks
+      // its own diff baseline) so it doesn't belong in the shared
+      // helper.
       lastSeenText = '';
       lastSeenCursor = 0;
     },

--- a/packages/opencues-runtime/adapters/gemini/v0.41/boot.test.ts
+++ b/packages/opencues-runtime/adapters/gemini/v0.41/boot.test.ts
@@ -288,4 +288,31 @@ describe('Gemini CLI v0.41 boot()', () => {
 
     result.dispose();
   });
+
+  // ─── resetBufferState contract ──────────────────────────────────────────
+  // Per-band guarantee that the method is wired. Deep wipe-set + journey
+  // assertions live in `src/modules/reset-buffer-state.scenarios.test.ts`.
+  const minimalHost = {
+    hostVersion: '0.41.x',
+    cwd: '/proj',
+    getText: () => '',
+    getCursorOffset: () => 0,
+    setText: () => {},
+    setCursorOffset: () => {},
+    forceRender: () => {},
+  };
+
+  it('exposes resetBufferState as a method', () => {
+    const result = boot(minimalHost);
+    expect(typeof result.resetBufferState).toBe('function');
+  });
+
+  it('resetBufferState is idempotent on a cold boot (no prior state)', () => {
+    const result = boot(minimalHost);
+    expect(() => {
+      result.resetBufferState();
+      result.resetBufferState();
+      result.resetBufferState();
+    }).not.toThrow();
+  });
 });

--- a/packages/opencues-runtime/adapters/gemini/v0.41/boot.ts
+++ b/packages/opencues-runtime/adapters/gemini/v0.41/boot.ts
@@ -20,7 +20,7 @@ import { TTS } from '../../../src/modules/tts';
 import { CursorStateExport } from '../../../src/modules/cursor-state-export';
 import { ConfigLoader } from '../../../src/modules/config-loader';
 import { applyDirectives } from '../../../src/render-directives';
-import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver } from '../../../src/boot-common';
+import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver, resetSharedBufferState } from '../../../src/boot-common';
 import { startEventBridge } from '../../../src/event-bridge';
 import { EventEmitter } from '../../../src/lib/event-emitter';
 import type {
@@ -113,6 +113,15 @@ export interface BootResult {
    * "looks the same").
    */
   consumePendingRender(currentText: string, currentCursor: number): { text: string; cursor: number } | null;
+  /**
+   * Wipe per-buffer runtime state (DynDefs, HighlightState, SpanFill,
+   * SelectorSatellite). Fire whenever an external mutation has invalidated
+   * the runtime's tracked spans — terminal paste, host-level undo, any
+   * write that bypasses the runtime's setText pipeline. Idempotent.
+   * See `resetSharedBufferState` in `src/boot-common.ts` for the full
+   * rationale + state objects deliberately NOT wiped.
+   */
+  resetBufferState(): void;
   /** Call to dispose the runtime (e.g. on AppContainer unmount). */
   dispose(): void;
 }
@@ -591,6 +600,9 @@ export function boot(host: HostInfo): BootResult {
     },
     consumePendingRender(currentText, currentCursor) {
       return consumePendingRenderImpl(currentText, currentCursor);
+    },
+    resetBufferState() {
+      resetSharedBufferState(shared);
     },
     dispose() {
       adapter.dispose();

--- a/packages/opencues-runtime/adapters/oc/v1.14/boot.test.ts
+++ b/packages/opencues-runtime/adapters/oc/v1.14/boot.test.ts
@@ -115,4 +115,31 @@ describe('OpenCode v1.14 boot()', () => {
     const caps = (startupCall?.[2] as { capabilities?: string[] } | undefined)?.capabilities ?? [];
     expect(caps).toContain('spawn-process');
   });
+
+  // ─── resetBufferState contract ──────────────────────────────────────────
+  // Per-band guarantee that the method is wired. Deep wipe-set + journey
+  // assertions live in `src/modules/reset-buffer-state.scenarios.test.ts`.
+  const minimalHost = {
+    hostVersion: '1.14.17',
+    cwd: '/proj',
+    getText: () => '',
+    getCursorOffset: () => 0,
+    setText: () => {},
+    setCursorOffset: () => {},
+    forceRender: () => {},
+  };
+
+  it('exposes resetBufferState as a method', () => {
+    const result = boot(minimalHost);
+    expect(typeof result.resetBufferState).toBe('function');
+  });
+
+  it('resetBufferState is idempotent on a cold boot (no prior state)', () => {
+    const result = boot(minimalHost);
+    expect(() => {
+      result.resetBufferState();
+      result.resetBufferState();
+      result.resetBufferState();
+    }).not.toThrow();
+  });
 });

--- a/packages/opencues-runtime/adapters/oc/v1.14/boot.ts
+++ b/packages/opencues-runtime/adapters/oc/v1.14/boot.ts
@@ -18,7 +18,7 @@ import { AgentRewrite } from '../../../src/modules/agent-rewrite';
 import { TTS } from '../../../src/modules/tts';
 import { CursorStateExport } from '../../../src/modules/cursor-state-export';
 import { ConfigLoader } from '../../../src/modules/config-loader';
-import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver } from '../../../src/boot-common';
+import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver, resetSharedBufferState } from '../../../src/boot-common';
 import { EventEmitter } from '../../../src/lib/event-emitter';
 import type {
   CommonHostInfo,
@@ -67,6 +67,15 @@ export interface BootResult {
    * extmarks on the textarea.
    */
   collectRenderDirectives(text: string, cursor: number): RenderDirectives[];
+  /**
+   * Wipe per-buffer runtime state (DynDefs, HighlightState, SpanFill,
+   * SelectorSatellite). Fire whenever an external mutation has invalidated
+   * the runtime's tracked spans — terminal paste, host-level undo, any
+   * write that bypasses the runtime's setText pipeline. Idempotent.
+   * See `resetSharedBufferState` in `src/boot-common.ts` for the full
+   * rationale + state objects deliberately NOT wiped.
+   */
+  resetBufferState(): void;
   /** Call to dispose the runtime (e.g. on TUI unmount). */
   dispose(): void;
 }
@@ -291,6 +300,9 @@ export function boot(host: HostInfo): BootResult {
       lastSeenCursor = cursor;
       const ctx: RenderContext = { text, cursor, externalHighlights: [] };
       return renderEvents.collect(ctx, err => log('error', 'render handler threw', err));
+    },
+    resetBufferState() {
+      resetSharedBufferState(shared);
     },
     dispose() {
       adapter.dispose();

--- a/packages/opencues-runtime/adapters/oc/v1.4/boot.test.ts
+++ b/packages/opencues-runtime/adapters/oc/v1.4/boot.test.ts
@@ -115,4 +115,31 @@ describe('OpenCode v1.4 boot()', () => {
     const caps = (startupCall?.[2] as { capabilities?: string[] } | undefined)?.capabilities ?? [];
     expect(caps).toContain('spawn-process');
   });
+
+  // ─── resetBufferState contract ──────────────────────────────────────────
+  // Per-band guarantee that the method is wired. Deep wipe-set + journey
+  // assertions live in `src/modules/reset-buffer-state.scenarios.test.ts`.
+  const minimalHost = {
+    hostVersion: '1.4.11',
+    cwd: '/proj',
+    getText: () => '',
+    getCursorOffset: () => 0,
+    setText: () => {},
+    setCursorOffset: () => {},
+    forceRender: () => {},
+  };
+
+  it('exposes resetBufferState as a method', () => {
+    const result = boot(minimalHost);
+    expect(typeof result.resetBufferState).toBe('function');
+  });
+
+  it('resetBufferState is idempotent on a cold boot (no prior state)', () => {
+    const result = boot(minimalHost);
+    expect(() => {
+      result.resetBufferState();
+      result.resetBufferState();
+      result.resetBufferState();
+    }).not.toThrow();
+  });
 });

--- a/packages/opencues-runtime/adapters/oc/v1.4/boot.ts
+++ b/packages/opencues-runtime/adapters/oc/v1.4/boot.ts
@@ -18,7 +18,7 @@ import { AgentRewrite } from '../../../src/modules/agent-rewrite';
 import { TTS } from '../../../src/modules/tts';
 import { CursorStateExport } from '../../../src/modules/cursor-state-export';
 import { ConfigLoader } from '../../../src/modules/config-loader';
-import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver } from '../../../src/boot-common';
+import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver, resetSharedBufferState } from '../../../src/boot-common';
 import { EventEmitter } from '../../../src/lib/event-emitter';
 import type {
   CommonHostInfo,
@@ -67,6 +67,15 @@ export interface BootResult {
    * extmarks on the textarea.
    */
   collectRenderDirectives(text: string, cursor: number): RenderDirectives[];
+  /**
+   * Wipe per-buffer runtime state (DynDefs, HighlightState, SpanFill,
+   * SelectorSatellite). Fire whenever an external mutation has invalidated
+   * the runtime's tracked spans — terminal paste, host-level undo, any
+   * write that bypasses the runtime's setText pipeline. Idempotent.
+   * See `resetSharedBufferState` in `src/boot-common.ts` for the full
+   * rationale + state objects deliberately NOT wiped.
+   */
+  resetBufferState(): void;
   /** Call to dispose the runtime (e.g. on TUI unmount). */
   dispose(): void;
 }
@@ -291,6 +300,9 @@ export function boot(host: HostInfo): BootResult {
       lastSeenCursor = cursor;
       const ctx: RenderContext = { text, cursor, externalHighlights: [] };
       return renderEvents.collect(ctx, err => log('error', 'render handler threw', err));
+    },
+    resetBufferState() {
+      resetSharedBufferState(shared);
     },
     dispose() {
       adapter.dispose();

--- a/packages/opencues-runtime/adapters/terminal/v1/boot.test.ts
+++ b/packages/opencues-runtime/adapters/terminal/v1/boot.test.ts
@@ -82,4 +82,23 @@ describe('Terminal v1 boot()', () => {
     });
     expect(consumed).toBe(true);
   });
+
+  // ─── resetBufferState contract ──────────────────────────────────────────
+  // Mirrors chrome's contract test. The wipe set + multi-step journey
+  // assertions live in `src/modules/reset-buffer-state.scenarios.test.ts`;
+  // this is just the per-band guarantee that the method exists, accepts
+  // repeated calls, and doesn't throw on a cold boot.
+  it('exposes resetBufferState as a method', () => {
+    const result = boot(minimalHost);
+    expect(typeof result.resetBufferState).toBe('function');
+  });
+
+  it('resetBufferState is idempotent on a cold boot (no prior state)', () => {
+    const result = boot(minimalHost);
+    expect(() => {
+      result.resetBufferState();
+      result.resetBufferState();
+      result.resetBufferState();
+    }).not.toThrow();
+  });
 });

--- a/packages/opencues-runtime/adapters/terminal/v1/boot.ts
+++ b/packages/opencues-runtime/adapters/terminal/v1/boot.ts
@@ -23,7 +23,7 @@ import { AgentRewrite } from '../../../src/modules/agent-rewrite';
 import { TTS } from '../../../src/modules/tts';
 import { CursorStateExport } from '../../../src/modules/cursor-state-export';
 import { ConfigLoader } from '../../../src/modules/config-loader';
-import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver } from '../../../src/boot-common';
+import { buildSharedRuntime, createLogFunction, buildAgentLLMResolver, resetSharedBufferState } from '../../../src/boot-common';
 import { EventEmitter } from '../../../src/lib/event-emitter';
 import type {
   CommonHostInfo,
@@ -46,6 +46,16 @@ export interface BootResult {
   notifyTextChange(text: string, cursorOffset: number, source: 'user' | 'runtime'): void;
   notifyCursorChange(text: string, cursorOffset: number, source: 'user' | 'runtime'): void;
   collectRenderDirectives(text: string, cursor: number): RenderDirectives[];
+  /**
+   * Wipe per-buffer runtime state (DynDefs, HighlightState, SpanFill,
+   * SelectorSatellite). Fire whenever an external mutation has invalidated
+   * the runtime's tracked spans — e.g. host-level undo, paste, IME commit,
+   * or any UI write that bypasses the runtime's setText pipeline.
+   * Idempotent. See `resetSharedBufferState` in `src/boot-common.ts` for
+   * the full rationale + the state objects deliberately NOT wiped
+   * (agentTaskState, dismissedBlanks).
+   */
+  resetBufferState(): void;
   dispose(): void;
 }
 
@@ -214,6 +224,9 @@ export function boot(host: HostInfo): BootResult {
       lastSeenCursor = cursor;
       const ctx: RenderContext = { text, cursor, externalHighlights: [] };
       return renderEvents.collect(ctx, err => log('error', 'render handler threw', err));
+    },
+    resetBufferState() {
+      resetSharedBufferState(shared);
     },
     dispose() {
       adapter.dispose();

--- a/packages/opencues-runtime/src/boot-common.ts
+++ b/packages/opencues-runtime/src/boot-common.ts
@@ -339,3 +339,59 @@ export function buildSharedRuntime(
     markdownRender,
   };
 }
+
+/* ─── Per-buffer state reset ─────────────────────────────────────────────
+ *
+ * Wipe the state objects whose contents are bound to specific character
+ * offsets / word indices in the live buffer. Callers fire this whenever
+ * an external mutation has invalidated those offsets:
+ *
+ *   - Chrome content script — focus change between fields (each field
+ *     is its own buffer with its own word indices), AND buffer-replacing
+ *     input events (undo / redo / paste / IME commit / native autocomplete).
+ *   - Native hosts — TBD per host. Terminal undo, paste, and any host-
+ *     UI write that bypasses the runtime's setText pipeline qualify.
+ *
+ * What gets cleared:
+ *   dynDefs                — leftover word-position entries either render
+ *                            phantom highlights or block legit substitutions
+ *                            (the May 2026 "first `_` doesn't work" bug).
+ *   hlState                — stale highlight pointer renders the wrong
+ *                            word as "current" until the user moves caret.
+ *   spanFillState          — in-flight span-fill from the prior buffer
+ *                            state would splice into the new text at the
+ *                            same character range.
+ *   selectorSatelliteState — mid-cycle on a settings selector would resume
+ *                            against the wrong buffer (wrong-buffer settings
+ *                            writes).
+ *
+ * Deliberately NOT cleared (session-scoped, not buffer-scoped):
+ *   agentTaskState  — armed `agentically X _` task survives so users can
+ *                     leave a draft, tab away, return without re-arming.
+ *   dismissedBlanks — dismissing `weather _` once stays dismissed for the
+ *                     session; undo shouldn't resurrect the suggestion.
+ *
+ * Resolver re-runs on the next keystroke debounce — the user sees a clean
+ * buffer briefly, then cues repopulate. Acceptable UX cost vs. the silent
+ * desync that partial reconciliation would produce.
+ *
+ * Idempotent — safe to call repeatedly (focus-change spam, input-event
+ * bursts during paste or IME composition).
+ *
+ * Signature takes a minimal structural type, not `SharedRuntime`, so the
+ * CC v2.1 boot (which builds its state classes inline rather than via
+ * `buildSharedRuntime`) can pass the same locals it already has — every
+ * band stays in lockstep on the wipe set without forcing CC to also
+ * adopt SharedRuntime.
+ */
+export function resetSharedBufferState(state: {
+  readonly dynDefs: Pick<DynDefs, 'clear'>;
+  readonly hlState: Pick<HighlightState, 'deactivate'>;
+  readonly spanFillState: Pick<SpanFillState, 'clear'>;
+  readonly selectorSatelliteState: Pick<SelectorSatelliteState, 'clear'>;
+}): void {
+  state.dynDefs.clear();
+  state.hlState.deactivate();
+  state.spanFillState.clear();
+  state.selectorSatelliteState.clear();
+}

--- a/packages/opencues-runtime/src/modules/reset-buffer-state.scenarios.test.ts
+++ b/packages/opencues-runtime/src/modules/reset-buffer-state.scenarios.test.ts
@@ -1,0 +1,597 @@
+/**
+ * Scenario tests for `resetSharedBufferState()` (the wipe-on-external-
+ * mutation handler exposed as `BootResult.resetBufferState()` on every
+ * band).
+ *
+ * The handler exists because the runtime's span / DynDef / highlight
+ * state objects are anchored to character offsets in the live buffer.
+ * Anything that mutates the buffer outside the runtime's `setText`
+ * pipeline — host-level undo / redo, paste, IME commit, native
+ * autocomplete, multi-buffer focus switch — leaves those offsets
+ * pointing at characters that no longer mean what they did. Cycling,
+ * dim-render, navigation then operate on stale anchors.
+ *
+ * These tests pin the wipe set (what gets cleared, what survives) AND
+ * the multi-step user journeys that triggered the original bug class:
+ *
+ *   1. The "cycle → external-replace → cycle" sequence — does the
+ *      runtime stop trying to splice against stale DynDefs?
+ *   2. The "blank fill in flight → reset" path — does the in-flight
+ *      span-fill stash get cleared so it can't splice into the new
+ *      buffer?
+ *   3. The "selector-satellite mid-cycle → reset" path — does the
+ *      two-headed pair clear without leaving a half-broken state?
+ *   4. The "armed agent task survives" invariant — does undo NOT
+ *      destroy the user's `agentically X _` task?
+ *
+ * Unit tests on `dynDefs.clear()` etc. would pass without the contract
+ * holding at the journey level. These scenarios cross modules + state
+ * + time, matching the CLAUDE.md "write the scenario that triggered
+ * the bug" rule.
+ *
+ * Companion to:
+ *   - `src/boot-common.ts` (resetSharedBufferState implementation)
+ *   - `adapters/<band>/<v>/boot.ts` (per-band BootResult.resetBufferState)
+ *   - `adapters/chrome/v1/boot.test.ts` (chrome-level integration test)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Cycling } from './cycling';
+import { ConfigLoader } from './config-loader';
+import { Navigation } from './navigation';
+import { resetSharedBufferState } from '../boot-common';
+import { HighlightState } from '../state/highlight-state';
+import { DynDefs } from '../state/dyn-defs';
+import { SpanFillState } from '../state/span-fill';
+import { SelectorSatelliteState, type SelectorSatelliteEntry } from '../state/selector-satellite';
+import { AgentTaskState } from '../state/agent-task';
+import { DismissedBlanks } from '../state/dismissed-blanks';
+import { MockAdapter, wrapTipsAsCuesMd } from '../../testing/mock-adapter';
+
+const TIPS = wrapTipsAsCuesMd({
+  domain: 'test',
+  version: 1,
+  concepts: [
+    {
+      id: 'words',
+      words: {
+        attorney: { tip: '', alts: ['lawyer', 'legal eagle', 'defendant counsel'] },
+        fast: { tip: '', alts: ['quick', 'rapid', 'swift'] },
+        big: { tip: '', alts: ['large', 'huge'] },
+        word: { tip: '', alts: ['term'] },
+      },
+    },
+  ],
+});
+
+interface Harness {
+  adapter: MockAdapter;
+  hlState: HighlightState;
+  dynDefs: DynDefs;
+  spanFillState: SpanFillState;
+  selectorSatelliteState: SelectorSatelliteState;
+  agentTaskState: AgentTaskState;
+  dismissedBlanks: DismissedBlanks;
+  loader: ConfigLoader;
+  cycling: Cycling;
+  nav: Navigation;
+}
+
+async function setup(initialText: string): Promise<Harness> {
+  const adapter = new MockAdapter({ files: { '/mock/CUES.md': TIPS } });
+  adapter.pushText(initialText);
+  const hlState = new HighlightState();
+  const dynDefs = new DynDefs();
+  const spanFillState = new SpanFillState();
+  const selectorSatelliteState = new SelectorSatelliteState();
+  const agentTaskState = new AgentTaskState();
+  const dismissedBlanks = new DismissedBlanks();
+  const loader = new ConfigLoader(adapter);
+  await loader.load();
+  const cycling = new Cycling(
+    adapter, hlState, dynDefs, loader,
+    spanFillState, dismissedBlanks, selectorSatelliteState,
+  );
+  cycling.subscribe();
+  const nav = new Navigation(adapter, hlState, dynDefs, loader, spanFillState, selectorSatelliteState);
+  nav.subscribe();
+  return {
+    adapter, hlState, dynDefs, spanFillState, selectorSatelliteState,
+    agentTaskState, dismissedBlanks, loader, cycling, nav,
+  };
+}
+
+function makeSatelliteEntry(): SelectorSatelliteEntry {
+  return {
+    blankName: 'opencues',
+    scriptPath: '/mock/opencues-blank.sh',
+    selectorIndex: 1,
+    selectorLength: 1,
+    satelliteIndex: 2,
+    satelliteLength: 1,
+    currentSetting: 'voice-mode',
+    currentValue: 'active',
+    separator: ' ',
+    clearOnEdit: false,
+    pairCharStart: 9,
+    pairCharEnd: 26,
+  };
+}
+
+// ===========================================================================
+// A. Wipe set — what resetSharedBufferState clears
+// ===========================================================================
+
+describe('resetSharedBufferState — wipe set', () => {
+  it('clears every DynDef populated by prior cycles', async () => {
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed');
+    hlState.activate(1, 'the attorney filed');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    expect(dynDefs.size).toBeGreaterThan(0);
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(dynDefs.size).toBe(0);
+    expect(dynDefs.get(1)).toBeUndefined();
+  });
+
+  it('deactivates the active highlight', async () => {
+    const { hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed');
+    hlState.activate(1, 'the attorney filed');
+    expect(hlState.active).toBe(true);
+    expect(hlState.wordIndex).toBe(1);
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(hlState.active).toBe(false);
+    expect(hlState.wordIndex).toBeNull();
+  });
+
+  it('clears an in-flight SpanFillState entry', async () => {
+    const { hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('improve this _');
+    spanFillState.set(
+      { index: 0, alternatives: ['improve this <better>'], currentAltIndex: 0, spanLength: 3 },
+      'improve this <better>',
+    );
+    expect(spanFillState.current).not.toBeNull();
+    expect(spanFillState.lastFilledText).toBe('improve this <better>');
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(spanFillState.current).toBeNull();
+    expect(spanFillState.lastFilledText).toBe('');
+  });
+
+  it('clears an active SelectorSatelliteState pair', async () => {
+    const { hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('opencues voice-mode active');
+    selectorSatelliteState.set(makeSatelliteEntry(), 'opencues voice-mode active');
+    expect(selectorSatelliteState.current).not.toBeNull();
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(selectorSatelliteState.current).toBeNull();
+    expect(selectorSatelliteState.lastFilledText).toBe('');
+  });
+
+  it('wipes all four state objects in a single call when every one is populated', async () => {
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed quickly');
+    // Populate everything in one go.
+    hlState.activate(1, 'the attorney filed quickly');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    spanFillState.set(
+      { index: 3, alternatives: ['<placeholder>'], currentAltIndex: 0, spanLength: 1 },
+      'irrelevant',
+    );
+    selectorSatelliteState.set(makeSatelliteEntry(), 'irrelevant');
+
+    expect(dynDefs.size).toBeGreaterThan(0);
+    expect(hlState.active).toBe(true);
+    expect(spanFillState.current).not.toBeNull();
+    expect(selectorSatelliteState.current).not.toBeNull();
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(dynDefs.size).toBe(0);
+    expect(hlState.active).toBe(false);
+    expect(spanFillState.current).toBeNull();
+    expect(selectorSatelliteState.current).toBeNull();
+  });
+});
+
+// ===========================================================================
+// B. Survival set — what resetSharedBufferState deliberately preserves
+// ===========================================================================
+//
+// The deliberate non-wipes encode product decisions:
+//   - agentTaskState: armed `agentically X _` survives undo / focus / paste
+//     so users can leave a draft, switch tabs, return without re-arming.
+//   - dismissedBlanks: dismissing `weather _` once stays dismissed; undo
+//     shouldn't resurrect a suggestion the user already declined.
+//
+// These tests fail loudly if a future refactor extends the wipe set.
+
+describe('resetSharedBufferState — survival set (deliberate non-wipes)', () => {
+  it('does NOT touch an armed AgentTaskState', async () => {
+    const { hlState, dynDefs, spanFillState, selectorSatelliteState, agentTaskState } =
+      await setup('the doc');
+    agentTaskState.arm('shorten every sentence');
+    const taskIdBefore = agentTaskState.taskId;
+    const promptBefore = agentTaskState.prompt;
+    expect(agentTaskState.armed).toBe(true);
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(agentTaskState.armed).toBe(true);
+    expect(agentTaskState.taskId).toBe(taskIdBefore);
+    expect(agentTaskState.prompt).toBe(promptBefore);
+  });
+
+  it('does NOT touch DismissedBlanks entries', async () => {
+    const { hlState, dynDefs, spanFillState, selectorSatelliteState, dismissedBlanks } =
+      await setup('weather today');
+    dismissedBlanks.add(0);
+    dismissedBlanks.add(2);
+    expect(dismissedBlanks.has(0)).toBe(true);
+    expect(dismissedBlanks.has(2)).toBe(true);
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(dismissedBlanks.has(0)).toBe(true);
+    expect(dismissedBlanks.has(2)).toBe(true);
+  });
+
+  it('does NOT touch ConfigLoader (loaded settings + cue sources stay loaded)', async () => {
+    const { hlState, dynDefs, spanFillState, selectorSatelliteState, loader } =
+      await setup('the attorney filed');
+    expect(loader.loaded).toBe(true);
+    const cueMapSizeBefore = loader.cueMap.size;
+    const opencuesStateBefore = loader.opencuesState;
+    expect(cueMapSizeBefore).toBeGreaterThan(0);
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(loader.loaded).toBe(true);
+    expect(loader.cueMap.size).toBe(cueMapSizeBefore);
+    expect(loader.opencuesState).toBe(opencuesStateBefore);
+  });
+});
+
+// ===========================================================================
+// C. Multi-step user journeys — the bugs this exists to prevent
+// ===========================================================================
+//
+// CLAUDE.md "Write the scenario that triggered the bug" rule. Each test
+// here mirrors a user sequence that produced (or would produce) a
+// stale-offset / phantom-highlight / blocked-substitution bug before
+// the wipe was wired up.
+
+describe('reset-buffer-state scenarios — multi-step journeys', () => {
+  it('cycle → cycle → external buffer replace → reset → next activate works on the new buffer', async () => {
+    // The canonical undo scenario: user cycles a word twice, browser undo
+    // restores text that doesn't match the runtime's DynDef anchors.
+    // Reset clears the stale state; a fresh activate on the post-undo
+    // buffer cycles correctly without bleed-through.
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed');
+    hlState.activate(1, 'the attorney filed');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    expect(adapter.setTextCalls.at(-1)).toBe('the legal eagle filed');
+    expect(dynDefs.size).toBeGreaterThan(0);
+
+    // External mutation — host writes the new buffer directly (paste /
+    // undo / IME). The runtime's spans now anchor to characters that no
+    // longer exist at those offsets.
+    adapter.pushText('big fast word');
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    // Fresh activate on the new buffer — every cycle must operate on
+    // the post-mutation text, not leftover anchors from "the legal eagle filed".
+    expect(dynDefs.size).toBe(0);
+    hlState.activate(1, 'big fast word');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    expect(adapter.setTextCalls.at(-1)).toBe('big quick word');
+  });
+
+  it('multi-word cycle (span expansion) → reset → no stale span offsets remain', async () => {
+    // Multi-word alts expand the span, which is exactly when stale-offset
+    // bugs surface most badly — the post-cycle DynDefs hold spanEnd > the
+    // original word's end, and any subsequent operation against the
+    // post-undo buffer would splice on a non-existent range.
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed');
+    hlState.activate(1, 'the attorney filed');
+    adapter.fireKey('up', { ctrl: true, alt: true }); // attorney → lawyer (1 word)
+    adapter.fireKey('up', { ctrl: true, alt: true }); // lawyer → legal eagle (2 words)
+    const def = dynDefs.get(1);
+    expect(def).toBeDefined();
+    expect(def!.spanEnd - def!.spanStart).toBeGreaterThan('attorney'.length);
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(dynDefs.get(1)).toBeUndefined();
+    expect([...dynDefs.entries()].length).toBe(0);
+  });
+
+  it('reset then second-buffer cycle does NOT echo into prior buffer state', async () => {
+    // The May 2026 fluid-blank-cross-buffer bug at the journey level:
+    // a buffer-bound DynDef from a prior buffer would block / mislocate
+    // the next buffer's activation. After reset, the second buffer's
+    // wordIndex 1 must be a fresh fast-quick cycle, not a confused
+    // attorney-anchored splice.
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed');
+    hlState.activate(1, 'the attorney filed');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    expect(dynDefs.get(1)?.originalWord).toBe('attorney');
+
+    // External replace + reset (simulate undo / focus switch).
+    adapter.pushText('a fast car');
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    hlState.activate(1, 'a fast car');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    expect(adapter.setTextCalls.at(-1)).toBe('a quick car');
+    expect(dynDefs.get(1)?.originalWord).toBe('fast');
+  });
+
+  it('blank fill in flight → reset → in-flight state cannot splice into new buffer', async () => {
+    // A span-fill stash from a fluid blank in flight would, without
+    // reset, fire its substitute into whatever the new buffer says at
+    // the same character range. After reset the stash is gone; any
+    // subsequent text change is treated as fresh user input.
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('answer _ please');
+    spanFillState.set(
+      { index: 1, alternatives: ['answer 42 please'], currentAltIndex: 0, spanLength: 1 },
+      'answer 42 please',
+    );
+    expect(spanFillState.current).not.toBeNull();
+    expect(spanFillState.lastFilledText).toBe('answer 42 please');
+
+    // External replace + reset.
+    adapter.pushText('totally different content');
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(spanFillState.current).toBeNull();
+    expect(spanFillState.lastFilledText).toBe('');
+  });
+
+  it('selector-satellite mid-cycle → reset → pair clears without half-broken state', async () => {
+    // Mid-cycle on `opencues voice-mode active`: a half-cleared pair
+    // (e.g. selector cleared but satellite retained) would leave the
+    // satellite cycling against a setting that no longer exists in the
+    // buffer. Reset must clear both heads atomically.
+    const { hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('opencues voice-mode active');
+    selectorSatelliteState.set(makeSatelliteEntry(), 'opencues voice-mode active');
+    expect(selectorSatelliteState.current?.currentSetting).toBe('voice-mode');
+    expect(selectorSatelliteState.current?.currentValue).toBe('active');
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(selectorSatelliteState.current).toBeNull();
+    expect(selectorSatelliteState.lastFilledText).toBe('');
+  });
+
+  it('armed agent task + cycle state → reset → task survives, cycle state gone', async () => {
+    // Composite invariant: even when the user has both an armed agent
+    // task AND active cycle state, the reset preserves only the task.
+    // Pins both halves at once so a regression splitting the wipe set
+    // would still trip.
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState, agentTaskState } =
+      await setup('the attorney filed');
+    agentTaskState.arm('be more concise');
+    hlState.activate(1, 'the attorney filed');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    expect(dynDefs.size).toBeGreaterThan(0);
+    expect(agentTaskState.armed).toBe(true);
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(dynDefs.size).toBe(0);
+    expect(hlState.active).toBe(false);
+    expect(agentTaskState.armed).toBe(true);
+    expect(agentTaskState.prompt).toBe('be more concise');
+  });
+
+  it('reset between two cycle batches — first batch does not leak into second', async () => {
+    // Without reset, the first buffer's DynDefs would survive into the
+    // second buffer's cycle attempt and the runtime would try to splice
+    // the wrong alts at the wrong offsets. After reset, each batch sees
+    // a clean slate.
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed');
+    hlState.activate(1, 'the attorney filed');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    const firstBatchCalls = adapter.setTextCalls.length;
+
+    adapter.pushText('the big word');
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+    hlState.activate(1, 'the big word');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    const lastCall = adapter.setTextCalls.at(-1);
+
+    expect(adapter.setTextCalls.length).toBeGreaterThan(firstBatchCalls);
+    expect(lastCall).toBe('the large word');
+    expect(lastCall).not.toContain('attorney');
+    expect(lastCall).not.toContain('lawyer');
+    expect(lastCall).not.toContain('legal eagle');
+  });
+});
+
+// ===========================================================================
+// D. Edge cases — cold state, idempotency, ordering
+// ===========================================================================
+
+describe('resetSharedBufferState — edge cases', () => {
+  it('does not throw when called on a completely cold state', () => {
+    const dynDefs = new DynDefs();
+    const hlState = new HighlightState();
+    const spanFillState = new SpanFillState();
+    const selectorSatelliteState = new SelectorSatelliteState();
+
+    expect(() => {
+      resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+    }).not.toThrow();
+
+    expect(dynDefs.size).toBe(0);
+    expect(hlState.active).toBe(false);
+    expect(spanFillState.current).toBeNull();
+    expect(selectorSatelliteState.current).toBeNull();
+  });
+
+  it('is idempotent — three consecutive calls leave identical state', async () => {
+    // Focus-change spam / input-event bursts during paste or IME
+    // composition can trigger the reset many times in a row. Must be
+    // a true no-op after the first call.
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed');
+    hlState.activate(1, 'the attorney filed');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+    const afterFirst = {
+      dynDefSize: dynDefs.size,
+      hlActive: hlState.active,
+      spanFillCurrent: spanFillState.current,
+      satelliteCurrent: selectorSatelliteState.current,
+    };
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(dynDefs.size).toBe(afterFirst.dynDefSize);
+    expect(hlState.active).toBe(afterFirst.hlActive);
+    expect(spanFillState.current).toBe(afterFirst.spanFillCurrent);
+    expect(selectorSatelliteState.current).toBe(afterFirst.satelliteCurrent);
+  });
+
+  it('reset does not fire side-effect mutations on the host (no setText call)', async () => {
+    // The wipe is in-memory state only — it must not write to the host
+    // buffer. Hosts that emit the reset signal (chrome's undo handler,
+    // focus-change handler) already let the host's own write land
+    // first; we'd double-render if reset also called setText.
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed');
+    hlState.activate(1, 'the attorney filed');
+    adapter.fireKey('up', { ctrl: true, alt: true });
+    const setTextCountBeforeReset = adapter.setTextCalls.length;
+
+    resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+
+    expect(adapter.setTextCalls.length).toBe(setTextCountBeforeReset);
+  });
+
+  it('survives a reset → activate → cycle → reset → cycle loop ten times', async () => {
+    // Stress / repeat-cycle safety net: nothing accumulates over
+    // repeated reset+cycle cycles. Catches a regression where reset
+    // forgot to clear an internal map and the Nth iteration tripped on
+    // leftover N-1 state.
+    const { adapter, hlState, dynDefs, spanFillState, selectorSatelliteState } =
+      await setup('the attorney filed');
+
+    for (let i = 0; i < 10; i++) {
+      hlState.activate(1, 'the attorney filed');
+      adapter.fireKey('up', { ctrl: true, alt: true });
+      expect(adapter.setTextCalls.at(-1)).toBe('the lawyer filed');
+      adapter.pushText('the attorney filed');
+      resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+      expect(dynDefs.size).toBe(0);
+      expect(hlState.active).toBe(false);
+    }
+  });
+
+  it('order of population does not matter — same end state regardless', async () => {
+    // Two harnesses: populate state objects in opposite orders, reset
+    // both, assert identical outcomes. Pins that the reset doesn't
+    // depend on insertion order or internal map iteration.
+    const a = await setup('the attorney filed');
+    const b = await setup('the attorney filed');
+
+    a.hlState.activate(1, 'the attorney filed');
+    a.adapter.fireKey('up', { ctrl: true, alt: true });
+    a.spanFillState.set(
+      { index: 3, alternatives: ['<x>'], currentAltIndex: 0, spanLength: 1 },
+      'x',
+    );
+    a.selectorSatelliteState.set(makeSatelliteEntry(), 'x');
+
+    b.selectorSatelliteState.set(makeSatelliteEntry(), 'x');
+    b.spanFillState.set(
+      { index: 3, alternatives: ['<x>'], currentAltIndex: 0, spanLength: 1 },
+      'x',
+    );
+    b.hlState.activate(1, 'the attorney filed');
+    b.adapter.fireKey('up', { ctrl: true, alt: true });
+
+    resetSharedBufferState(a);
+    resetSharedBufferState(b);
+
+    expect(a.dynDefs.size).toBe(b.dynDefs.size);
+    expect(a.hlState.active).toBe(b.hlState.active);
+    expect(a.spanFillState.current).toBe(b.spanFillState.current);
+    expect(a.selectorSatelliteState.current).toBe(b.selectorSatelliteState.current);
+  });
+});
+
+// ===========================================================================
+// E. Structural-type contract — minimal Pick<> signature
+// ===========================================================================
+//
+// `resetSharedBufferState` takes a structural Pick<> shape rather than
+// `SharedRuntime` so CC v2.1 (which builds state classes inline) can
+// pass its locals. These tests pin that contract — if someone tightens
+// the signature back to SharedRuntime, the CC band breaks at compile
+// time but these tests are the runtime smoke check that the
+// destructured-args path stays sound.
+
+describe('resetSharedBufferState — structural-type contract', () => {
+  it('accepts a plain object literal of state classes (CC v2.1 calling shape)', () => {
+    const dynDefs = new DynDefs();
+    const hlState = new HighlightState();
+    const spanFillState = new SpanFillState();
+    const selectorSatelliteState = new SelectorSatelliteState();
+    hlState.activate(0, 'hi');
+
+    expect(() => {
+      resetSharedBufferState({ dynDefs, hlState, spanFillState, selectorSatelliteState });
+    }).not.toThrow();
+    expect(hlState.active).toBe(false);
+  });
+
+  it('accepts a SharedRuntime-shaped object (buildSharedRuntime calling shape)', () => {
+    // Smoke-test that extra fields (configLoader, blankLoading, etc.)
+    // on the passed object are ignored — the helper only reads the
+    // four state fields and tolerates extras the SharedRuntime callers
+    // include.
+    const dynDefs = new DynDefs();
+    const hlState = new HighlightState();
+    const spanFillState = new SpanFillState();
+    const selectorSatelliteState = new SelectorSatelliteState();
+    const sharedShaped = {
+      dynDefs,
+      hlState,
+      spanFillState,
+      selectorSatelliteState,
+      // Extra fields that buildSharedRuntime would include:
+      configLoader: {} as unknown,
+      blankLoading: {} as unknown,
+      markdownRender: {} as unknown,
+      dismissedBlanks: new DismissedBlanks(),
+      agentTaskState: new AgentTaskState(),
+    };
+    hlState.activate(0, 'hi');
+
+    expect(() => {
+      resetSharedBufferState(sharedShaped);
+    }).not.toThrow();
+    expect(hlState.active).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Per-buffer runtime state (`DynDefs`, `HighlightState`, `SpanFillState`, `SelectorSatelliteState`) anchors to character offsets in the live buffer. Anything that mutates the buffer outside the runtime's `setText` pipeline — undo, redo, paste, IME commit — leaves those offsets pointing at content the runtime didn't author. The next cycle splices on stale offsets, dim repaints a phantom span, or `_` silently no-ops on a leftover `blankName` entry.
- Promotes the existing chrome-only `resetBufferState()` to a uniform `BootResult` method on every band (cc/v2.1, oc/v1.4, oc/v1.14, gemini/v0.41, terminal/v1, chrome/v1). Implementation extracted to `resetSharedBufferState` in `src/boot-common.ts` so the wipe set stays in lockstep across bands.
- Wires chrome's content script to call `notifyBufferReplacedExternally()` from a `beforeinput` listener gated on `inputType ∈ {historyUndo, historyRedo, insertFromPaste, insertCompositionText}` and `isTrusted` (mirrors the existing keydown/paste/drop security pattern).

## What gets wiped vs. preserved

| State | Action | Rationale |
|---|---|---|
| `DynDefs` | clear | Leftover word-position entries either render phantom highlights or block legit substitutions |
| `HighlightState` | deactivate | Stale highlight pointer renders the wrong word as 'current' |
| `SpanFillState` | clear | In-flight span-fill would splice into the new buffer at the same character range |
| `SelectorSatelliteState` | clear | Mid-cycle on a settings selector would resume against the wrong buffer |
| `AgentTaskState` | **preserved** | Armed \`agentically X _\` survives undo so users can experiment without re-arming |
| `dismissedBlanks` | **preserved** | Dismissed suggestions stay dismissed; undo shouldn't resurrect them |

## Test plan

- [x] 22 new scenario tests in `packages/opencues-runtime/src/modules/reset-buffer-state.scenarios.test.ts` — wipe set, survival set, 7 multi-step user journeys (the canonical bug cases), edge cases (cold-state, idempotency, 10× repeat loop, order-independence), structural-type contract
- [x] Per-band `BootResult.resetBufferState()` contract tests added to cc/v2.1, oc/v1.4, oc/v1.14, gemini/v0.41, terminal/v1 (chrome already had them)
- [x] Full runtime suite: 1349/1349 green
- [x] Chrome bundle: 115/115 green
- [x] Bundle synced + new symbol verified in `/mnt/c/Users/.../opencues-chrome/dist/content.js`
- [ ] **Manual browser verification** (in-progress with reporter): Gmail (generic contenteditable), claude.ai (ProseMirror), Reddit (Lexical), LinkedIn (ProseMirror) — undo / redo / paste each followed by a cycle, confirming the post-mutation cycle operates on the visible buffer
- [ ] IME composition path (CJK users) — opportunistic

## Notes

- `beforeinput` handler does **not** call `preventDefault` — the browser still performs the native undo / redo / paste / IME action; we wipe in-memory state in parallel
- Wipe is idempotent — focus-change spam and IME composition bursts (which fire `insertCompositionText` per character, not per commit) safely re-trigger the same no-op
- `notifyBufferReplacedExternally()` is no-op when boot hasn't completed (rare initial-attach race) — same defensive shape as `publishTarget`
- The `resetSharedBufferState` helper takes a minimal `Pick<>`-typed structural shape rather than `SharedRuntime` so CC v2.1 (which builds state classes inline rather than via `buildSharedRuntime`) can pass its locals without adopting the shared-runtime construction pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)