### PR TITLE
blank-loading: refcount animator + chrome: flatten status-bar

### DIFF
--- a/integrations/chrome/src/content.css
+++ b/integrations/chrome/src/content.css
@@ -30,7 +30,8 @@
  * on Chrome today; the italic rule is included as a forward-compat
  * hint and silently ignored when not supported. */
 
-/* Status bar — fixed bottom-right corner */
+/* Status bar — fixed bottom-right corner. Plain square box: no
+ * rounded corners, no shadow, no glow. */
 .oc-status-bar {
   position: fixed;
   bottom: 16px;
@@ -40,8 +41,8 @@
   color: #e2e8f0;
   font-family: system-ui, sans-serif;
   font-size: 13px;
-  border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  border-radius: 0;
+  box-shadow: none;
   z-index: 99999;
   opacity: 0;
   transform: translateY(8px);

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -295,8 +295,10 @@ export class BlankFill {
       });
       // Loading indicator — start animating the slot while the source
       // resolves. No-op when blank-loading-animation is 'off'. Stopped
-      // in the .then/.catch handlers below.
-      this._loadingAnimator().start(slot.index);
+      // in the .then/.catch handlers below. Owner tag keeps Resolver's
+      // own start/stop on the same slot from racing this one — the slot
+      // animates until BOTH owners release (refcounted in animator).
+      this._loadingAnimator().start(slot.index, 'blank-fill');
 
       // Try host-native blank invocation first (Chrome, Electron,
       // anything without shell access). Fall through to spawnProcess
@@ -312,8 +314,11 @@ export class BlankFill {
         if (!script) {
           // blankInvoke didn't recognise the blank AND there's no
           // shell fallback. Drop the dedup so a later state change can
-          // retry, and skip cleanly.
+          // retry, and skip cleanly. Release the loading claim we
+          // just took — without this, the slot would animate forever
+          // (no .then/.catch ever fires to stop it).
           this._pendingScripts.delete(dedupKey);
+          this._loadingAnimator().stop(slot.index, 'blank-fill');
           continue;
         }
         // OS-level sandbox config — populated when the blank's
@@ -355,7 +360,7 @@ export class BlankFill {
       }
       handle.result.then(res => {
         this._pendingScripts.delete(dedupKey);
-        this._loadingAnimator().stop(slot.index);
+        this._loadingAnimator().stop(slot.index, 'blank-fill');
         this.adapter.log('debug', `BlankFill: script result for ${slot.blankName}`, { exitCode: res.exitCode, timedOut: res.timedOut, stdoutLen: res.stdout?.length ?? 0, stdoutPreview: res.stdout?.slice(0, 80) });
         if (res.exitCode !== 0 || res.timedOut) return;
         const stdout = res.stdout.trim();
@@ -363,7 +368,7 @@ export class BlankFill {
         this.applyAsyncFill(slot, stdout);
       }).catch(err => {
         this._pendingScripts.delete(dedupKey);
-        this._loadingAnimator().stop(slot.index);
+        this._loadingAnimator().stop(slot.index, 'blank-fill');
         this.adapter.log('error', `BlankFill: script promise rejected for ${slot.blankName}`, err);
       });
     }

--- a/packages/opencues-runtime/src/modules/blank-loading.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-loading.test.ts
@@ -309,6 +309,105 @@ describe('BlankLoadingAnimator — start/stop lifecycle', () => {
   });
 });
 
