### PR TITLE
feat(terminal): oc-shell — tmux-wrapped popup for any shell

### DIFF
--- a/integrations/terminal/CLAUDE.md
+++ b/integrations/terminal/CLAUDE.md
@@ -22,6 +22,10 @@ against it, and prints the buffer on submit.
 | `compat.json` | Declared compatibility (`host-kind: self`) |
 | `patches/setup.sh` | One-command installer (Bun, build runtime, optional symlink) |
 | `bin/oc-edit` | Bun entrypoint — chooses dist/ if built, else src/ |
+| `bin/oc-shell` | tmux wrapper — launches user's shell with Ctrl+Alt+X popup binding. Always uses the vendored tmux at `~/.opencues/vendor/tmux/bin/tmux`; PATH is never consulted. |
+| `bin/oc-popup` | Invoked by the tmux popup; runs `oc-edit`, bracket-pastes the committed text back into the originating pane via the vendored tmux. |
+| `bin/oc-install-tmux` | Builds tmux 3.4 from source into `~/.opencues/vendor/tmux/`. Required once before `oc-shell` first runs. System tmux is never touched. |
+| `conf/oc-shell.tmux.conf` | Private tmux config loaded by oc-shell (doesn't touch `~/.tmux.conf`). |
 | `src/app.tsx` | The Solid app — single `<textarea>` + statusline |
 | `src/bootstrap.ts` | OpenCues wiring (analog of `integrations/opencode/patches/opencuesBootstrap.ts`, but without the holder/publish dance) |
 | `../../packages/opencues-runtime/adapters/terminal/v1/` | Adapter band |

--- a/integrations/terminal/TEST-WHEN-MERGED.md
+++ b/integrations/terminal/TEST-WHEN-MERGED.md
@@ -78,7 +78,25 @@ Verify Ctrl+Alt+↑/↓ actually cycles on each terminal you care about:
 
 This list mirrors the long-tail the OC + Gemini integrations already document in their REPAIR.md files. Failures here aren't blockers for merge — they're reasons to add a `KEY-COMPAT.md` for the terminal app.
 
-## 9. Uninstall (10 s)
+## 9. Tmux popup wrapper — `oc-shell` (5 min, includes one-time tmux build)
+
+### 9a. Vendored tmux install (one-time, ~30s)
+- [ ] On a machine without `libevent-dev` / `bison`: `oc-install-tmux` exits cleanly with `oc-install-tmux: missing build deps: ...` and prints the apt/dnf/pacman/brew command. No half-finished build state in `~/.opencues/vendor/`.
+- [ ] After `sudo apt install -y libevent-dev bison` (or platform equivalent): `oc-install-tmux` downloads source, builds, installs to `~/.opencues/vendor/tmux/bin/tmux`. Final line confirms version. Build logs at `~/.opencues/vendor/{configure,make,install}.log`.
+- [ ] Re-running `oc-install-tmux` after install: no-op with "tmux X.Y already vendored" message.
+- [ ] System tmux (`/usr/bin/tmux`, brew tmux, etc.) is untouched. Verify with `which -a tmux` — both old and new paths visible.
+
+### 9b. oc-shell behavior
+- [ ] `oc-shell` before running `oc-install-tmux`: clean exit with "vendored tmux not found" + instructions. No PATH fallback to system tmux.
+- [ ] On tmux >= 3.2 outside any tmux: `oc-shell` drops into the user's `$SHELL` at the current `$PWD`. Bottom-right status line reads `OpenCues  Ctrl+Alt+X popup   type "exit" to leave`. `pwd` matches the dir oc-shell was invoked from.
+- [ ] Press **Ctrl+Alt+X**: a centered floating box opens (80% × 70%), running `oc-edit` inside. The OpenCues runtime is active — typing `the attorney filed today` highlights words, Ctrl+Alt+↑ cycles, etc.
+- [ ] Compose multi-line text in the popup (Enter for newline). Press **Ctrl+S**. Popup closes; the composed block is bracket-pasted into the originating pane at the shell prompt — multi-line text lands as a single editable paste, not as separate executed commands.
+- [ ] Press **Ctrl+Alt+X** then **Ctrl+C** (or Esc) inside oc-edit: popup closes with nothing pasted.
+- [ ] Type `exit` (or Ctrl+D) at the wrapped shell — the tmux session is destroyed (`destroy-unattached on`) and `oc-shell` returns to the outer terminal. No orphan `tmux` server on the `opencues-*` socket (verify with `ls /tmp/tmux-*/opencues-*` → empty).
+- [ ] Already-inside-tmux case: from inside an existing tmux session, run `oc-shell`. It does NOT nest. Instead it prints `OpenCues popup registered in this tmux session.` and exits. Ctrl+Alt+X then works in the user's existing tmux. `tmux unbind-key -n M-C-x` cleanly removes.
+- [ ] Status line removal note (no test, just verify the comment block in `conf/oc-shell.tmux.conf` describes the one-line change — `set -g status on` → `set -g status off` — and that it works when applied).
+
+## 10. Uninstall (10 s)
 - [ ] `opencues uninstall terminal` removes `integrations/terminal/node_modules/@opencues/*/`
 - [ ] `opencues install terminal --dry-run` shows the plan; **no files modified**
 

--- a/integrations/terminal/bin/install.cjs
+++ b/integrations/terminal/bin/install.cjs
@@ -61,7 +61,11 @@ function doInstall() {
     console.log('[dry-run] Would stage runtime + core into:');
     console.log(`  ${path.join(PKG_DIR, 'node_modules', '@opencues', 'core')}/`);
     console.log(`  ${path.join(PKG_DIR, 'node_modules', '@opencues', 'runtime')}/`);
-    if (args.link) console.log(`[dry-run] Would symlink: ${args.link}/oc-edit → ${path.join(PKG_DIR, 'bin', 'oc-edit')}`);
+    if (args.link) {
+      for (const b of ['oc-edit', 'oc-shell', 'oc-popup', 'oc-install-tmux']) {
+        console.log(`[dry-run] Would symlink: ${args.link}/${b} → ${path.join(PKG_DIR, 'bin', b)}`);
+      }
+    }
     return;
   }
 
@@ -89,13 +93,15 @@ function doUninstall() {
   // local node_modules + the optional symlink the user passed via --link.
   const stagedCore = path.join(PKG_DIR, 'node_modules', '@opencues', 'core');
   const stagedRt = path.join(PKG_DIR, 'node_modules', '@opencues', 'runtime');
-  const linkPath = args.link ? path.join(args.link, 'oc-edit') : null;
+  const linkPaths = args.link
+    ? ['oc-edit', 'oc-shell', 'oc-popup', 'oc-install-tmux'].map((b) => path.join(args.link, b))
+    : [];
 
   console.log('Uninstall plan:');
   for (const p of [stagedCore, stagedRt]) {
     if (fs.existsSync(p)) console.log(`  rm -rf ${p}`);
   }
-  if (linkPath) {
+  for (const linkPath of linkPaths) {
     try {
       if (fs.lstatSync(linkPath).isSymbolicLink()) console.log(`  rm ${linkPath}`);
     } catch { /* ignore */ }
@@ -106,7 +112,7 @@ function doUninstall() {
   for (const p of [stagedCore, stagedRt]) {
     if (fs.existsSync(p)) { fs.rmSync(p, { recursive: true, force: true }); console.log(`  removed ${p}/`); }
   }
-  if (linkPath) {
+  for (const linkPath of linkPaths) {
     try {
       if (fs.lstatSync(linkPath).isSymbolicLink()) { fs.unlinkSync(linkPath); console.log(`  removed ${linkPath}`); }
     } catch { /* ignore */ }
@@ -172,7 +178,7 @@ function printHelp() {
   console.log('  help                Show this message');
   console.log('');
   console.log('Flags:');
-  console.log('  --link <dir>        Symlink bin/oc-edit into <dir> (typically ~/.local/bin)');
+  console.log('  --link <dir>        Symlink bin/oc-edit, oc-shell, oc-popup, oc-install-tmux into <dir> (typically ~/.local/bin)');
   console.log('  --dry-run           Print the plan; do not execute');
   console.log('  --help              Show this message');
   console.log('');

--- a/integrations/terminal/bin/oc-install-tmux
+++ b/integrations/terminal/bin/oc-install-tmux
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# oc-install-tmux — build a private tmux 3.4 into ~/.opencues/vendor/tmux/.
+#
+# oc-shell uses the vendored binary exclusively; the system tmux
+# (/usr/bin/tmux, brew tmux, etc.) is never invoked.
+#
+# Build-time deps are NOT vendored — we link against the system's
+# libevent / ncurses. Those are libraries, not tmux. If they're not
+# present, we print platform-specific install commands and exit.
+#
+# Uninstall: `rm -rf ~/.opencues/vendor/tmux/`.
+
+set -euo pipefail
+
+VENDOR_DIR="$HOME/.opencues/vendor/tmux"
+SRC_DIR="$HOME/.opencues/vendor/src"
+TMUX_VERSION="3.4"
+TARBALL="tmux-${TMUX_VERSION}.tar.gz"
+URL="https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/${TARBALL}"
+
+# ── If already installed, no-op ─────────────────────────────────────
+if [ -x "$VENDOR_DIR/bin/tmux" ]; then
+  installed_ver="$("$VENDOR_DIR/bin/tmux" -V 2>&1 | awk '{print $2}')"
+  echo "tmux $installed_ver already vendored at $VENDOR_DIR/bin/tmux"
+  echo "  (force reinstall: rm -rf $VENDOR_DIR && $0)"
+  exit 0
+fi
+
+# ── Build-dep probe ─────────────────────────────────────────────────
+missing=()
+command -v gcc       >/dev/null 2>&1 || missing+=(gcc)
+command -v make      >/dev/null 2>&1 || missing+=(make)
+command -v pkg-config >/dev/null 2>&1 || missing+=(pkg-config)
+command -v bison     >/dev/null 2>&1 || missing+=(bison)
+command -v curl      >/dev/null 2>&1 || missing+=(curl)
+pkg-config --exists libevent 2>/dev/null || missing+=(libevent-dev)
+{ pkg-config --exists ncurses 2>/dev/null || pkg-config --exists ncursesw 2>/dev/null; } || missing+=(libncurses-dev)
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "oc-install-tmux: missing build deps: ${missing[*]}" >&2
+  echo "" >&2
+  echo "Install (pick the one for your platform):" >&2
+  echo "  Debian/Ubuntu:  sudo apt install -y ${missing[*]}" >&2
+  echo "  Fedora:         sudo dnf install -y libevent-devel ncurses-devel bison gcc make pkgconf-pkg-config" >&2
+  echo "  Arch:           sudo pacman -S --needed libevent ncurses bison gcc make pkgconf" >&2
+  echo "  macOS:          brew install libevent ncurses bison pkg-config" >&2
+  echo "" >&2
+  echo "These are libraries needed only to BUILD tmux — your system" >&2
+  echo "tmux (if any) is left untouched. After installing the deps," >&2
+  echo "re-run: $0" >&2
+  exit 1
+fi
+
+mkdir -p "$SRC_DIR" "$VENDOR_DIR"
+
+# ── Fetch source ─────────────────────────────────────────────────────
+cd "$SRC_DIR"
+if [ ! -f "$TARBALL" ]; then
+  echo "▸ downloading tmux $TMUX_VERSION source"
+  curl -fsSL -o "$TARBALL.tmp" "$URL"
+  mv "$TARBALL.tmp" "$TARBALL"
+fi
+if [ ! -d "tmux-${TMUX_VERSION}" ]; then
+  tar -xzf "$TARBALL"
+fi
+
+# ── Configure + build + install ──────────────────────────────────────
+cd "tmux-${TMUX_VERSION}"
+
+LOG_DIR="$HOME/.opencues/vendor"
+mkdir -p "$LOG_DIR"
+
+echo "▸ configuring (prefix=$VENDOR_DIR)"
+./configure --prefix="$VENDOR_DIR" --enable-static=no >"$LOG_DIR/configure.log" 2>&1
+
+cores="$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)"
+echo "▸ building with $cores cores"
+make -j"$cores" >"$LOG_DIR/make.log" 2>&1
+
+echo "▸ installing to $VENDOR_DIR"
+make install >"$LOG_DIR/install.log" 2>&1
+
+installed_ver="$("$VENDOR_DIR/bin/tmux" -V 2>&1 | awk '{print $2}')"
+echo ""
+echo "✓ tmux $installed_ver installed at $VENDOR_DIR/bin/tmux"
+echo "  Build logs: $LOG_DIR/{configure,make,install}.log"
+echo ""
+echo "oc-shell will use this automatically. System tmux is untouched:"
+echo "  vendored: $VENDOR_DIR/bin/tmux ($installed_ver)"
+sys_tmux="$(command -v tmux 2>/dev/null || echo '(none)')"
+if [ "$sys_tmux" != "(none)" ] && [ "$sys_tmux" != "$VENDOR_DIR/bin/tmux" ]; then
+  echo "  system:   $sys_tmux ($($sys_tmux -V 2>&1 | awk '{print $2}'))"
+fi
+echo ""
+echo "To uninstall: rm -rf $VENDOR_DIR ${SRC_DIR}/tmux-${TMUX_VERSION}*"

--- a/integrations/terminal/bin/oc-popup
+++ b/integrations/terminal/bin/oc-popup
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# oc-popup — runs inside a tmux display-popup. Invokes oc-edit and,
+# on a successful commit, bracket-pastes the result into the
+# originating pane (the pane that was active when Ctrl+Alt+X fired).
+#
+# Usage: oc-popup <originating-pane-id>
+#
+# Why bracket-paste (paste-buffer -p) instead of send-keys -l:
+#   - Preserves multi-line text without each newline triggering
+#     command execution in the shell.
+#   - Modern bash/zsh/fish respect bracketed paste — the pasted
+#     block lands at the prompt as a single editable chunk.
+#
+# Lifecycle:
+#   - tmux opens this script in a display-popup with `-E`, which
+#     closes the popup when oc-popup exits.
+#   - On Ctrl+S in oc-edit: text written to tmpfile, popup closes,
+#     bracket-paste fires.
+#   - On Ctrl+C / Esc / empty buffer: tmpfile is empty or missing,
+#     nothing is pasted.
+
+set -u
+
+ORIGIN_PANE="${1:-}"
+TMPFILE="$(mktemp -t oc-popup.XXXXXX)"
+trap 'rm -f "$TMPFILE"' EXIT
+
+# Resolve through symlinks so a symlinked oc-popup still finds its sibling oc-edit.
+SCRIPT="$(readlink -f -- "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+HERE="$(cd -- "$(dirname -- "$SCRIPT")" && pwd)"
+if [ -x "$HERE/oc-edit" ]; then
+  OC_EDIT="$HERE/oc-edit"
+else
+  OC_EDIT="$(command -v oc-edit 2>/dev/null || true)"
+fi
+
+if [ -z "${OC_EDIT:-}" ]; then
+  echo "oc-popup: oc-edit not found on PATH or in sibling bin/" >&2
+  sleep 2
+  exit 127
+fi
+
+"$OC_EDIT" --out "$TMPFILE" || true
+
+# Use the same vendored tmux oc-shell exported. We must NOT
+# PATH-resolve `tmux` here — the system tmux's client speaks a
+# different protocol than our vendored server (different versions),
+# and the user explicitly opted out of system-tmux involvement.
+TMUX_BIN="${OPENCUES_TMUX:-$HOME/.opencues/vendor/tmux/bin/tmux}"
+if [ ! -x "$TMUX_BIN" ]; then
+  echo "oc-popup: vendored tmux not found at $TMUX_BIN" >&2
+  sleep 2
+  exit 1
+fi
+
+# Inject only if oc-edit committed text AND we have a pane target.
+if [ -n "$ORIGIN_PANE" ] && [ -s "$TMPFILE" ]; then
+  "$TMUX_BIN" load-buffer -b oc-popup "$TMPFILE"
+  "$TMUX_BIN" paste-buffer -p -b oc-popup -t "$ORIGIN_PANE"
+  "$TMUX_BIN" delete-buffer -b oc-popup
+fi

--- a/integrations/terminal/bin/oc-shell
+++ b/integrations/terminal/bin/oc-shell
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# oc-shell — launch a tmux-wrapped shell with the OpenCues popup binding.
+#
+# Always uses our own vendored tmux. The system tmux (/usr/bin/tmux,
+# brew tmux, etc.) is NEVER invoked — by absolute path only.
+#
+# From the user's POV:
+#   - Run `oc-shell` from anywhere.
+#   - They get their normal $SHELL prompt in the current $PWD.
+#   - Press Ctrl+Alt+X to open a floating OpenCues popup.
+#   - Type `exit` (or Ctrl+D) to leave; the wrapped tmux session is
+#     destroyed and oc-shell returns.
+#
+# Resolution order for the tmux binary:
+#   1. $OPENCUES_TMUX (explicit override; useful for tests / packagers)
+#   2. ~/.opencues/vendor/tmux/bin/tmux (built by `oc-install-tmux`)
+#   ─── nothing else ───
+#
+# PATH is intentionally NOT consulted. If the vendored binary isn't
+# present, oc-shell exits with a clear "run oc-install-tmux" message.
+
+set -u
+
+# Resolve through symlinks so `~/.local/bin/oc-shell -> .../integrations/terminal/bin/oc-shell`
+# still finds ../conf/oc-shell.tmux.conf relative to the REAL script location.
+SCRIPT="$(readlink -f -- "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
+HERE="$(cd -- "$(dirname -- "$SCRIPT")" && pwd)"
+CONF="$HERE/../conf/oc-shell.tmux.conf"
+VENDOR_TMUX="$HOME/.opencues/vendor/tmux/bin/tmux"
+OC_TMUX="${OPENCUES_TMUX:-$VENDOR_TMUX}"
+
+# Make oc-edit / oc-popup visible to the wrapped session even if the
+# user invoked oc-shell via an absolute path (no PATH entry).
+export PATH="$HERE:$PATH"
+# Propagate the chosen tmux to oc-popup (which also needs to invoke
+# tmux for buffer ops against the wrapped server).
+export OPENCUES_TMUX="$OC_TMUX"
+
+if [ ! -f "$CONF" ]; then
+  echo "oc-shell: missing tmux config at $CONF" >&2
+  exit 1
+fi
+
+if [ ! -x "$OC_TMUX" ]; then
+  echo "oc-shell: vendored tmux not found at $OC_TMUX" >&2
+  echo "" >&2
+  echo "Build it (one-time, ~30s):" >&2
+  echo "  $HERE/oc-install-tmux" >&2
+  echo "" >&2
+  echo "Or point at an existing >=3.2 binary:" >&2
+  echo "  OPENCUES_TMUX=/path/to/tmux oc-shell" >&2
+  exit 1
+fi
+
+# Sanity-check the vendored version. We built it ourselves so this
+# should always pass — but a packager or override path could differ.
+TMUX_VER="$("$OC_TMUX" -V 2>&1 | awk '{print $2}' | sed 's/[^0-9.].*//')"
+TMUX_MAJOR="${TMUX_VER%%.*}"
+TMUX_MINOR_REST="${TMUX_VER#*.}"
+TMUX_MINOR="${TMUX_MINOR_REST%%.*}"
+if [ -n "$TMUX_MAJOR" ] && [ -n "$TMUX_MINOR" ]; then
+  if [ "$TMUX_MAJOR" -lt 3 ] || { [ "$TMUX_MAJOR" -eq 3 ] && [ "$TMUX_MINOR" -lt 2 ]; }; then
+    echo "oc-shell: $OC_TMUX is tmux $TMUX_VER; >= 3.2 required for display-popup." >&2
+    echo "  Rebuild: rm -rf ~/.opencues/vendor/tmux && $HERE/oc-install-tmux" >&2
+    exit 1
+  fi
+fi
+
+# ── Nested-tmux: we still spawn OUR tmux on a private socket ────────
+# tmux 3.0+ warns when $TMUX is set on launch (it detects nesting).
+# Unset it so our private server starts cleanly; the user's outer
+# tmux is still there underneath and untouched.
+unset TMUX
+
+# ── Fresh wrap ──────────────────────────────────────────────────────
+SHELL_TO_RUN="${SHELL:-/bin/sh}"
+SOCKET="opencues-$$"
+
+exec "$OC_TMUX" -L "$SOCKET" -f "$CONF" \
+  new-session -A -s main -c "$PWD" "$SHELL_TO_RUN"

--- a/integrations/terminal/conf/oc-shell.tmux.conf
+++ b/integrations/terminal/conf/oc-shell.tmux.conf
@@ -1,0 +1,64 @@
+# OpenCues tmux wrapper config — loaded by `oc-shell`.
+#
+# This file is private to oc-shell and does NOT touch ~/.tmux.conf.
+# oc-shell launches tmux with `-L opencues-<pid> -f <this file>` so the
+# user's existing tmux server and config are untouched.
+
+# ─── Terminal capabilities ──────────────────────────────────────────
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",xterm-256color:RGB,xterm-kitty:RGB,alacritty:RGB,wezterm:RGB"
+set -g allow-passthrough on
+
+# ─── Mouse + behaviour ──────────────────────────────────────────────
+set -g mouse on
+set -g destroy-unattached on
+set -g remain-on-exit off
+set -g history-limit 50000
+
+# ─── No prefix (oc-shell does not expose tmux features) ─────────────
+# Passes Ctrl+B through to readline / the running app instead of
+# putting tmux into a prefix-waiting state.
+set -g prefix None
+unbind C-b
+
+# ─── Status line ────────────────────────────────────────────────────
+# Status line is ON so users can see how to exit during this early
+# build. It's a thin one-liner at the bottom of the screen.
+#
+# TO REMOVE THE STATUS LINE LATER:
+#   1. Change "set -g status on" to "set -g status off" below.
+#      That's it — the rest of the status-* lines become inert.
+#   2. (Optional) delete the status-style / status-right lines for
+#      tidiness; they have no effect when status is off.
+#
+# With status off the wrapped session is visually indistinguishable
+# from a plain terminal (one $TMUX env var still leaks; see oc-shell
+# for notes).
+set -g status on
+set -g status-position bottom
+set -g status-interval 5
+set -g status-style 'bg=#1a1a1a fg=#888888'
+set -g status-justify left
+set -g status-left ''
+set -g status-left-length 0
+set -g status-right 'OpenCues  Ctrl+Alt+X popup   type "exit" to leave '
+set -g status-right-length 80
+set -g window-status-format ''
+set -g window-status-current-format ''
+
+# ─── Popup binding ──────────────────────────────────────────────────
+# Ctrl+Alt+X opens the OpenCues popup as a centered floating box,
+# sized 80% wide × 70% tall (enough room for multi-line composition).
+# The popup runs `oc-popup <originating-pane-id>`, which invokes
+# oc-edit; on commit the result is bracket-pasted into the pane the
+# user invoked from.
+#
+# `-n`         = root key-table (no prefix needed)
+# `-E`         = close the popup automatically when the command exits
+# `-w / -h`    = popup geometry as % of the terminal size
+# `-d ...`     = open the popup in the same CWD as the originating pane
+# `#{pane_id}` = format string resolved against the originating pane
+bind-key -n M-C-x display-popup -E \
+  -w 80% -h 70% \
+  -d "#{pane_current_path}" \
+  "oc-popup '#{pane_id}'"

--- a/integrations/terminal/package.json
+++ b/integrations/terminal/package.json
@@ -5,7 +5,10 @@
   "description": "OpenCues for the terminal — a standalone Bun/OpenTUI TUI you launch as `oc-edit`. Brings full cues, blanks, cycling, agent-rewrite to any shell via $EDITOR or a ZLE widget.",
   "type": "module",
   "bin": {
-    "oc-edit": "./bin/oc-edit"
+    "oc-edit": "./bin/oc-edit",
+    "oc-shell": "./bin/oc-shell",
+    "oc-popup": "./bin/oc-popup",
+    "oc-install-tmux": "./bin/oc-install-tmux"
   },
   "scripts": {
     "//comment-on-build": "Intentionally a no-op in CI. bin/oc-edit falls back to src/app.tsx when dist/app.js is absent (Bun handles TSX natively at run time), so a pre-bundled dist is purely a perf optimisation for warm starts — not required for correctness. CI runners don't have Bun installed; running `bun build` there fails. To produce a pre-bundled dist for a release, run `pnpm run bundle` locally with Bun on PATH.",
@@ -26,6 +29,7 @@
   },
   "files": [
     "bin/",
+    "conf/",
     "dist/",
     "README.md"
   ]

--- a/integrations/terminal/patches/setup.sh
+++ b/integrations/terminal/patches/setup.sh
@@ -70,15 +70,21 @@ fi
 # ─── Optional symlink ────────────────────────────────────────────────
 if [[ -n "$LINK_DIR" ]]; then
   mkdir -p "$LINK_DIR"
-  ln -sf "$TERM_DIR/bin/oc-edit" "$LINK_DIR/oc-edit"
-  echo "  ▸ symlinked oc-edit → $LINK_DIR/oc-edit"
+  for bin in oc-edit oc-shell oc-popup oc-install-tmux; do
+    ln -sf "$TERM_DIR/bin/$bin" "$LINK_DIR/$bin"
+    echo "  ▸ symlinked $bin → $LINK_DIR/$bin"
+  done
 fi
 
 echo "✓ Terminal integration ready."
 echo
 echo "Try it:"
-echo "  $TERM_DIR/bin/oc-edit"
-echo "  echo 'the attorney filed today' | $TERM_DIR/bin/oc-edit"
+echo "  $TERM_DIR/bin/oc-edit                  # standalone editor"
+echo "  $TERM_DIR/bin/oc-shell                 # shell wrapped with Ctrl+Alt+X popup"
+echo
+echo "For oc-shell, build the vendored tmux 3.4 first (one-time, ~30s):"
+echo "  $TERM_DIR/bin/oc-install-tmux          # builds to ~/.opencues/vendor/tmux/"
+echo "  (system tmux is never touched; user PATH is never changed)"
 echo
 echo "As your editor:"
 echo "  export EDITOR=$TERM_DIR/bin/oc-edit"


### PR DESCRIPTION
## Summary
- Adds `oc-shell`: a hotkey-triggered OpenCues popup that overlays any shell.
  Boots a private tmux session at the user's CWD, exposes their `$SHELL` as normal, binds `Ctrl+Alt+X` to a centered floating popup running `oc-edit`. On commit, the text is bracket-pasted into the originating pane (multi-line preserved as a single editable paste, no premature execution on newlines).
- Adds `oc-install-tmux`: one-time build of tmux 3.4 → `~/.opencues/vendor/tmux/`. The system tmux is never invoked — `oc-shell` and `oc-popup` resolve the binary by absolute path only, PATH is never consulted.
- Status line ON for now ("OpenCues  Ctrl+Alt+X popup   type 'exit' to leave"); the conf file has an inline comment block documenting the one-line change to hide it later.

## Files
- `bin/oc-shell` — launcher (private socket, private config, vendored binary, unsets $TMUX before exec)
- `bin/oc-popup` — invoked by display-popup; runs oc-edit, `tmux load-buffer` + `paste-buffer -p` back to the origin pane
- `bin/oc-install-tmux` — probes build deps (libevent-dev, bison, etc.), prints platform-specific install commands if missing, otherwise downloads + builds + installs
- `conf/oc-shell.tmux.conf` — private tmux config: status line on, prefix None (Ctrl+B passes through to readline), mouse on, popup binding via `display-popup -E -w 80% -h 70%`
- Installer wiring: `setup.sh`, `install.cjs`, `package.json` bin map, `CLAUDE.md`, `TEST-WHEN-MERGED.md` § 9

## Design notes
- Why vendored tmux: spec from @wkasekende — "we always want our own"; never touch the system tmux. Resolution order in `oc-shell` is strictly `$OPENCUES_TMUX` → `~/.opencues/vendor/tmux/bin/tmux` → error. No PATH fallback.
- Why bracket-paste (not send-keys -l): preserves multi-line input as a single editable chunk; newlines don't execute prematurely. Uses `load-buffer` + `paste-buffer -p`.
- Why `set -g prefix None` + `unbind C-b`: oc-shell does not expose tmux features; Ctrl+B should pass through to readline as a normal backward-char.
- Nested-tmux: `oc-shell` simply unsets `$TMUX` before exec — our private tmux server runs on its own `-L opencues-<pid>` socket and the user's outer tmux is untouched.

## Test plan
- [ ] On a tmux < 3.2 box with deps missing: `oc-install-tmux` exits cleanly with the right `sudo apt install ...` line
- [ ] After installing deps: `oc-install-tmux` builds tmux 3.4 into `~/.opencues/vendor/tmux/`; `/usr/bin/tmux` still 3.0a, untouched
- [ ] `oc-shell` with no vendored tmux: clean error pointing at `oc-install-tmux`
- [ ] `oc-shell` after install: drops into `$SHELL` at `$PWD`, status bar at bottom
- [ ] `Ctrl+Alt+X`: popup opens (80% × 70%), oc-edit running, OpenCues cycling/blanks active
- [ ] Compose multi-line text + `Ctrl+S`: popup closes, text bracket-pastes at prompt as one editable block
- [ ] `Esc` / `Ctrl+C` in popup: closes with nothing pasted
- [ ] `exit` at wrapped shell: tmux session destroyed, no orphan socket
- [ ] Already-in-tmux: `oc-shell` still wraps on its own private socket; user's outer tmux untouched

Full reviewer checklist: `integrations/terminal/TEST-WHEN-MERGED.md` § 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)