+describe('BlankLoadingAnimator — owner refcount', () => {
+  // The scenario this guards: BlankFill animates a keyword-bound `_`
+  // (stocks, weather, volume) for the full duration of its async
+  // fetch (~200-500ms). The Resolver ALSO starts animation on every
+  // `_` slot and stops them when its own pipeline returns — which is
+  // ~1ms when no resolver-side source claims the slot. Without the
+  // refcount the resolver's stop killed BlankFill's animation before
+  // the first frame (150ms tick) ever painted.
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('two owners on the same slot: stop from one keeps animation alive', () => {
+    const { adapter, setTextCalls } = makeAdapter('nvda stock _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(2, 'blank-fill');
+    a.start(2, 'resolver');
+    expect(a.active).toBe(true);
+    // Resolver's fast stop — animation should KEEP going (blank-fill
+    // still owns the slot).
+    a.stop(2, 'resolver');
+    expect(a.active).toBe(true);
+    vi.advanceTimersByTime(100);
+    expect(setTextCalls).toEqual(['nvda stock -']);   // tick happened
+    vi.advanceTimersByTime(100);
+    expect(setTextCalls).toEqual(['nvda stock -', 'nvda stock ‾']);
+    // blank-fill's fetch returns and releases its claim → finally stops.
+    a.stop(2, 'blank-fill');
+    expect(a.active).toBe(false);
+    expect(setTextCalls.at(-1)).toBe('nvda stock _');  // restored
+  });
+
+  it('symmetric: blank-fill stops first, resolver still animates', () => {
+    const { adapter, setTextCalls } = makeAdapter('foo _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1, 'blank-fill');
+    a.start(1, 'resolver');
+    a.stop(1, 'blank-fill');
+    expect(a.active).toBe(true);
+    vi.advanceTimersByTime(100);
+    expect(setTextCalls).toEqual(['foo -']);
+    a.stop(1, 'resolver');
+    expect(a.active).toBe(false);
+  });
+
+  it('same owner double-start is a no-op', () => {
+    const { adapter } = makeAdapter('foo _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1, 'blank-fill');
+    a.start(1, 'blank-fill');
+    a.stop(1, 'blank-fill');
+    // One stop matches both starts (idempotent for same owner).
+    expect(a.active).toBe(false);
+  });
+
+  it('stop with unknown owner is a no-op', () => {
+    const { adapter } = makeAdapter('foo _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1, 'blank-fill');
+    a.stop(1, 'resolver');     // resolver never started this slot
+    expect(a.active).toBe(true);
+    a.stop(1, 'blank-fill');
+    expect(a.active).toBe(false);
+  });
+
+  it('default owner used when none supplied (back-compat)', () => {
+    const { adapter, setTextCalls } = makeAdapter('foo _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1);
+    a.stop(1);
+    expect(a.active).toBe(false);
+    expect(setTextCalls).toEqual([]);  // never ticked before stop
+  });
+
+  it('stopAll(owner) only drops that owner\'s claims', () => {
+    const { adapter } = makeAdapter('a _ b _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1, 'resolver');
+    a.start(1, 'blank-fill');
+    a.start(3, 'resolver');           // only resolver on this slot
+    a.stopAll('resolver');
+    // Slot 1 still has blank-fill; slot 3 had only resolver → dropped.
+    expect(a.active).toBe(true);
+    expect(a.activeSlots.has(1)).toBe(true);
+    expect(a.activeSlots.has(3)).toBe(false);
+    a.stop(1, 'blank-fill');
+    expect(a.active).toBe(false);
+  });
+
+  it('stopAll() (no owner) hard-drops every slot regardless of owners', () => {
+    const { adapter } = makeAdapter('a _ b _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1, 'resolver');
+    a.start(1, 'blank-fill');
+    a.start(3, 'blank-fill');
+    a.stopAll();
+    expect(a.active).toBe(false);
+  });
+});
+
 describe('parseCustomFrames', () => {
   it('returns null for empty input', () => {
     expect(parseCustomFrames(undefined)).toBeNull();

--- a/packages/opencues-runtime/src/modules/blank-loading.ts
+++ b/packages/opencues-runtime/src/modules/blank-loading.ts
@@ -281,15 +281,33 @@ interface ActiveSlot {
  * Per-buffer loading-animation manager. One instance per BlankFill;
  * created by the runtime once at boot.
  *
- *   start(wordIndex)  — claim a slot and begin animating.
- *   stop(wordIndex)   — release a slot and snap back to `_`.
- *   stopAll()         — release every active slot (used on adapter teardown).
+ *   start(wordIndex, owner)  — claim a slot and begin animating.
+ *   stop(wordIndex, owner)   — release this owner's claim; the slot
+ *                              stops only when the LAST owner releases.
+ *   stopAll(owner?)          — release every active slot (used on
+ *                              adapter teardown). With an owner, only
+ *                              that owner's claims are released.
+ *
+ * Owner-based refcounting matters because two modules independently
+ * animate the same slot:
+ *   - BlankFill animates keyword-bound `_` (stocks, weather, volume)
+ *     while its blankInvoke / spawnProcess call is in flight.
+ *   - Resolver animates every `_` for the duration of its source pass
+ *     (covers FluidBlank / TransformBlank LLM round-trips).
+ * Without refcounting, the Resolver — which returns within ~1ms for a
+ * `_` that no resolver-side source claims (the keyword-bound case) —
+ * would kill BlankFill's still-pending animation. The first frame
+ * never paints (tick interval is 150ms; resolver's stop fires before
+ * the timer ever ticks).
  *
  * Tests in `blank-loading.test.ts` exercise the frame state machine
  * against a mock adapter.
  */
 export class BlankLoadingAnimator {
   private readonly _active = new Map<number, ActiveSlot>();
+  /** Per-slot set of owner IDs. The slot stops animating only when
+   *  this set becomes empty. */
+  private readonly _owners = new Map<number, Set<string>>();
   private _timer: ReturnType<typeof setInterval> | null = null;
   private readonly _frameIntervalMsFn: () => number;
   private readonly _modeFn: () => BlankLoadingMode;
@@ -358,16 +376,25 @@ export class BlankLoadingAnimator {
 
   /**
    * Begin animating the `_` at the given word index. Honours the
-   * current mode — if `off`, this is a no-op. If already animating
-   * the same wordIndex, it's a no-op (avoids double-claim race
-   * between BlankFill's dedup and a stale call).
+   * current mode — if `off`, this is a no-op. The `owner` identifies
+   * which module is claiming the slot; the slot keeps animating until
+   * EVERY owner that called `start` has called `stop`. A second start
+   * from the SAME owner on an already-active slot is a no-op (avoids
+   * double-claim on dedup retries).
    */
-  start(wordIndex: number): void {
+  start(wordIndex: number, owner: string = 'default'): void {
     const mode = this._modeFn();
     const customFrames = mode === 'custom' ? this._customFramesFn() : null;
     const frames = framesFor(mode, customFrames);
     if (frames.length === 0) return;          // mode === 'off'
-    if (this._active.has(wordIndex)) return;
+    let owners = this._owners.get(wordIndex);
+    if (owners === undefined) {
+      owners = new Set();
+      this._owners.set(wordIndex, owners);
+    }
+    if (owners.has(owner)) return;
+    owners.add(owner);
+    if (this._active.has(wordIndex)) return;  // already animating for another owner
     const customFramesPresent = mode === 'custom' && customFrames !== null && customFrames.length > 0;
     this._active.set(wordIndex, {
       wordIndex,
@@ -379,33 +406,59 @@ export class BlankLoadingAnimator {
       ? (customFramesPresent ? 'custom' : 'custom→braille-rotate (fallback)')
       : mode;
     const framesPreview = frames.map(f => JSON.stringify(f)).join(',');
-    this._log(`BlankLoading: start wordIndex=${wordIndex} mode=${modeTag} frames=[${framesPreview}]`);
+    this._log(`BlankLoading: start wordIndex=${wordIndex} owner=${owner} mode=${modeTag} frames=[${framesPreview}]`);
     if (this._timer === null) {
       this._timer = setInterval(() => this._tick(), this._frameIntervalMsFn());
     }
   }
 
   /**
-   * Stop animating the slot and restore its character to `_`. Idempotent.
-   * The restore is best-effort: if the slot's current char isn't one of
-   * our frame characters (user typed over it, substitution already ran),
-   * the restore is skipped — we don't want to overwrite real content.
+   * Release this owner's claim on the slot. The slot actually stops
+   * (timer drops, `_` restored) only when the LAST owner releases.
+   * Idempotent: stopping with an unknown owner / unknown slot is a
+   * no-op. Restore is best-effort — if the slot's current char isn't
+   * one of our frame characters (user typed over it, substitution
+   * already ran), restore is skipped.
    */
-  stop(wordIndex: number): void {
+  stop(wordIndex: number, owner: string = 'default'): void {
+    const owners = this._owners.get(wordIndex);
+    if (owners === undefined) return;
+    if (!owners.delete(owner)) return;
+    if (owners.size > 0) return;              // other owners still animating
+    this._owners.delete(wordIndex);
     const slot = this._active.get(wordIndex);
     if (!slot) return;
     this._active.delete(wordIndex);
     this._restoreUnderscore(wordIndex, slot.frames);
-    this._log(`BlankLoading: stop wordIndex=${wordIndex}`);
+    this._log(`BlankLoading: stop wordIndex=${wordIndex} owner=${owner}`);
     if (this._active.size === 0 && this._timer !== null) {
       clearInterval(this._timer);
       this._timer = null;
     }
   }
 
-  /** Drop every active slot. Used on adapter teardown / explicit reset. */
-  stopAll(): void {
-    for (const idx of [...this._active.keys()]) this.stop(idx);
+  /**
+   * Drop every active slot. With an `owner`, releases only that
+   * owner's claims (other owners may keep slots alive). Without one,
+   * forcibly drops every slot regardless of owner — used on adapter
+   * teardown / explicit reset.
+   */
+  stopAll(owner?: string): void {
+    if (owner === undefined) {
+      this._owners.clear();
+      for (const idx of [...this._active.keys()]) {
+        const slot = this._active.get(idx);
+        if (!slot) continue;
+        this._active.delete(idx);
+        this._restoreUnderscore(idx, slot.frames);
+      }
+      if (this._timer !== null) {
+        clearInterval(this._timer);
+        this._timer = null;
+      }
+      return;
+    }
+    for (const idx of [...this._owners.keys()]) this.stop(idx, owner);
   }
 
   // ─── Internals ──────────────────────────────────────────────────────
@@ -486,6 +539,7 @@ export class BlankLoadingAnimator {
 
   private _dropQuiet(wordIndex: number): void {
     this._active.delete(wordIndex);
+    this._owners.delete(wordIndex);
     if (this._active.size === 0 && this._timer !== null) {
       clearInterval(this._timer);
       this._timer = null;

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -826,23 +826,28 @@ export class Resolver {
     }
 
     // Loading animation: start animating every `_` slot before dispatch
-    // and stop them all after the pipeline returns (success, error, or
-    // empty result). Idempotent: BlankFill may have already started
-    // animating a keyword-bound `_`, in which case start() is a no-op.
+    // and release the resolver's claim after the pipeline returns
+    // (success, error, or empty result). Refcounted by owner — when a
+    // keyword-bound `_` (stocks, weather, volume) is also being filled
+    // by BlankFill, both modules call start/stop with their own owner
+    // ID and the slot keeps animating until BOTH release. Without that,
+    // the resolver's typically-fast return on keyword-bound slots
+    // (no resolver-side source claims them) would kill BlankFill's
+    // still-pending animation before the first frame ever paints.
     // stop() restores each slot to `_` so the substitution path's
     // `target.word === '_'` check still passes.
     const animatedSlots: number[] = [];
     if (this.blankLoading) {
       for (let i = 0; i < cleanWords.length; i++) {
         if (cleanWords[i] === '_') {
-          this.blankLoading.start(i);
+          this.blankLoading.start(i, 'resolver');
           animatedSlots.push(i);
         }
       }
     }
     const stopAllAnimations = (): void => {
       if (!this.blankLoading) return;
-      for (const i of animatedSlots) this.blankLoading.stop(i);
+      for (const i of animatedSlots) this.blankLoading.stop(i, 'resolver');
     };
 
     // Capture resolve-start so we can surface end-to-end pipeline


### PR DESCRIPTION
## Summary

Two independent changes that came up in the same session:

- **Refcount `BlankLoadingAnimator`** — fixes the loading animation never showing for keyword-bound blanks (`stocks _`, `weather _`, `volume _`). Two modules (`Resolver` and `BlankFill`) share one animator instance and were racing on stop calls: the Resolver returned within ~1ms for slots no resolver-side source claimed (the keyword-bound case) and its `stopAllAnimations()` killed BlankFill's still-pending animation before the first 150ms tick painted a frame. Owner-based refcounting (\`start(idx, 'resolver')\` vs \`start(idx, 'blank-fill')\`) makes the slot keep animating until every owner releases. Also fixes an existing leak in BlankFill's no-handle/no-script branch.
- **Chrome status-bar styling** — drops \`border-radius\` (6→0) and \`box-shadow\` (→ none) on \`.oc-status-bar\` for a flat square look.

## Test plan

- [x] \`pnpm exec vitest run\` in \`packages/opencues-runtime\` — 1377/1377 pass (includes 7 new scenario tests for refcount behaviour)
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] Chrome bundle rebuilt + synced to Windows extension path
- [x] Manual: type \`nvda stock _\` in any host with fresh keyword (StocksBlank caches 60s — cache hits return too fast to animate by design); confirm bounce/braille-rotate animates while the Finnhub fetch is in flight
- [x] Manual: reload chrome extension + hard-refresh page; confirm status bar renders as flat square with no shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)