### PR TITLE
feat(cc): single-fork install, opt-in statusline, native 2.1.150 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -565,9 +565,9 @@ done
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
 | `packages/opencues-core/` | `@opencues/core` | 0.1.0 | private |
 | `packages/opencues-runtime/` | `@opencues/runtime` | 0.1.0 | private |
-| `packages/opencues-cli/` | `opencues` (real CLI) | 0.1.0 | private |
+| `packages/opencues-cli/` | `opencues` (real CLI) | 0.1.1 | private |
 | `packages/opencues-park/` | `opencues` (placeholder) | 0.0.1 | **PUBLISHED on npm** |
-| `integrations/claude-code/` | `@opencues/claude-code` | 0.1.0 | private |
+| `integrations/claude-code/` | `@opencues/claude-code` | 0.1.1 | private |
 | `integrations/opencode/` | `@opencues/opencode` | 0.1.0 | private |
 | `integrations/chrome/` | `@opencues/chrome` | 0.1.0 | private |
 | `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.1.0 | private |

--- a/docs/install.md
+++ b/docs/install.md
@@ -212,13 +212,26 @@ Shows the highlighted word and its tip in Claude Code's status bar:
 agents (1/3) - Spawn parallel workers via Task tool
 ```
 
-**Enable:** Run `/statusline` in Claude Code and set the command to:
+**Opt-in by design.** `opencues install claude-code` stages
+`statusline.sh` into the CC fork dir but **does not write to
+`~/.claude/settings.json`** — that's Claude Code's own directory and
+we don't want to touch it without explicit consent. Run the dedicated
+command:
 
-```
-~/claude-code-cues/.cues/statusline.sh
+```bash
+opencues statusline status               # what's configured where?
+opencues statusline enable               # writes ~/.claude/settings.json (user-level)
+opencues statusline enable --project     # writes <cwd>/.claude/settings.json (project-level)
+opencues statusline disable [--project]  # clears it
 ```
 
-**Disable:** Run `/statusline` again and clear the command.
+Behaviour rules:
+
+- We back up `settings.json` to `settings.json.bak.cues-statusline` before any write.
+- If `statusLine.command` is already a custom script (your starship.sh, etc.) we refuse to overwrite — pass `--force` if you want to replace it.
+- If `statusLine.command` already points at a stale opencues path (from a prior install layout), `enable` rewrites it to the current path.
+- `disable` only clears our entry — never touches a non-opencues `statusLine.command`.
+- Project-level wins over user-level. `opencues doctor` flags this shadow case so you know when project-level CC settings are suppressing the user-level tip surface.
 
 Full reference: [`integrations/claude-code/docs/status-line.md`](../integrations/claude-code/docs/status-line.md).
 

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -56,7 +56,7 @@ The installer (`opencues install claude-code`) chains two scripts:
    - `npm install @anthropic-ai/claude-code` — pinned to exact version (2.1.110 for the cli.js fork at `~/claude-code-cues/`; 2.1.150+ for the native-binary fork at `~/claude-code-cues-150/`). See [UPGRADING.md](UPGRADING.md) for the cross-shape install dance.
    - Clones tweakcc into `<CC_FORK>/.cues/tweakcc/` (the patcher lives inside the fork)
    - Builds + installs `@opencues/{core,runtime}` into `<CC_FORK>/node_modules/@opencues/`
-   - Installs `statusline.sh` into `<CC_FORK>/.cues/`
+   - Installs `statusline.sh` into `<CC_FORK>/.cues/` (does NOT auto-edit `~/.claude/settings.json` — that's an explicit opt-in via `opencues statusline enable`)
    - Patches tweakcc to wire OpenCues v2 + disable every stock patch
    - Builds tweakcc + verifies dist contains v2 wiring (fail loud if not)
    - Applies tweakcc to cli.js + verifies the boot landed (fail loud if not)

--- a/integrations/claude-code/bin/install.cjs
+++ b/integrations/claude-code/bin/install.cjs
@@ -78,7 +78,10 @@ const { command, args, unknown } = parseArgv(process.argv.slice(2));
 warnUnknownFlags(unknown);
 if (args.help || command === 'help') { printHelp(); process.exit(0); }
 
-printBanner();
+// Skip the per-host banner when invoked as a sub-process from a
+// higher-level command that already printed its own banner (e.g.
+// `opencues update`). Avoids duplicate banners mid-stream.
+if (process.env.OPENCUES_SKIP_BANNER !== '1') printBanner();
 
 const isClone = fs.existsSync(path.join(REPO_ROOT, 'pnpm-workspace.yaml'));
 if (!isClone) {
@@ -107,68 +110,200 @@ if (command === 'install') {
 // --- INSTALL --------------------------------------------------------------
 
 function doInstall() {
-  const target = args.target || tryAutoDetectCli();
-  if (target) checkCompat(target);
-  console.log(`Target cli.js: ${target || '(auto-detecting under ~/.claude/)'}`);
-
-  const installRoot = computeInstallRoot(target);
-  const tweakccConfigDir = installRoot ? path.join(installRoot, 'patch-state') : null;
-  const legacy = legacyPaths();
-
-  if (args.dryRun) {
-    console.log(`\n[dry-run] Would install everything inside the CC fork dir:`);
-    console.log(`  ${installRoot || '(unknown — pass --target to compute)'}/`);
-    for (const p of ['statusline.sh', 'scripts/', 'patch-state/  (patcher config + cli.js.backup)']) {
-      console.log(`    ${p}`);
+  // SINGLE-fork model. We maintain ONE canonical CC fork at
+  // ~/claude-code-cues/. The shape (cli.js vs native binary) is inferred
+  // automatically from the CC version pinned in that fork's package.json
+  // — setup.sh's shape detection handles both. Upgrading CC is editing
+  // the pin in that fork's package.json + re-running install; the fork
+  // stays at ~/claude-code-cues/ regardless of which CC version is pinned.
+  //
+  // Why not "patch every fork I find on disk":
+  //   - Most users only ever want one CC install. Two fork dirs is a
+  //     dev convention, not a product feature.
+  //   - The launcher name (`claude-cues`) is singular. There's no good
+  //     UX for multi-binary.
+  //   - Version upgrades happen IN-PLACE in the canonical fork, not
+  //     by maintaining parallel forks at different pins.
+  //
+  // For devs who DO want parallel forks (testing a new CC version
+  // without disturbing the canonical install): pass --target <cli.js>
+  // explicitly — single-fork install against the named target. Doctor
+  // surfaces extra `~/claude-code-cues-*` dirs as "dev relics — safe
+  // to delete" info findings.
+  const canonicalRoot = path.join(HOME, 'claude-code-cues');
+  let fork;
+  if (args.target) {
+    // Explicit override — point at a specific cli.js or bin/claude.exe.
+    const target = args.target;
+    const basename = path.basename(target);
+    const shape = basename === 'cli.js' ? 'cli.js' : 'native';
+    const root = basename === 'cli.js'
+      ? path.resolve(path.dirname(target), '..', '..', '..')
+      : path.resolve(path.dirname(target), '..', '..', '..', '..');
+    fork = { root, target, shape };
+  } else {
+    // Default — canonical fork at ~/claude-code-cues/. Bootstrap if missing.
+    ensureCanonicalForkExists(canonicalRoot);
+    fork = inferForkShape(canonicalRoot);
+    if (!fork) {
+      console.error(`Could not infer fork shape for ${canonicalRoot}.`);
+      console.error('Expected one of:');
+      console.error(`  ${canonicalRoot}/node_modules/@anthropic-ai/claude-code/cli.js`);
+      console.error(`  ${canonicalRoot}/node_modules/@anthropic-ai/claude-code/bin/claude.exe`);
+      console.error('Neither exists. Re-run install — setup.sh should npm-install the pinned CC version into the fork.');
+      process.exit(2);
     }
-    console.log(`  ${target ? path.join(path.dirname(target), '..', '..', '@opencues') : '<fork>/node_modules/@opencues'}/`);
-    console.log(`    core/`);
-    console.log(`    runtime/`);
-    console.log(`\n[dry-run] Would remove legacy paths if present:`);
-    for (const p of legacy) console.log(`  ${p}`);
-    if (target) console.log(`\n[dry-run] Would patch in place: ${target}`);
-    console.log(`[dry-run] cli.js backup will be at: ${tweakccConfigDir || '<install-root>'}/cli.js.backup`);
-    return;
   }
 
-  // Delegate to setup.sh — strictly CC-specific work now (cli.js patching,
-  // statusline install, tweakcc build/apply, settings.json fixup). All the
-  // shared ~/.cues/ + ~/.cues/OPENCUES.md writes (blank library scripts, settings
-  // self-heal, .cs compilation, TTS speak.sh) live in `opencues seed-configs`,
-  // which the top-level `opencues install` invokes BEFORE this script runs.
-  //
-  // tweakcc clones into <CC_FORK>/.cues/tweakcc by default — no need
-  // to pass an override unless the user is hacking on a side checkout.
-  // Pass through --keep-state for dev iteration; otherwise default to
-  // from-scratch.
+  console.log(`CC fork: ${fork.root}/  (${fork.shape})`);
+  console.log('');
+
+  // No-op-if-healthy gate. Idempotent semantics: a fresh `opencues
+  // install claude-code` against an already-healthy fork should NOT
+  // tear it down and rebuild. The nuke-and-rebuild work (setup.sh's
+  // default) is now opt-in via --rebuild — explicit destructive
+  // intent. validateFork checks every artefact (runtime + core +
+  // statusline.sh + patched cli.js/native-extract with opencues
+  // markers). If it passes, we exit cleanly with a notice; if it
+  // FAILS for any reason, we auto-escalate to rebuild and log why so
+  // the user's "re-run install to fix things" instinct still works.
+  if (!args.rebuild && !args.dryRun) {
+    const validation = validateFork(fork);
+    if (validation.ok) {
+      console.log(`${'\x1b[32m✓\x1b[0m'} ${fork.root} is already installed + healthy. No work needed.`);
+      console.log(`  ${'\x1b[2m'}Pass --rebuild to force a nuke-and-reinstall from scratch.${'\x1b[0m'}`);
+      return;
+    }
+    console.log(`${'\x1b[33m▸\x1b[0m'} install state needs repair: ${validation.reason}`);
+    console.log(`  ${'\x1b[2m'}Running full reinstall...${'\x1b[0m'}`);
+    console.log('');
+  }
+
+  checkCompat(fork.target);
+  const result = installFork(fork);
+
+  if (!result.ok) {
+    console.error(`\n✗ ${fork.root} (${fork.shape}) — ${result.reason}`);
+    process.exit(1);
+  }
+  console.log(`\n✓ ${fork.root} (${fork.shape}) installed + validated.`);
+
+  // Print the opt-in hint for the statusline. We install statusline.sh
+  // into the fork's .cues/ dir but do NOT auto-edit ~/.claude/settings.json
+  // — that's CC's own dir, and writing to it without consent is
+  // intrusive. Suggest the explicit command instead. Skipped silently
+  // if the user already has our statusLine configured.
+  try {
+    const userSettings = path.join(HOME, '.claude', 'settings.json');
+    if (fs.existsSync(userSettings)) {
+      const data = JSON.parse(fs.readFileSync(userSettings, 'utf8'));
+      const cmd = data?.statusLine?.command;
+      if (typeof cmd === 'string' && (cmd.includes('claude-code-cues') || cmd.endsWith('/statusline.sh'))) {
+        return; // already enabled
+      }
+    }
+    const oc = launchCommand();
+    console.log('');
+    console.log(`Status line tip surface is opt-in — to enable it in Claude Code:`);
+    console.log(`  ${oc} statusline enable             # writes ~/.claude/settings.json`);
+    console.log(`  ${oc} statusline enable --project   # writes <cwd>/.claude/settings.json`);
+  } catch { /* non-fatal — never block install on this hint */ }
+}
+
+// Bootstrap the canonical fork dir + package.json if either is missing.
+// Pin defaults to whatever compat.json declares as current-pin. This is
+// what removes the "package.json missing" first-time-user error.
+function ensureCanonicalForkExists(forkRoot) {
+  fs.mkdirSync(forkRoot, { recursive: true });
+  const pkgPath = path.join(forkRoot, 'package.json');
+  if (!fs.existsSync(pkgPath)) {
+    const compat = JSON.parse(fs.readFileSync(path.join(PKG_DIR, 'compat.json'), 'utf8'));
+    const pin = compat['current-pin'] || '2.1.150';
+    fs.writeFileSync(pkgPath, JSON.stringify({
+      private: true,
+      dependencies: { '@anthropic-ai/claude-code': pin },
+    }, null, 2) + '\n');
+    console.log(`Bootstrapped ${pkgPath} with @anthropic-ai/claude-code@${pin}`);
+  }
+}
+
+// Look inside a fork dir to figure out which shape's already there.
+// Returns { root, target, shape } or null if neither artefact exists.
+// (setup.sh will npm-install on first run; this is for the case where
+// install completed once and we're re-running.)
+function inferForkShape(root) {
+  const cliJs = path.join(root, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+  const nativeBin = path.join(root, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe');
+  if (fs.existsSync(cliJs)) return { root, target: cliJs, shape: 'cli.js' };
+  if (fs.existsSync(nativeBin)) return { root, target: nativeBin, shape: 'native' };
+  // First-time install: artefacts don't exist yet. Infer from the
+  // pin in package.json — versions ≤ 2.1.111 are cli.js shape, ≥ 2.1.113
+  // are native. setup.sh's npm install will create whichever; we just
+  // need to give it the right target path.
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+    const pin = pkg.dependencies?.['@anthropic-ai/claude-code'] || '';
+    const m = pin.match(/^(\d+)\.(\d+)\.(\d+)/);
+    if (m) {
+      const patch = parseInt(m[3], 10);
+      if (m[1] === '2' && m[2] === '1' && patch <= 111) {
+        return { root, target: cliJs, shape: 'cli.js' };
+      }
+      // 2.1.113+ (and any future major) → native binary.
+      return { root, target: nativeBin, shape: 'native' };
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+// Run setup.sh against a single fork + validate the result. Pulled out
+// of doInstall so the dry-run / multi-fork paths share the same code.
+function installFork(fork) {
+  const installRoot = path.join(fork.root, '.cues');
+  const tweakccConfigDir = path.join(installRoot, 'patch-state');
+  const legacy = legacyPaths();
+
+  console.log(`\n▸ ${fork.root} (${fork.shape})`);
+
+  if (args.dryRun) {
+    console.log(`  [dry-run] Would install into ${installRoot}/ + node_modules/@opencues/`);
+    console.log(`  [dry-run] Would patch ${fork.target} (${fork.shape})`);
+    console.log(`  [dry-run] cli.js backup → ${tweakccConfigDir}/cli.js.backup`);
+    return { ok: true };
+  }
+
+  // Delegate to setup.sh — strictly CC-specific work (cli.js patching,
+  // statusline install, tweakcc build/apply, settings.json fixup).
+  // Pass through --keep-state for dev iteration.
   const setupSh = path.join(PKG_DIR, 'patches', 'setup.sh');
   const setupArgs = [];
   if (args.keepState) setupArgs.push('--keep-state');
-  const env = { ...process.env };
-  if (target) env.OPENCUES_CC_TARGET = target;
+  const env = { ...process.env, OPENCUES_CC_TARGET: fork.target };
   const result = spawnSync(setupSh, setupArgs, { stdio: 'inherit', env });
 
-  // exit 2 from setup.sh = "everything built, but no cli.js to patch
-  // and no target was given." Print a single actionable hint and bail.
   if (result.status === 2) {
-    console.error('\nRe-run with --target /path/to/cli.js once Claude Code is installed.');
-    process.exit(2);
+    return { ok: false, reason: 'setup.sh exited 2 (no cli.js to patch — fork state invalid?)' };
   }
   if (result.status !== 0) {
-    console.error(`\nInstall failed. To roll back: ${launchCommand()} uninstall claude-code`);
-    process.exit(result.status || 1);
+    return { ok: false, reason: `setup.sh exited ${result.status}` };
   }
-  // Success — setup.sh already printed "Done. Restart Claude Code to
-  // activate." Write the version marker AFTER setup.sh succeeded so
-  // doctor + `opencues update` can detect bundled-runtime drift.
-  // Marker write failure is non-fatal (we lose drift detection on
-  // this host but the install itself worked).
-  if (installRoot) {
-    try {
-      const { writeMarker } = require(path.join(REPO_ROOT, 'packages/opencues-cli/src/lib/version-markers.cjs'));
-      writeMarker('claude-code', installRoot, { pkg, REPO_ROOT });
-    } catch { /* non-fatal */ }
+
+  // setup.sh claimed success — VALIDATE the artefacts actually landed.
+  // This catches the silent-failure mode where tweakcc reports
+  // success but the patched-artifact verification was skipped.
+  const validation = validateFork(fork);
+  if (!validation.ok) {
+    return { ok: false, reason: `validation failed: ${validation.reason}` };
   }
+
+  // Write the version marker AFTER setup.sh + validation succeeded.
+  // Doctor + `opencues update` use this to detect bundled-runtime drift.
+  try {
+    const { writeMarker } = require(path.join(REPO_ROOT, 'packages/opencues-cli/src/lib/version-markers.cjs'));
+    writeMarker('claude-code', installRoot, { pkg, REPO_ROOT });
+  } catch { /* non-fatal */ }
+
+  return { ok: true };
 }
 
 // --- UNINSTALL ------------------------------------------------------------
@@ -197,6 +332,17 @@ function doUninstall() {
   const legacy = legacyPaths();
   const legacyToRemove = legacy.filter(p => fs.existsSync(p));
 
+  // Detect whether ~/.claude/settings.json's statusLine.command points
+  // at our script — if so, uninstall removes it. This is the symmetric
+  // counterpart to `opencues statusline enable` (we never write to
+  // settings.json from install, but a user who explicitly enabled the
+  // statusline expects uninstall to put the slot back).
+  // Project-level settings.json (<cwd>/.claude/settings.json) is NOT
+  // touched here — uninstall is host-scoped, project-scoped statusline
+  // cleanup is `opencues statusline disable --project`.
+  const settingsJsonPath = path.join(CLAUDE_DIR, 'settings.json');
+  const statuslineToRevert = detectOpenCuesStatusLine(settingsJsonPath);
+
   console.log('Uninstall plan:');
   if (target && fs.existsSync(tweakccBin) && backup) {
     console.log(`  tweakcc --revert against ${target}  (backup: ${backup})`);
@@ -210,7 +356,10 @@ function doUninstall() {
   if (rootExists) console.log(`  rm -rf ${installRoot}/`);
   if (inForkExists) console.log(`  rm -rf ${inForkNodeModules}/  (runtime)`);
   for (const p of legacyToRemove) console.log(`  rm -rf ${p}  (legacy)`);
-  if (!rootExists && !inForkExists && !legacyToRemove.length) {
+  if (statuslineToRevert) {
+    console.log(`  edit ${settingsJsonPath}  (clear statusLine.command — currently: ${statuslineToRevert})`);
+  }
+  if (!rootExists && !inForkExists && !legacyToRemove.length && !statuslineToRevert) {
     console.log('  (no installed paths found — appears clean)');
   }
 
@@ -255,8 +404,43 @@ function doUninstall() {
   }
   rmdirIfEmpty(path.join(CLAUDE_DIR, 'node_modules', '@opencues'));
 
+  // 4. Revert settings.json's statusLine if we configured it.
+  if (statuslineToRevert) {
+    try {
+      const data = JSON.parse(fs.readFileSync(settingsJsonPath, 'utf8'));
+      // Sanity: only delete if it's STILL our path (user might have
+      // edited between plan-print and execute).
+      if (data.statusLine && data.statusLine.command === statuslineToRevert) {
+        fs.copyFileSync(settingsJsonPath, settingsJsonPath + '.bak.cues-uninstall');
+        delete data.statusLine;
+        fs.writeFileSync(settingsJsonPath, JSON.stringify(data, null, 2) + '\n');
+        console.log(`  cleared statusLine from ${settingsJsonPath}`);
+      }
+    } catch (err) {
+      console.warn(`  could not revert ${settingsJsonPath}: ${err.message}`);
+    }
+  }
+
   console.log(`\n${pkg.name} uninstall complete.`);
   console.log('To fully remove the cloned repo: rm -rf <opencues-clone-dir>');
+}
+
+// Read ~/.claude/settings.json and return the opencues statusLine
+// command if that's currently configured. Returns null if no
+// settings.json, no statusLine, or the command isn't ours.
+function detectOpenCuesStatusLine(settingsFile) {
+  if (!fs.existsSync(settingsFile)) return null;
+  let data;
+  try { data = JSON.parse(fs.readFileSync(settingsFile, 'utf8')); }
+  catch { return null; }
+  const cmd = data?.statusLine?.command;
+  if (typeof cmd !== 'string') return null;
+  const isOurs = cmd.includes('claude-code-cues') ||
+                 cmd.includes('claude-code-cues-150') ||
+                 cmd.includes('.claude/highlight-statusline.sh') ||
+                 cmd.includes('.claude/opencues/statusline.sh') ||
+                 (cmd.endsWith('/statusline.sh') && cmd.includes('/.cues/'));
+  return isOurs ? cmd : null;
 }
 
 // --- SEED CONFIGS ---------------------------------------------------------
@@ -310,14 +494,138 @@ function listActionFileBasenames() {
   return [...new Set(out)];
 }
 
+// Single-target detection — back-compat for uninstall (which only ever
+// touched one fork at a time). For install, prefer detectAllForks().
 function tryAutoDetectCli() {
   // Common locations. Order: standard npm install → claude-cues local install.
   const candidates = [
     path.join(CLAUDE_DIR, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
     path.join(HOME, 'claude-code-cues', 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'),
+    path.join(HOME, 'claude-code-cues-150', 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe'),
   ];
   for (const c of candidates) if (fs.existsSync(c)) return c;
   return null;
+}
+
+// Multi-fork detection. Returns every CC fork on disk that's a viable
+// install target. Returns [{root, target, shape: 'cli.js' | 'native'}].
+//
+// Why this matters: prior to today, install.cjs only patched whichever
+// single fork tryAutoDetectCli() returned first. Users with both the
+// 2.1.110 cli.js fork AND the 2.1.150 native-binary fork would re-run
+// install thinking it'd update both — silently the 150 fork stayed
+// unpatched. (Documented in CLAUDE.md root § Claude Installs.) Now
+// install enumerates every fork + patches each in turn.
+//
+// Lookup order:
+//   1. Standard `~/.claude/node_modules/...` (rare — pre-fork-era layout)
+//   2. `~/claude-code-cues/` (default cli.js fork, CC ≤ 2.1.111)
+//   3. `~/claude-code-cues-150/` (default native-binary fork, CC ≥ 2.1.113)
+//   4. Any other `~/claude-code-cues-*/` (user-named forks)
+//
+// An explicit --target overrides the auto-detection — single-fork mode.
+function detectAllForks() {
+  const out = [];
+  const seen = new Set();
+
+  // (1) Pre-fork legacy.
+  const legacyCli = path.join(CLAUDE_DIR, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+  if (fs.existsSync(legacyCli)) {
+    const root = path.resolve(path.dirname(legacyCli), '..', '..', '..');
+    if (!seen.has(root)) { out.push({ root, target: legacyCli, shape: 'cli.js' }); seen.add(root); }
+  }
+
+  // (2) + (3) + (4): walk ~/claude-code-cues* dirs. Each one has either
+  // a cli.js or a bin/claude.exe in its node_modules.
+  try {
+    for (const entry of fs.readdirSync(HOME, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (!entry.name.startsWith('claude-code-cues')) continue;
+      const root = path.join(HOME, entry.name);
+      if (seen.has(root)) continue;
+      const cliJs = path.join(root, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+      const nativeBin = path.join(root, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe');
+      if (fs.existsSync(cliJs)) {
+        out.push({ root, target: cliJs, shape: 'cli.js' });
+        seen.add(root);
+      } else if (fs.existsSync(nativeBin)) {
+        out.push({ root, target: nativeBin, shape: 'native' });
+        seen.add(root);
+      }
+      // If neither exists, this is an empty fork dir (e.g. user created
+      // it but never ran install). Skip — setup.sh would fail anyway.
+    }
+  } catch { /* HOME unreadable — extremely unlikely; fall through */ }
+
+  return out;
+}
+
+// Verify a patched fork actually has the OpenCues v2 wiring landed.
+// Returns { ok, reason }. Called after each setup.sh run so we can
+// surface partial-install failures loud (versus the prior silent
+// "claimed success, half-patched" failure mode).
+//
+// IMPORTANT: detect the CURRENT shape from what's on disk right now
+// rather than trusting the `fork.shape` snapshot from before install.
+// An upgrade that crosses the 2.1.111 → 2.1.113 cutover (cli.js ↔
+// native binary) makes the pre-install shape stale by the time
+// validation runs — the artefact files have moved. Re-detecting here
+// lets a single install handle in-place shape transitions cleanly.
+function validateFork(fork) {
+  const installRoot = path.join(fork.root, '.cues');
+  const runtime = path.join(fork.root, 'node_modules', '@opencues', 'runtime');
+  const core = path.join(fork.root, 'node_modules', '@opencues', 'core');
+  const statusline = path.join(installRoot, 'statusline.sh');
+
+  if (!fs.existsSync(runtime)) return { ok: false, reason: `runtime missing at ${runtime}` };
+  if (!fs.existsSync(core))    return { ok: false, reason: `core missing at ${core}` };
+  if (!fs.existsSync(statusline)) return { ok: false, reason: `statusline.sh missing at ${statusline}` };
+
+  // Re-detect shape from what's actually on disk now.
+  const cliJs     = path.join(fork.root, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+  const nativeBin = path.join(fork.root, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe');
+  const liveShape = fs.existsSync(nativeBin) ? 'native'
+                  : fs.existsSync(cliJs)     ? 'cli.js'
+                  : null;
+  if (!liveShape) {
+    return { ok: false, reason: `neither cli.js nor bin/claude.exe present in ${path.dirname(cliJs)} — npm install may not have completed` };
+  }
+
+  // Patched-artefact validation differs by shape:
+  //   - cli.js shape: cli.js is text-patched in place; grep for @opencues/runtime.
+  //   - native shape: tweakcc extracts cli.js from the ELF .bun
+  //     section, patches it, repacks, AND writes the post-patch text
+  //     to <installRoot>/patch-state/native-claudejs-patched.js for
+  //     verification (the bun section itself isn't ASCII-greppable
+  //     because it's compressed).
+  if (liveShape === 'cli.js') {
+    try {
+      const text = fs.readFileSync(cliJs, 'utf8');
+      if (!text.includes('@opencues/runtime') && !text.includes('startOpenCues')) {
+        return { ok: false, reason: `cli.js exists but missing opencues markers` };
+      }
+    } catch (err) {
+      return { ok: false, reason: `cli.js unreadable: ${err.message}` };
+    }
+  } else {
+    const verifiedExtract = path.join(installRoot, 'patch-state', 'native-claudejs-patched.js');
+    if (!fs.existsSync(verifiedExtract)) {
+      return { ok: false, reason: `tweakcc post-patch extract missing at ${verifiedExtract} — tweakcc never ran or didn't extract` };
+    }
+    try {
+      const text = fs.readFileSync(verifiedExtract, 'utf8');
+      if (!text.includes('@opencues/runtime') && !text.includes('startOpenCues')) {
+        return { ok: false, reason: `post-patch extract exists but missing opencues markers` };
+      }
+    } catch (err) {
+      return { ok: false, reason: `post-patch extract unreadable: ${err.message}` };
+    }
+  }
+
+  // Update caller's view so success log + version marker match reality.
+  fork.shape = liveShape;
+  fork.target = liveShape === 'cli.js' ? cliJs : nativeBin;
+  return { ok: true };
 }
 
 function checkCompat(cliJsPath) {
@@ -359,10 +667,10 @@ function rmdirIfEmpty(dir) {
 
 function parseArgv(argv) {
   // First non-flag positional = command. Default 'install'.
-  const KNOWN_FLAGS = new Set(['--help', '-h', '--target', '--dry-run', '--clean', '--keep-state']);
+  const KNOWN_FLAGS = new Set(['--help', '-h', '--target', '--dry-run', '--clean', '--keep-state', '--rebuild']);
   const VALUE_FLAGS = new Set(['--target']);
   const KNOWN_COMMANDS = new Set(['install', 'uninstall', 'seed-configs', 'help']);
-  const out = { command: 'install', args: { help: false, dryRun: false, clean: false, keepState: false }, unknown: [] };
+  const out = { command: 'install', args: { help: false, dryRun: false, clean: false, keepState: false, rebuild: false }, unknown: [] };
   let i = 0;
   if (argv[i] && !argv[i].startsWith('-')) {
     if (KNOWN_COMMANDS.has(argv[i])) {
@@ -380,6 +688,7 @@ function parseArgv(argv) {
     else if (a === '--dry-run') out.args.dryRun = true;
     else if (a === '--clean') out.args.clean = true;
     else if (a === '--keep-state') out.args.keepState = true;
+    else if (a === '--rebuild') out.args.rebuild = true;
     else if (a === '--target') out.args.target = argv[++i];
     else out.unknown.push(a);
   }

--- a/integrations/claude-code/docs/status-line.md
+++ b/integrations/claude-code/docs/status-line.md
@@ -25,10 +25,28 @@ Words without alts or a cue-blank tip produce no status line output.
 
 ## Setup
 
-1. `setup.sh` copies `highlight-statusline.sh` to `~/.claude/`
-2. Run `/statusline` in Claude Code
-3. Set command to full path: `/home/YOUR_USER/.claude/highlight-statusline.sh`
-4. Restart Claude Code
+Two steps — install first, then opt in via a dedicated command:
+
+```bash
+opencues install claude-code             # stages statusline.sh into <CC_FORK>/.cues/
+opencues statusline enable               # writes ~/.claude/settings.json — explicit consent
+```
+
+Why two steps: `~/.claude/` is Claude Code's directory, not OpenCues's. Touching it on every install would surprise users (especially anyone running a custom statusline like starship). The opt-in command makes the file modification explicit + reversible.
+
+The `opencues statusline` command supports:
+
+- `enable [--project] [--force]` — write our `statusLine.command` to user (default) or `<cwd>/.claude/settings.json`. `--force` overrides a non-opencues custom command.
+- `disable [--project]` — clear our `statusLine.command`. Refuses to clear a non-opencues command.
+- `status` — read-only inspection of both user- and project-level settings.
+
+Behaviour rules baked into the command (and pinned by tests in `packages/opencues-cli/src/lib/cc-statusline.test.cjs`):
+
+- Back up `settings.json.bak.cues-statusline` before any write.
+- Refuse to overwrite a user-custom `statusLine.command` (your starship.sh, etc.) without `--force`.
+- Refuse to clear a non-opencues `statusLine.command` (never touch what's not ours).
+- Auto-rewrite stale opencues paths (e.g. legacy `~/.claude/opencues/statusline.sh`) to the current install root on `enable`.
+- Project-level (`<cwd>/.claude/settings.json`) wins over user-level when CC reads it. `opencues doctor` flags the shadow case prominently when project-level suppresses user-level.
 
 ## Data Flow
 

--- a/integrations/claude-code/package.json
+++ b/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/claude-code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "OpenCues for Claude Code \u2014 patches Claude Code's CLI via tweakcc to add real-time word alternatives, blanks, and cue-controls.",
   "compatibility": {

--- a/integrations/claude-code/patches/highlight-statusline.sh
+++ b/integrations/claude-code/patches/highlight-statusline.sh
@@ -6,10 +6,15 @@
 #   { "statusLine": { "type": "command", "command": "/full/path/highlight-statusline.sh" } }
 
 # Find Claude Code PID by walking up the process tree.
-# Match either:
-#   - cmdline starting with `claude` (the native install or `claude-cues` shim)
-#   - cmdline containing `claude-code/cli.js` (when invoked as `node .../cli.js`,
-#     e.g. the local install used during integration development)
+# Match any of:
+#   - cmdline starting with `claude` (the system install or a `claude-cues` shim)
+#   - cmdline containing `claude-code/cli.js` (cli.js fork — CC 2.1.111 and earlier;
+#     invoked as `node .../@anthropic-ai/claude-code/cli.js`)
+#   - cmdline containing `claude-code/bin/claude` (native bun-binary fork —
+#     CC 2.1.113+ including 2.1.150; invoked as the absolute path to claude.exe.
+#     We match `bin/claude` rather than `bin/claude.exe` because the bun-compile
+#     output also spawns child processes via the same binary path, sometimes
+#     without the `.exe` suffix on linux builds.)
 #
 # Linux exposes per-PID cmdline + parent at /proc/$PID/{cmdline,stat}.
 # macOS has no /proc — fall back to `ps -o command=` for cmdline and
@@ -26,7 +31,7 @@ while [ "$WALK_PID" != "1" ] && [ -n "$WALK_PID" ]; do
   else
     CMDLINE=$(ps -o command= -p "$WALK_PID" 2>/dev/null)
   fi
-  if echo "$CMDLINE" | grep -qE '^claude|claude-code/cli\.js'; then
+  if echo "$CMDLINE" | grep -qE '^claude|claude-code/cli\.js|claude-code/bin/claude'; then
     CLAUDE_PID=$WALK_PID
     break
   fi
@@ -72,17 +77,36 @@ if [ -f "$HIGHLIGHT_FILE" ]; then
     if [ -n "$word" ]; then
       is_cue_blank=$(echo "$content" | grep -o '"cueBlank":true')
       altcount=$(echo "$content" | sed -n 's/.*"alts":\[\([^]]*\)\].*/\1/p' | tr ',' '\n' | wc -l)
-      # Show if word has alts OR is a cue-blank with a tip
-      if [ "$altcount" -gt 0 ] 2>/dev/null || [ -n "$is_cue_blank" -a -n "$tip" ]; then
+      altidx=$(echo "$content" | sed -n 's/.*"currentAltIndex":\([0-9]*\).*/\1/p')
+      altidx=${altidx:-0}
+      altpos=$((altidx + 1))
+      # Show if word has alts OR is a cue-blank with a tip OR cue-blank
+      # with no tip but a substituted alt (sentence cues, transform
+      # blanks, etc. — the alt text IS the content the user cares about,
+      # even when cueTip is null).
+      if [ "$altcount" -gt 0 ] 2>/dev/null || [ -n "$is_cue_blank" ]; then
         # Inline (no newline) — CC v2.1.x renders only the first line of the
         # status command output. Use a separator instead of a newline.
         printf ' %s|%s ' "$YELLOW" "$RESET"
         if [ -n "$is_cue_blank" ]; then
-          printf '%s' "$tip"
+          # Cue-blank: prefer tip if present; otherwise show the alt
+          # text (truncated) + position so the user sees what's currently
+          # selected. Sentence cues (cueBlank=true, cueTip=null) hit
+          # this branch — without it the statusline rendered as just
+          # "user@host:dir | " which looked broken.
+          if [ -n "$tip" ]; then
+            printf '%s' "$tip"
+          else
+            # Truncate long sentence-cue substitutions to ~70 chars so
+            # the statusline doesn't blow past the terminal width.
+            truncated=$(printf '%s' "$word" | cut -c1-70)
+            if [ "${#word}" -gt 70 ]; then truncated="${truncated}…"; fi
+            printf '%s%s%s' "${DIM}" "$truncated" "$RESET"
+            if [ "$altcount" -gt 1 ] 2>/dev/null; then
+              printf ' (%d/%d)' "$altpos" "$altcount"
+            fi
+          fi
         else
-          altidx=$(echo "$content" | sed -n 's/.*"currentAltIndex":\([0-9]*\).*/\1/p')
-          altidx=${altidx:-0}
-          altpos=$((altidx + 1))
           printf '%s%s%s (%d/%d)' "${BOLD}${CYAN}" "$word" "$RESET" "$altpos" "$altcount"
           if [ -n "$tip" ]; then
             printf ' - %s' "$tip"

--- a/integrations/claude-code/patches/setup.sh
+++ b/integrations/claude-code/patches/setup.sh
@@ -116,8 +116,26 @@ fi
 # Default fork location: ~/claude-code-cues. Allow override via OPENCUES_CC_TARGET
 # pointing at a cli.js inside any other fork.
 if [ -n "${OPENCUES_CC_TARGET:-}" ]; then
-  # OPENCUES_CC_TARGET points at <fork>/node_modules/@anthropic-ai/claude-code/cli.js
-  CC_FORK_DIR="$(cd "$(dirname "$OPENCUES_CC_TARGET")/../../.." && pwd)"
+  # OPENCUES_CC_TARGET points at either:
+  #   <fork>/node_modules/@anthropic-ai/claude-code/cli.js          (3 dirs deep)
+  #   <fork>/node_modules/@anthropic-ai/claude-code/bin/claude.exe  (4 dirs deep)
+  # Pre-2.1.113 we only ever ran against cli.js. The native-binary
+  # fork (2.1.113+) needs the extra hop. Detect by basename + adjust.
+  _TARGET_BASENAME="$(basename "$OPENCUES_CC_TARGET")"
+  case "$_TARGET_BASENAME" in
+    cli.js)
+      CC_FORK_DIR="$(cd "$(dirname "$OPENCUES_CC_TARGET")/../../.." && pwd)"
+      ;;
+    claude.exe|claude)
+      CC_FORK_DIR="$(cd "$(dirname "$OPENCUES_CC_TARGET")/../../../.." && pwd)"
+      ;;
+    *)
+      echo "Error: OPENCUES_CC_TARGET basename '$_TARGET_BASENAME' not recognised." >&4
+      echo "Expected: cli.js (cli.js fork shape) or claude.exe (native-binary fork shape)." >&4
+      exit 1
+      ;;
+  esac
+  unset _TARGET_BASENAME
 else
   CC_FORK_DIR="$HOME/claude-code-cues"
 fi
@@ -336,17 +354,29 @@ mkdir -p "$OC_INSTALL_ROOT/scripts"
 cp "$SCRIPT_DIR/highlight-statusline.sh" "$OC_INSTALL_ROOT/statusline.sh"
 chmod +x "$OC_INSTALL_ROOT/statusline.sh"
 
-# 6a. Auto-fix CC settings.json so statusLine.command points at the
-# newly-installed script. Two prior layouts shipped statuslines at
-# different paths — both are gone now, so settings.json pointing at
-# either would invoke a missing file. settings.json holds an absolute
-# path, so the statusline works from any cwd you launch claude-cues from.
+# 6a. Migrate legacy statusLine paths only — never auto-write fresh.
+#
+# Design choice: setup.sh stages statusline.sh into our fork dir but
+# does NOT proactively edit ~/.claude/settings.json. ~/.claude/ is
+# Claude Code's directory; we're guests, and writing to it without
+# explicit user consent feels wrong. The user enables the tip surface
+# explicitly via:
+#
+#   opencues statusline enable             # writes ~/.claude/settings.json
+#   opencues statusline enable --project   # writes <cwd>/.claude/settings.json
+#
+# What we DO touch automatically: stale legacy opencues paths. If
+# the user previously enabled it via an old install layout, the
+# path will be wrong now (the install root has moved). Rewriting a
+# stale legacy path is a corrective in-place edit, not a fresh
+# write, and refusing to do it would leave the user's statusline
+# broken. Same sed-based logic the legacy install used.
 SETTINGS_JSON="$HOME/.claude/settings.json"
 if [ -f "$SETTINGS_JSON" ] && grep -qE "highlight-statusline\.sh|\.claude/opencues/statusline\.sh" "$SETTINGS_JSON" 2>/dev/null; then
   cp "$SETTINGS_JSON" "$SETTINGS_JSON.bak.cues-statusline"
   sedi "s|$HOME/.claude/highlight-statusline.sh|$OC_INSTALL_ROOT/statusline.sh|g" "$SETTINGS_JSON"
   sedi "s|$HOME/.claude/opencues/statusline.sh|$OC_INSTALL_ROOT/statusline.sh|g" "$SETTINGS_JSON"
-  echo "Updated statusLine.command in $SETTINGS_JSON"
+  echo "Migrated stale statusLine.command in $SETTINGS_JSON → $OC_INSTALL_ROOT/statusline.sh"
 fi
 end_step
 

--- a/packages/opencues-cli/bin/cli.cjs
+++ b/packages/opencues-cli/bin/cli.cjs
@@ -36,6 +36,7 @@ const COMMANDS = {
   'set-key':      () => require('../src/commands/set-key.cjs'),
   'check-keys':   () => require('../src/commands/check-keys.cjs'),
   update:         () => require('../src/commands/update.cjs'),
+  statusline:     () => require('../src/commands/statusline.cjs'),
   debug:          () => require('../src/commands/debug.cjs'),
   completion:     () => require('../src/commands/completion.cjs'),
   which:          () => require('../src/commands/which.cjs'),

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -408,6 +408,69 @@ module.exports = async function doctor(argv, ctx) {
         findings.push({ sev: 'warn', msg: `cli.js at ${cli} is not patched`, fix: `opencues install claude-code --target ${cli}` });
       }
     }
+    // ── StatusLine opt-in surface (CC's settings.json) ──────────────
+    // Status line tip is OPT-IN — install never touches ~/.claude/.
+    // Surface user-level + project-level state distinctly so users
+    // discover the command. Reuses the same lib statusline.cjs uses
+    // so this view can't drift from what `opencues statusline status`
+    // shows.
+    try {
+      const ccsl = require('../lib/cc-statusline.cjs');
+      const userInfo = ccsl.inspect('user');
+      const projectInfo = ccsl.inspect('project');
+
+      // User-level row.
+      if (userInfo.state === 'opencues-ours') {
+        s.ok(`statusLine (user)`, true);
+      } else if (userInfo.state === 'missing') {
+        s.info(`statusLine (user)`, dim('not configured — opt-in: `opencues statusline enable`'));
+      } else if (userInfo.state === 'opencues-stale') {
+        s.bad(`statusLine (user) — stale opencues path`, false);
+        findings.push({
+          sev: 'warn',
+          msg: `statusLine.command in ${userInfo.file} points at a stale opencues path (${userInfo.currentCmd})`,
+          fix: 'opencues statusline enable   # rewrites to current install root',
+        });
+      } else if (userInfo.state === 'user-custom') {
+        s.info(`statusLine (user) — custom`, dim(userInfo.currentCmd));
+      } else if (userInfo.state === 'broken') {
+        s.bad(`statusLine (user) — settings.json unreadable`, false);
+      }
+
+      // Project-level row. Only shown when something actually exists
+      // at <cwd>/.claude/settings.json — otherwise this would yell at
+      // every cwd that doesn't have CC project settings.
+      if (fs.existsSync(projectInfo.file)) {
+        if (projectInfo.state === 'opencues-ours') {
+          s.ok(`statusLine (project: ${process.cwd()})`, true);
+        } else if (projectInfo.state === 'missing') {
+          s.info(`statusLine (project)`, dim(`project settings.json exists but no statusLine — opt-in: opencues statusline enable --project`));
+        } else if (projectInfo.state === 'opencues-stale') {
+          s.bad(`statusLine (project) — stale opencues path`, false);
+          findings.push({
+            sev: 'warn',
+            msg: `statusLine.command in ${projectInfo.file} points at a stale opencues path (${projectInfo.currentCmd})`,
+            fix: 'opencues statusline enable --project   # rewrites to current install root',
+          });
+        } else if (projectInfo.state === 'user-custom') {
+          // Project-shadow case. User-level might be ours; project takes precedence.
+          // Surface this prominently — it's the genuine "tips don't appear here, why?" case.
+          if (userInfo.state === 'opencues-ours') {
+            s.info(`statusLine (project) — SHADOWING user-level`, dim(projectInfo.currentCmd));
+            findings.push({
+              sev: 'info',
+              msg: `OpenCues tips won't appear in CC launched from this project — ${projectInfo.file} sets its own statusLine.command (${projectInfo.currentCmd}) which takes precedence over your user-level configuration.`,
+              fix: 'opencues statusline enable --project --force   # if you want to replace the project command\n         ' +
+                   '(or `opencues statusline enable --project` after manually removing the project field)',
+            });
+          } else {
+            s.info(`statusLine (project) — custom`, dim(projectInfo.currentCmd));
+          }
+        } else if (projectInfo.state === 'broken') {
+          s.bad(`statusLine (project) — settings.json unreadable`, false);
+        }
+      }
+    } catch { /* cc-statusline lib unavailable — non-fatal */ }
     s.render();
   }
   // Stale pre-compact-footprint install still on disk?
@@ -419,6 +482,23 @@ module.exports = async function doctor(argv, ctx) {
       fix: 'opencues install claude-code',
     });
   }
+  // Detect extra CC fork dirs (e.g. ~/claude-code-cues-150/) — these
+  // are dev-only relics from when we maintained parallel forks per CC
+  // shape. The product model is now single-fork (upgrade in place via
+  // `opencues update claude-code --to <ver>`), so any extra fork is
+  // safe to delete. Surface as info, not warn — the user might still
+  // be using it intentionally as a side-by-side dev setup.
+  try {
+    const { detectExtraCCForks } = require('../lib/version-markers.cjs');
+    const extras = detectExtraCCForks();
+    for (const extra of extras) {
+      findings.push({
+        sev: 'info',
+        msg: `extra CC fork at ${extra}/ — the product model is single-fork (~/claude-code-cues/, upgraded in place). This fork is a dev relic; safe to remove.`,
+        fix: `rm -rf ${extra}   # if you don't want it; otherwise patch it explicitly with: opencues install claude-code --target ${path.join(extra, 'node_modules/@anthropic-ai/claude-code/bin/claude.exe')}`,
+      });
+    }
+  } catch { /* lib unavailable — skip */ }
   // Only surface "CC not installed" when the fork is actually absent.
   // If the fork is present (cli.js patched + runtime/core installed) but
   // .cues/ support dir is missing, it usually means the patch was

--- a/packages/opencues-cli/src/commands/run.cjs
+++ b/packages/opencues-cli/src/commands/run.cjs
@@ -188,10 +188,11 @@ function printCachedUpdateNotice(ctx) {
 }
 
 function runCC(passthrough, ctx) {
-  // Preferred binary: ~/claude-code-cues-150/.../bin/claude.exe — the
-  // 2.1.150 native bun-compile install. That's the current default
-  // pin (compat.json current-pin=2.1.150). Falls back to the older
-  // cli.js install at ~/claude-code-cues/ for users still on 2.1.110.
+  // SINGLE canonical fork at ~/claude-code-cues/. Auto-detect whichever
+  // shape (cli.js or native binary) the pinned CC version ships in.
+  // Upgrading the version happens via `opencues update claude-code
+  // --to <ver>` in this same fork — no parallel fork dirs.
+  //
   // --bin always wins for explicit overrides.
   const binFlag = passthrough.indexOf('--bin');
   if (binFlag >= 0 && passthrough[binFlag + 1]) {
@@ -206,39 +207,39 @@ function runCC(passthrough, ctx) {
     return;
   }
 
-  // 2.1.150 native bun-binary (the new default).
-  const native150 = path.join(os.homedir(), 'claude-code-cues-150', 'node_modules',
-    '@anthropic-ai', 'claude-code', 'bin', 'claude.exe');
-  if (fs.existsSync(native150)) {
+  const forkRoot = path.join(os.homedir(), 'claude-code-cues');
+  const nativeBin = path.join(forkRoot, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe');
+  const cliJs    = path.join(forkRoot, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js');
+
+  // Native binary wins when present — that's CC 2.1.113+ (current).
+  if (fs.existsSync(nativeBin)) {
     printLaunchBanner(ctx, 'claude-code', [
-      ['host',    'claude-code  ' + style.dim('(patched, native 2.1.150)')],
+      ['host',    'claude-code  ' + style.dim('(patched, native binary)')],
       ['command', `claude.exe ${passthrough.join(' ')}`.trim()],
-      ['fork',    style.fileLink(native150, native150)],
+      ['fork',    style.fileLink(nativeBin, nativeBin)],
     ]);
     clearScreenForHandoff();
-    const result = spawnSync(native150, passthrough, { stdio: 'inherit' });
-    exitFromSpawn(result, native150);
+    const result = spawnSync(nativeBin, passthrough, { stdio: 'inherit' });
+    exitFromSpawn(result, nativeBin);
     return;
   }
 
-  // 2.1.110 cli.js (legacy fork, kept for users who haven't migrated).
-  const patchedCli = path.join(os.homedir(), 'claude-code-cues', 'node_modules',
-    '@anthropic-ai', 'claude-code', 'cli.js');
-  if (fs.existsSync(patchedCli)) {
+  // cli.js shape — CC ≤ 2.1.111.
+  if (fs.existsSync(cliJs)) {
     printLaunchBanner(ctx, 'claude-code', [
-      ['host',    'claude-code  ' + style.dim('(patched, cli.js 2.1.110)')],
+      ['host',    'claude-code  ' + style.dim('(patched, cli.js)')],
       ['command', `node cli.js ${passthrough.join(' ')}`.trim()],
-      ['fork',    style.fileLink(patchedCli, patchedCli)],
+      ['fork',    style.fileLink(cliJs, cliJs)],
     ]);
     clearScreenForHandoff();
-    const result = spawnSync('node', [patchedCli, ...passthrough], { stdio: 'inherit' });
-    exitFromSpawn(result, patchedCli);
+    const result = spawnSync('node', [cliJs, ...passthrough], { stdio: 'inherit' });
+    exitFromSpawn(result, cliJs);
     return;
   }
 
   // Fallback: PATH-based lookup. `claude-cues` shell alias won't
   // resolve via `which` — only a real binary on PATH works.
-  console.warn(`${style.tag('warn')} patched install not found at ~/claude-code-cues-150 or ~/claude-code-cues`);
+  console.warn(`${style.tag('warn')} patched install not found at ${forkRoot}/`);
   console.warn(`     Install with: ${style.bold('opencues install claude-code')}`);
   console.warn(`     Falling back to PATH lookup (likely UNPATCHED — cues will not work):`);
   for (const c of ['claude-cues', 'claude']) {

--- a/packages/opencues-cli/src/commands/statusline.cjs
+++ b/packages/opencues-cli/src/commands/statusline.cjs
@@ -1,0 +1,130 @@
+// `opencues statusline <enable|disable|status> [--project] [--force]`
+//
+// Opt-in surface for CC's statusLine slot. Why this is a separate
+// command instead of folded into `opencues install claude-code`:
+// ~/.claude/ is Claude Code's directory; we're guests, and writing
+// to it on every install would surprise users with custom statuslines
+// AND users who didn't realise we'd touch CC's own config dir.
+//
+// Today only CC has a statusLine concept this fits. If a future host
+// gets one, this command grows a --host flag (defaults to claude-code).
+
+'use strict';
+
+const path = require('node:path');
+const { tag, bold, dim, banner, cliVersion } = require('../lib/style.cjs');
+const lib = require('../lib/cc-statusline.cjs');
+
+function printHelp() {
+  console.log('opencues statusline <enable | disable | status> [--project] [--force]');
+  console.log('');
+  console.log('Manage the Claude Code statusLine slot — opt-in by design.');
+  console.log('');
+  console.log('Subcommands:');
+  console.log('  enable               Write our statusLine.command into settings.json');
+  console.log('  disable              Clear our statusLine.command from settings.json');
+  console.log('  status               Show what\'s currently configured at user + project level');
+  console.log('');
+  console.log('Flags:');
+  console.log('  --project            Operate on <cwd>/.claude/settings.json (project-scoped)');
+  console.log('                       instead of ~/.claude/settings.json (user-scoped, default)');
+  console.log('  --force              enable: overwrite a user-custom statusLine.command');
+  console.log('                       (off by default — we refuse to clobber your starship.sh etc.)');
+  console.log('  -h, --help           Show this message');
+  console.log('');
+  console.log('Examples:');
+  console.log('  opencues statusline status              # what\'s configured where?');
+  console.log('  opencues statusline enable              # turn it on at user level');
+  console.log('  opencues statusline enable --project    # turn it on for THIS project only');
+  console.log('  opencues statusline disable             # turn it off at user level');
+  console.log('  opencues statusline enable --force      # replace your custom command');
+  console.log('');
+  console.log('Behavior rules:');
+  console.log('  - We only ever touch a settings.json after you run this command.');
+  console.log('  - We back up to settings.json.bak.cues-statusline before writing.');
+  console.log('  - We refuse to overwrite a non-opencues statusLine.command (use --force).');
+  console.log('  - We refuse to clear a non-opencues statusLine.command (manual edit only).');
+  console.log('  - Project-level settings.json wins over user-level when CC reads it.');
+}
+
+module.exports = function statusline(argv, ctx) {
+  if (argv.includes('--help') || argv.includes('-h') || argv.length === 0) {
+    return printHelp();
+  }
+
+  // First positional = subcommand.
+  let sub = null;
+  let scope = 'user';
+  let force = false;
+  for (const a of argv) {
+    if (a === '--project') { scope = 'project'; continue; }
+    if (a === '--user')    { scope = 'user';    continue; }
+    if (a === '--force')   { force = true;      continue; }
+    if (!a.startsWith('-') && !sub) { sub = a; continue; }
+  }
+
+  if (!sub) { printHelp(); return 2; }
+
+  console.log(banner({ version: cliVersion(ctx), tagline: `statusline · ${sub}${scope === 'project' ? ' (project)' : ''}` }));
+  console.log('');
+
+  if (sub === 'status') return doStatus(ctx);
+  if (sub === 'enable') return doEnable(scope, force);
+  if (sub === 'disable') return doDisable(scope);
+
+  console.error(`opencues statusline: unknown subcommand "${sub}". One of: enable, disable, status.`);
+  return 2;
+};
+
+function doStatus(ctx) {
+  const userInfo = lib.inspect('user');
+  const projectInfo = lib.inspect('project');
+  console.log(`Statusline script: ${userInfo.scriptPath || dim('(not installed — run `opencues install claude-code` first)')}`);
+  console.log('');
+  printScope('user', userInfo);
+  console.log('');
+  printScope('project', projectInfo);
+  return 0;
+}
+
+function printScope(label, info) {
+  console.log(`${bold(label === 'user' ? 'User-level' : 'Project-level (' + process.cwd() + ')')}`);
+  console.log(`  file: ${info.file}`);
+  if (info.state === 'missing') {
+    console.log(`  state: ${dim('not configured')}`);
+    console.log(`  enable: ${bold(`opencues statusline enable${label === 'project' ? ' --project' : ''}`)}`);
+  } else if (info.state === 'opencues-ours') {
+    console.log(`  state: ${tag('ok')} configured — points at our script`);
+    console.log(`  command: ${info.currentCmd}`);
+  } else if (info.state === 'opencues-stale') {
+    console.log(`  state: ${tag('warn')} stale opencues path — needs re-enable`);
+    console.log(`  current: ${info.currentCmd}`);
+    console.log(`  fix: ${bold(`opencues statusline enable${label === 'project' ? ' --project' : ''}`)}`);
+  } else if (info.state === 'user-custom') {
+    console.log(`  state: ${tag('info')} user-custom — not ours`);
+    console.log(`  current: ${info.currentCmd}`);
+    console.log(`  to switch: ${bold(`opencues statusline enable${label === 'project' ? ' --project' : ''} --force`)} ${dim('(backs up the prior command)')}`);
+  } else if (info.state === 'broken') {
+    console.log(`  state: ${tag('err')} ${info.error}`);
+  }
+}
+
+function doEnable(scope, force) {
+  const r = lib.enable(scope, { force });
+  printResult(r);
+  return r.ok ? 0 : 1;
+}
+
+function doDisable(scope) {
+  const r = lib.disable(scope);
+  printResult(r);
+  return r.ok ? 0 : 1;
+}
+
+function printResult(r) {
+  const sigil = r.ok ? tag('ok') : tag('err');
+  console.log(`${sigil} ${r.message}`);
+  if (r.ok && (r.action === 'created' || r.action === 'updated' || r.action === 'replaced-stale')) {
+    console.log(dim('  Restart Claude Code (or open a new session) to pick it up.'));
+  }
+}

--- a/packages/opencues-cli/src/commands/update.cjs
+++ b/packages/opencues-cli/src/commands/update.cjs
@@ -21,7 +21,7 @@ const path = require('node:path');
 const os = require('node:os');
 const { spawnSync } = require('node:child_process');
 const compatLib = require('../lib/compat.cjs');
-const { tag, step, bold, dim, banner, tree, G, cliVersion } = require('../lib/style.cjs');
+const { tag, step, bold, dim, banner, tree, G, cliVersion, brightWhite } = require('../lib/style.cjs');
 
 const HOST_ALIASES = {
   'claude-code': 'claude-code', claudecode: 'claude-code', claude: 'claude-code', cc: 'claude-code',
@@ -59,8 +59,46 @@ module.exports = async function update(argv, ctx) {
   }
 
   // Mode dispatch.
+  // - `--check`: read-only "what's available" report.
+  // - `<host> --to <ver>`: explicit version upgrade.
+  // - `<host>` (no `--to`): upgrade to current-pin in compat.json. The
+  //   most common path — "give me the recommended version." No-op if
+  //   already current.
+  // - (no host): workspace pull + rebuild + redeploy all installed hosts.
   if (check) return doCheck(host, ctx);
   if (toVersion) return doUpgrade(host, toVersion, { force, dryRun }, ctx);
+  if (host) {
+    // Default to current-pin upgrade. Read compat.json, compare to
+    // installed, no-op if equal, otherwise call doUpgrade.
+    const compat = compatLib.loadCompat(ctx.REPO_ROOT, host);
+    if (!compat) {
+      console.error(`opencues update: no compat.json for ${host}`);
+      process.exit(1);
+    }
+    const targetVersion = compat['current-pin'];
+    if (!targetVersion) {
+      console.error(`opencues update: ${host}'s compat.json has no current-pin set; pass --to <ver> explicitly`);
+      process.exit(1);
+    }
+    const HOME = os.homedir();
+    const installedPin = compatLib.readNpmPin(HOME, compat) ||
+                         (compat['host-kind'] === 'git' ? compatLib.readGitPin(ctx.REPO_ROOT, compat)?.version : null);
+    if (installedPin === targetVersion) {
+      console.log(banner({ version: cliVersion(ctx), tagline: `update ${host}` }));
+      console.log('');
+      console.log(`${tag('ok')} ${host} already at current-pin ${bold(targetVersion)} — nothing to do.`);
+      console.log(`  ${dim('To force a rebuild without changing version: opencues install ' + host + ' --rebuild')}`);
+      return 0;
+    }
+    if (!installedPin) {
+      console.error(`opencues update: ${host} is not installed. Run \`opencues install ${host}\` first.`);
+      process.exit(1);
+    }
+    // Hand off to doUpgrade — it prints the banner. We don't print an
+    // info line BEFORE the banner because that breaks the visual
+    // hierarchy (every other CLI surface puts the banner first).
+    return doUpgrade(host, targetVersion, { force, dryRun, installedPin }, ctx);
+  }
   return doUpdate(host, { skipPull, dryRun }, ctx);
 };
 
@@ -281,11 +319,33 @@ function stripV(s) { return String(s || '').replace(/^v/, ''); }
 
 // ─── MODE 3: UPGRADE (--to) ────────────────────────────────────────────
 
-async function doUpgrade(host, toVersion, { force, dryRun }, ctx) {
+async function doUpgrade(host, toVersion, { force, dryRun, installedPin }, ctx) {
   if (!host) {
     console.error('opencues update --to <version>: must specify a host (e.g. opencues update claude-code --to 2.1.115)');
     process.exit(2);
   }
+  // Compute the installed pin BEFORE the banner so the banner tagline
+  // can carry the full from→to context. Avoids the redundant "info
+  // line under banner" pattern where banner says "→ X" and the line
+  // below repeats "Y → X".
+  if (!installedPin) {
+    const compatForRead = compatLib.loadCompat(ctx.REPO_ROOT, host);
+    if (compatForRead) {
+      const HOME = os.homedir();
+      installedPin = compatLib.readNpmPin(HOME, compatForRead) ||
+                     (compatForRead['host-kind'] === 'git' ? compatLib.readGitPin(ctx.REPO_ROOT, compatForRead)?.version : null);
+    }
+  }
+  // Version numbers in the tagline get bright-white-bold so they pop
+  // against the dim banner text — the from→to is what the user wants
+  // to verify at a glance.
+  const fromStr = brightWhite(bold(installedPin || ''));
+  const toStr   = brightWhite(bold(toVersion));
+  const tagline = installedPin && installedPin !== toVersion
+    ? `upgrade ${host} ${fromStr} → ${toStr}`
+    : `upgrade ${host} → ${toStr}`;
+  console.log(banner({ version: cliVersion(ctx), tagline }));
+  console.log('');
   const compat = compatLib.loadCompat(ctx.REPO_ROOT, host);
   if (!compat) {
     console.error(`opencues update: no compat.json for ${host} — can't upgrade automatically`);
@@ -393,7 +453,15 @@ async function doUpgradeGit(host, toVersion, compat, { dryRun }, ctx) {
 
 function runHostInstaller(host, ctx, { rollback }) {
   const installer = path.join(ctx.REPO_ROOT, 'integrations', host, 'bin/install.cjs');
-  const r = spawnSync('node', [installer, 'install'], { cwd: ctx.REPO_ROOT, stdio: 'inherit' });
+  // --rebuild forces the install to actually run setup.sh instead of
+  // no-opping on a healthy detection. Upgrade-to-new-version always
+  // requires real install work (npm-install the new CC version, patch
+  // it, write the marker) — never a no-op.
+  // OPENCUES_SKIP_BANNER=1 suppresses the per-host installer banner
+  // so we don't double-banner mid-stream (the update banner is
+  // already up).
+  const env = { ...process.env, OPENCUES_SKIP_BANNER: '1' };
+  const r = spawnSync('node', [installer, 'install', '--rebuild'], { cwd: ctx.REPO_ROOT, stdio: 'inherit', env });
   if (r.status !== 0) {
     console.error(`\nInstall failed at new pin.`);
     if (rollback) rollback();

--- a/packages/opencues-cli/src/commands/version.cjs
+++ b/packages/opencues-cli/src/commands/version.cjs
@@ -1,10 +1,25 @@
 // `opencues version` — print CLI version + per-integration versions
-// + their declared compatibility ranges. Pure inspection.
+// + their declared compatibility ranges + what's actually installed
+// on disk per integration (upstream host version + bundled runtime/core
+// + install timestamp).
+//
+// Three sections build a complete picture for bug reports + drift
+// checks:
+//   1. Integrations — what we'd install if you ran install today
+//      (source of truth: integrations/*/package.json)
+//   2. Installed hosts — what's actually deployed (each fork's
+//      version + bundled runtime/core marker)
+//   3. Internal libraries — runtime + core source versions
+//
+// The "Installed hosts" section is the answer to "what versions am I
+// actually running?" — until now you'd have to walk every fork dir
+// yourself to find out.
 
 'use strict';
 
 const fs = require('node:fs');
 const path = require('node:path');
+const os = require('node:os');
 const { banner, tree, dim, cliVersion } = require('../lib/style.cjs');
 
 const HOSTS = ['claude-code', 'opencode', 'chrome', 'gemini-cli', 'shell'];
@@ -15,6 +30,7 @@ module.exports = function version(argv, ctx) {
   console.log(banner({ version: cliVersion(ctx) }));
   console.log('');
 
+  // ── Integrations (source-of-truth — what would deploy on install) ──
   const integRows = [];
   for (const h of HOSTS) {
     const pkgPath = path.join(ctx.REPO_ROOT, 'integrations', h, 'package.json');
@@ -29,12 +45,38 @@ module.exports = function version(argv, ctx) {
     integRows.push([p.name || `@opencues/${h}`, `v${p.version || '?'}`, compat]);
   }
   console.log(tree({
-    title: 'Integrations',
-    description: 'host editor integrations and their declared compatibility',
+    title: 'Integrations (source)',
+    description: 'host editor integrations + declared upstream compatibility',
     rows: integRows,
   }));
   console.log('');
 
+  // ── Installed hosts (deployed-on-disk per fork) ────────────────────
+  const deployed = enumerateDeployed(ctx);
+  if (deployed.length === 0) {
+    console.log(tree({
+      title: 'Installed hosts',
+      description: 'no installs detected — run `opencues install <host>` to get started',
+      rows: [],
+    }));
+  } else {
+    const rows = deployed.map(d => [
+      d.host + (d.shape ? ` (${d.shape})` : ''),
+      d.upstreamVersion ? `host v${d.upstreamVersion}` : dim('(host version unknown)'),
+      d.runtime && d.core
+        ? `runtime ${d.runtime} / core ${d.core}`
+        : dim('(no version marker — re-run install to populate)'),
+      dim(d.root),
+    ]);
+    console.log(tree({
+      title: 'Installed hosts (deployed)',
+      description: 'what\'s actually on disk per fork',
+      rows,
+    }));
+  }
+  console.log('');
+
+  // ── Internal libraries (source) ────────────────────────────────────
   const libRows = [];
   for (const lib of ['opencues-core', 'opencues-runtime']) {
     const pkgPath = path.join(ctx.REPO_ROOT, 'packages', lib, 'package.json');
@@ -43,16 +85,112 @@ module.exports = function version(argv, ctx) {
     libRows.push([p.name || lib, `v${p.version || '?'}`]);
   }
   console.log(tree({
-    title: 'Internal libraries',
-    description: 'shared core + runtime packages every integration depends on',
+    title: 'Internal libraries (source)',
+    description: 'core + runtime source versions — compare against deployed runtime/core above to spot drift',
     rows: libRows,
   }));
 };
 
+// Enumerate every deployed install on disk. Returns:
+//   [{ host, root, shape?, upstreamVersion?, runtime?, core?, installedAt? }]
+//
+// Walks the standard install roots from version-markers.cjs (which
+// already knows about every host's canonical location), then for each
+// also reads the upstream host's package.json so we can show the host
+// version (e.g. "CC 2.1.150"), not just our bundled runtime version.
+function enumerateDeployed(ctx) {
+  const HOME = os.homedir();
+  let enumerateInstalledHosts;
+  try {
+    ({ enumerateInstalledHosts } = require('../lib/version-markers.cjs'));
+  } catch { return []; }
+
+  const installs = enumerateInstalledHosts(ctx);
+  return installs.map(({ host, root, drift }) => {
+    // The version-markers lib already gave us runtime + core from the
+    // marker; pull upstream version per-host from each fork's own
+    // package.json so the output is more useful.
+    const upstreamVersion = readUpstreamVersion(host, root);
+    const shape = inferShape(host, root);
+    return {
+      host: normaliseHostLabel(host),
+      root: forkRootFromMarkerDir(host, root),
+      shape,
+      upstreamVersion,
+      runtime: drift.marker?.runtime || null,
+      core: drift.marker?.core || null,
+      installedAt: drift.marker?.installedAt || null,
+    };
+  });
+}
+
+// Where each host's upstream package.json lives, relative to the
+// marker dir version-markers gave us. Subtle: each upstream repo
+// stores its user-facing version in a different place — CC packages
+// it under @anthropic-ai/claude-code, OC's monorepo has it under
+// packages/opencode (the root package.json is a workspace shell
+// with no version), Gemini puts it at the fork root.
+function readUpstreamVersion(host, markerDir) {
+  let pkgPath;
+  if (host === 'claude-code' || host === 'claude-code-150') {
+    // markerDir is <fork>/.cues; upstream pkg is at
+    // <fork>/node_modules/@anthropic-ai/claude-code/package.json
+    const forkRoot = path.dirname(markerDir);
+    pkgPath = path.join(forkRoot, 'node_modules', '@anthropic-ai', 'claude-code', 'package.json');
+  } else if (host === 'opencode') {
+    // markerDir is <fork>/.opencues; OC is a monorepo whose root
+    // package.json has no `version` — the user-facing version lives
+    // at packages/opencode/package.json.
+    pkgPath = path.join(path.dirname(markerDir), 'packages', 'opencode', 'package.json');
+  } else if (host === 'gemini-cli') {
+    // markerDir is <fork>/.opencues; upstream pkg at <fork>/package.json
+    pkgPath = path.join(path.dirname(markerDir), 'package.json');
+  } else {
+    return null; // chrome (extension self) + shell (self-owned) — no upstream
+  }
+  try {
+    const p = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    return p.version || null;
+  } catch { return null; }
+}
+
+// CC ships in two shapes; expose that distinction in the output so
+// users can see "I have BOTH a cli.js fork and a native fork."
+function inferShape(host, markerDir) {
+  if (host !== 'claude-code' && host !== 'claude-code-150') return null;
+  const forkRoot = path.dirname(markerDir);
+  if (fs.existsSync(path.join(forkRoot, 'node_modules', '@anthropic-ai', 'claude-code', 'cli.js'))) return 'cli.js';
+  if (fs.existsSync(path.join(forkRoot, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe'))) return 'native';
+  return null;
+}
+
+function forkRootFromMarkerDir(host, markerDir) {
+  // version-markers passes us the marker DIR; show the user the FORK
+  // root (its parent) since that's what they recognise from install
+  // commands.
+  if (host === 'shell' || host === 'chrome') return markerDir;
+  return path.dirname(markerDir);
+}
+
+function normaliseHostLabel(host) {
+  // version-markers distinguishes claude-code vs claude-code-150 so
+  // doctor can show two rows; for the user-facing version table both
+  // are "claude-code" with a shape suffix.
+  return host === 'claude-code-150' ? 'claude-code' : host;
+}
+
 function printHelp() {
   console.log('opencues version');
   console.log('');
-  console.log('Print the CLI version, every integration\'s version + declared host compatibility,');
-  console.log('and the internal library versions. Reads from package.json files in the workspace');
-  console.log('— what you see is what would be installed if you ran `opencues install` right now.');
+  console.log('Print three views:');
+  console.log('');
+  console.log('  • Integrations (source)    — what would deploy if you ran `opencues install`');
+  console.log('  • Installed hosts (deployed) — what\'s actually on disk per fork, including');
+  console.log('                                upstream host versions (CC, OC, Gemini) +');
+  console.log('                                bundled runtime/core + install timestamps');
+  console.log('  • Internal libraries (source) — runtime + core source versions');
+  console.log('');
+  console.log('Compare "deployed runtime/core" against "Internal libraries (source)"');
+  console.log('to spot drift — if any fork shows an older version, re-run install for that');
+  console.log('host (or `opencues update` for everything).');
 }

--- a/packages/opencues-cli/src/lib/cc-statusline.cjs
+++ b/packages/opencues-cli/src/lib/cc-statusline.cjs
@@ -1,0 +1,205 @@
+// CC statusline helpers — JSON-safe enable/disable/status against
+// either ~/.claude/settings.json (user) or <cwd>/.claude/settings.json
+// (project).
+//
+// Why a separate lib: both `opencues statusline <subcommand>` and
+// `opencues doctor` need to inspect the same files with the same
+// recognise-our-path rules. Drift between them would surface as
+// doctor saying "configured" when statusline says "not configured"
+// (or vice versa). Single source of truth.
+//
+// Design rules (the "graceful guest" model):
+//   1. Never write to a settings.json without an explicit user action
+//      — every write happens through this lib, and every entry point
+//      to this lib is a command the user typed.
+//   2. Always back up before writing (settings.json + suffix .bak.cues-statusline).
+//   3. Don't clobber a user's custom statusLine.command — if it's
+//      already set to something we don't recognise, refuse with a clear
+//      message + suggest --force.
+//   4. Recognise our own paths broadly (current install root +
+//      historic layouts) so a re-enable correctly identifies a stale
+//      opencues path and overwrites it.
+//   5. Disable restores nothing — we never save a "prior" command, so
+//      the slot is left empty after disable. Users who had a custom
+//      command before --force should know to re-set it themselves.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+// Resolve the absolute path to the statusline.sh script we want to
+// register. Walks the standard fork-install locations. Returns null
+// if no CC fork is installed (caller should tell the user to install
+// first).
+function resolveStatuslineScript() {
+  const HOME = os.homedir();
+  const candidates = [
+    path.join(HOME, 'claude-code-cues', '.cues', 'statusline.sh'),
+    path.join(HOME, 'claude-code-cues-150', '.cues', 'statusline.sh'),
+    // Legacy layout — kept so users on pre-compact-footprint installs
+    // can still enable. Mirror the rules in setup.sh.
+    path.join(HOME, '.claude', 'opencues', 'statusline.sh'),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+// Returns true if `cmd` looks like any opencues statusline path —
+// current install root OR historic layouts. Used to recognise our
+// own writes without false-positives on user customisations.
+function isOpenCuesPath(cmd) {
+  if (typeof cmd !== 'string') return false;
+  return cmd.includes('claude-code-cues') ||
+         cmd.includes('claude-code-cues-150') ||
+         cmd.includes('.claude/highlight-statusline.sh') ||
+         cmd.includes('.claude/opencues/statusline.sh') ||
+         (cmd.endsWith('/statusline.sh') && cmd.includes('/.cues/'));
+}
+
+// Resolve which settings.json a given scope writes to.
+//   'user'    → ~/.claude/settings.json
+//   'project' → <cwd>/.claude/settings.json
+function settingsPathFor(scope, cwd) {
+  if (scope === 'project') {
+    return path.join(cwd || process.cwd(), '.claude', 'settings.json');
+  }
+  return path.join(os.homedir(), '.claude', 'settings.json');
+}
+
+// Read JSON safely. Returns { ok, data, error }. `data` is {} when
+// the file doesn't exist (a no-op merge target for write).
+function readSettings(file) {
+  if (!fs.existsSync(file)) return { ok: true, data: {} };
+  let raw;
+  try { raw = fs.readFileSync(file, 'utf8'); }
+  catch (err) { return { ok: false, error: `read failed: ${err.message}` }; }
+  if (!raw.trim()) return { ok: true, data: {} };
+  try { return { ok: true, data: JSON.parse(raw) }; }
+  catch (err) { return { ok: false, error: `invalid JSON: ${err.message}` }; }
+}
+
+// Atomically write JSON. Backs up to .bak.cues-statusline first if
+// the file already exists. Caller is responsible for the merge.
+function writeSettings(file, data) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  if (fs.existsSync(file)) {
+    fs.copyFileSync(file, file + '.bak.cues-statusline');
+  }
+  fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
+}
+
+// Inspect status for a single settings.json. Returns:
+//   { state: 'missing'      , file, scriptPath: null }   — file doesn't exist OR no statusLine field
+//   { state: 'opencues-ours', file, currentCmd, scriptPath } — already pointing at our path
+//   { state: 'opencues-stale', file, currentCmd, scriptPath } — opencues path but not the current install
+//   { state: 'user-custom'  , file, currentCmd, scriptPath } — user has their own command
+//   { state: 'broken'       , file, error, scriptPath }   — JSON parse error
+function inspect(scope, cwd) {
+  const file = settingsPathFor(scope, cwd);
+  const scriptPath = resolveStatuslineScript();
+  const r = readSettings(file);
+  if (!r.ok) return { state: 'broken', file, error: r.error, scriptPath };
+  const cmd = r.data?.statusLine?.command;
+  if (typeof cmd !== 'string' || !cmd) {
+    return { state: 'missing', file, scriptPath };
+  }
+  if (cmd === scriptPath) {
+    return { state: 'opencues-ours', file, currentCmd: cmd, scriptPath };
+  }
+  if (isOpenCuesPath(cmd)) {
+    return { state: 'opencues-stale', file, currentCmd: cmd, scriptPath };
+  }
+  return { state: 'user-custom', file, currentCmd: cmd, scriptPath };
+}
+
+// Enable for a scope. Returns { ok, action, message }.
+//   action: 'created' | 'updated' | 'replaced-stale' | 'no-op' | 'refused' | 'no-script'
+function enable(scope, opts = {}) {
+  const { force = false, cwd } = opts;
+  const info = inspect(scope, cwd);
+  if (!info.scriptPath) {
+    return {
+      ok: false,
+      action: 'no-script',
+      message: 'No installed CC fork found. Run `opencues install claude-code` first.',
+    };
+  }
+  if (info.state === 'broken') {
+    return { ok: false, action: 'refused', message: `${info.file} is unreadable (${info.error}). Fix the file or remove it, then retry.` };
+  }
+  if (info.state === 'opencues-ours') {
+    return { ok: true, action: 'no-op', message: `Already enabled — ${info.file} statusLine.command already points at ${info.scriptPath}` };
+  }
+  if (info.state === 'user-custom' && !force) {
+    return {
+      ok: false,
+      action: 'refused',
+      message:
+        `${info.file} has a custom statusLine.command:\n` +
+        `  ${info.currentCmd}\n` +
+        `Refusing to overwrite. Re-run with --force to replace it, OR set it back to your custom path after running enable.`,
+    };
+  }
+  // Merge our statusLine into existing settings (preserve every other field).
+  //
+  // refreshInterval: 1 — required for CC 2.1.150+ (native binary).
+  // On those versions CC's debounced statusline-refresh hook (the S6
+  // seam our patch captured pre-2.1.113) is gone, so the runtime can't
+  // push tip updates on demand — we're entirely dependent on CC's
+  // polling. CC's default poll cadence is too slow: the active-highlight
+  // window (cursor on a cued word) closes within ~1-2 seconds as the
+  // user types, so a 5-30s poll misses the tip almost every time.
+  // 1s is CC's minimum + makes polling indistinguishable from event-
+  // driven. The script is ~5ms to run, so polling cost is negligible.
+  const r = readSettings(info.file);
+  const data = r.ok ? r.data : {};
+  data.statusLine = { type: 'command', command: info.scriptPath, refreshInterval: 1 };
+  writeSettings(info.file, data);
+  if (info.state === 'missing') {
+    return { ok: true, action: 'created', message: `Wrote statusLine.command to ${info.file} → ${info.scriptPath}` };
+  }
+  if (info.state === 'opencues-stale') {
+    return { ok: true, action: 'replaced-stale', message: `Updated stale statusLine.command in ${info.file} → ${info.scriptPath} (was: ${info.currentCmd})` };
+  }
+  // 'user-custom' + --force
+  return { ok: true, action: 'updated', message: `Replaced custom statusLine.command in ${info.file} → ${info.scriptPath} (was: ${info.currentCmd}; backup at ${info.file}.bak.cues-statusline)` };
+}
+
+// Disable for a scope. Removes the statusLine field entirely if it
+// points at our path. Refuses if it points elsewhere (user's own).
+function disable(scope, opts = {}) {
+  const { cwd } = opts;
+  const info = inspect(scope, cwd);
+  if (info.state === 'missing') {
+    return { ok: true, action: 'no-op', message: `Already disabled — ${info.file} has no statusLine field.` };
+  }
+  if (info.state === 'broken') {
+    return { ok: false, action: 'refused', message: `${info.file} is unreadable (${info.error}).` };
+  }
+  if (info.state === 'user-custom') {
+    return {
+      ok: false,
+      action: 'refused',
+      message: `${info.file} statusLine.command points at a non-opencues script (${info.currentCmd}). Refusing to remove — not ours to touch.`,
+    };
+  }
+  // opencues-ours OR opencues-stale → remove the field, write back.
+  const r = readSettings(info.file);
+  const data = r.ok ? r.data : {};
+  delete data.statusLine;
+  writeSettings(info.file, data);
+  return { ok: true, action: 'cleared', message: `Cleared statusLine from ${info.file} (was: ${info.currentCmd}; backup at ${info.file}.bak.cues-statusline)` };
+}
+
+module.exports = {
+  resolveStatuslineScript,
+  isOpenCuesPath,
+  settingsPathFor,
+  inspect,
+  enable,
+  disable,
+};

--- a/packages/opencues-cli/src/lib/cc-statusline.test.cjs
+++ b/packages/opencues-cli/src/lib/cc-statusline.test.cjs
@@ -1,0 +1,269 @@
+// Tests for cc-statusline.cjs — the opt-in user/project statusline
+// enable/disable logic.
+//
+// The point of this test suite is to pin the "graceful guest" rules
+// so we don't accidentally regress to clobbering user customisations:
+//
+//   - enable on empty file → CREATES with our statusLine, no other fields
+//   - enable when already ours → NO-OP (idempotent re-runs)
+//   - enable on stale opencues path → REPLACES (auto-migration)
+//   - enable on user-custom command → REFUSES without --force
+//   - enable on user-custom with --force → REPLACES + backs up
+//   - disable when ours → CLEARS the field, preserves other fields
+//   - disable when missing → NO-OP
+//   - disable on user-custom → REFUSES (never touch what's not ours)
+//   - corrupted JSON → REFUSES with clear error
+//
+// Each test runs in a fresh tmpdir so concurrent runs + the user's
+// real ~/.claude/ are never touched.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const lib = require('./cc-statusline.cjs');
+
+// Each test gets its own tmpdir to simulate cwd / HOME.
+function tmpdir(name) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `oc-statusline-${name}-`));
+}
+
+// Plant a fake CC fork so resolveStatuslineScript returns a path.
+// Returns the script path for assertions.
+function plantFork(home) {
+  const forkDir = path.join(home, 'claude-code-cues', '.cues');
+  fs.mkdirSync(forkDir, { recursive: true });
+  const scriptPath = path.join(forkDir, 'statusline.sh');
+  fs.writeFileSync(scriptPath, '#!/usr/bin/env bash\necho fake');
+  fs.chmodSync(scriptPath, 0o755);
+  return scriptPath;
+}
+
+// Override HOME for the duration of a test, restore after.
+function withHome(home, fn) {
+  const prior = process.env.HOME;
+  process.env.HOME = home;
+  try { return fn(); }
+  finally { process.env.HOME = prior; }
+}
+
+test('isOpenCuesPath: recognises every layout', () => {
+  assert.ok(lib.isOpenCuesPath('/home/u/claude-code-cues/.cues/statusline.sh'));
+  assert.ok(lib.isOpenCuesPath('/home/u/claude-code-cues-150/.cues/statusline.sh'));
+  assert.ok(lib.isOpenCuesPath('/home/u/.claude/highlight-statusline.sh'));
+  assert.ok(lib.isOpenCuesPath('/home/u/.claude/opencues/statusline.sh'));
+  assert.ok(!lib.isOpenCuesPath('/usr/local/bin/starship-claude.sh'));
+  assert.ok(!lib.isOpenCuesPath(undefined));
+  assert.ok(!lib.isOpenCuesPath(null));
+  assert.ok(!lib.isOpenCuesPath(42));
+});
+
+test('enable user: no settings.json → creates with statusLine only', () => {
+  const home = tmpdir('enable-create');
+  const scriptPath = plantFork(home);
+  withHome(home, () => {
+    const r = lib.enable('user');
+    assert.strictEqual(r.ok, true);
+    assert.strictEqual(r.action, 'created');
+    const data = JSON.parse(fs.readFileSync(path.join(home, '.claude', 'settings.json'), 'utf8'));
+    assert.deepStrictEqual(data.statusLine, { type: 'command', command: scriptPath, refreshInterval: 1 });
+    // Only the statusLine field — we never invent other fields.
+    assert.deepStrictEqual(Object.keys(data), ['statusLine']);
+  });
+});
+
+test('enable user: existing settings with no statusLine → merges, preserves other fields', () => {
+  const home = tmpdir('enable-merge');
+  const scriptPath = plantFork(home);
+  const settings = path.join(home, '.claude', 'settings.json');
+  fs.mkdirSync(path.dirname(settings), { recursive: true });
+  fs.writeFileSync(settings, JSON.stringify({ theme: 'dark-ansi', env: { FOO: 'bar' } }));
+  withHome(home, () => {
+    const r = lib.enable('user');
+    assert.strictEqual(r.action, 'created');
+    const data = JSON.parse(fs.readFileSync(settings, 'utf8'));
+    assert.strictEqual(data.theme, 'dark-ansi', 'theme preserved');
+    assert.deepStrictEqual(data.env, { FOO: 'bar' }, 'env preserved');
+    assert.deepStrictEqual(data.statusLine, { type: 'command', command: scriptPath, refreshInterval: 1 });
+  });
+});
+
+test('enable user: already configured → no-op, idempotent', () => {
+  const home = tmpdir('enable-idempotent');
+  const scriptPath = plantFork(home);
+  withHome(home, () => {
+    lib.enable('user');                   // first run
+    const r2 = lib.enable('user');        // second run
+    assert.strictEqual(r2.ok, true);
+    assert.strictEqual(r2.action, 'no-op');
+    assert.match(r2.message, /Already enabled/);
+  });
+});
+
+test('enable user: stale opencues path → replaces silently with new path', () => {
+  const home = tmpdir('enable-stale');
+  const scriptPath = plantFork(home);
+  const settings = path.join(home, '.claude', 'settings.json');
+  fs.mkdirSync(path.dirname(settings), { recursive: true });
+  // Plant a stale legacy opencues path.
+  fs.writeFileSync(settings, JSON.stringify({
+    statusLine: { type: 'command', command: path.join(home, '.claude', 'highlight-statusline.sh') },
+  }));
+  withHome(home, () => {
+    const r = lib.enable('user');
+    assert.strictEqual(r.ok, true);
+    assert.strictEqual(r.action, 'replaced-stale');
+    const data = JSON.parse(fs.readFileSync(settings, 'utf8'));
+    assert.strictEqual(data.statusLine.command, scriptPath);
+  });
+});
+
+test('enable user: user-custom statusLine → REFUSES without --force', () => {
+  const home = tmpdir('enable-refuse');
+  plantFork(home);
+  const settings = path.join(home, '.claude', 'settings.json');
+  fs.mkdirSync(path.dirname(settings), { recursive: true });
+  fs.writeFileSync(settings, JSON.stringify({
+    statusLine: { type: 'command', command: '/usr/local/bin/starship-claude.sh' },
+  }));
+  withHome(home, () => {
+    const r = lib.enable('user');
+    assert.strictEqual(r.ok, false);
+    assert.strictEqual(r.action, 'refused');
+    assert.match(r.message, /starship-claude\.sh/);
+    assert.match(r.message, /--force/);
+    // File must be unchanged.
+    const data = JSON.parse(fs.readFileSync(settings, 'utf8'));
+    assert.strictEqual(data.statusLine.command, '/usr/local/bin/starship-claude.sh');
+    // No backup created (refuse means no write happened).
+    assert.ok(!fs.existsSync(settings + '.bak.cues-statusline'));
+  });
+});
+
+test('enable user: user-custom with --force → replaces + backs up', () => {
+  const home = tmpdir('enable-force');
+  const scriptPath = plantFork(home);
+  const settings = path.join(home, '.claude', 'settings.json');
+  fs.mkdirSync(path.dirname(settings), { recursive: true });
+  fs.writeFileSync(settings, JSON.stringify({
+    statusLine: { type: 'command', command: '/usr/local/bin/starship-claude.sh' },
+  }));
+  withHome(home, () => {
+    const r = lib.enable('user', { force: true });
+    assert.strictEqual(r.ok, true);
+    assert.strictEqual(r.action, 'updated');
+    const data = JSON.parse(fs.readFileSync(settings, 'utf8'));
+    assert.strictEqual(data.statusLine.command, scriptPath);
+    // Backup must be present + contain the prior content.
+    const backup = JSON.parse(fs.readFileSync(settings + '.bak.cues-statusline', 'utf8'));
+    assert.strictEqual(backup.statusLine.command, '/usr/local/bin/starship-claude.sh');
+  });
+});
+
+test('enable: no installed CC fork → returns no-script error', () => {
+  const home = tmpdir('enable-no-fork');
+  // Don't plant fork.
+  withHome(home, () => {
+    const r = lib.enable('user');
+    assert.strictEqual(r.ok, false);
+    assert.strictEqual(r.action, 'no-script');
+    assert.match(r.message, /install claude-code/);
+  });
+});
+
+test('enable project: writes to <cwd>/.claude/settings.json', () => {
+  const home = tmpdir('enable-project-home');
+  const projectCwd = tmpdir('enable-project-cwd');
+  const scriptPath = plantFork(home);
+  withHome(home, () => {
+    const r = lib.enable('project', { cwd: projectCwd });
+    assert.strictEqual(r.ok, true);
+    assert.strictEqual(r.action, 'created');
+    // Project file written, NOT user file.
+    const projectSettings = path.join(projectCwd, '.claude', 'settings.json');
+    assert.ok(fs.existsSync(projectSettings));
+    assert.ok(!fs.existsSync(path.join(home, '.claude', 'settings.json')));
+    const data = JSON.parse(fs.readFileSync(projectSettings, 'utf8'));
+    assert.strictEqual(data.statusLine.command, scriptPath);
+  });
+});
+
+test('disable: ours → clears field, preserves other fields', () => {
+  const home = tmpdir('disable-ours');
+  const scriptPath = plantFork(home);
+  withHome(home, () => {
+    lib.enable('user');
+    // Add another field after enable so we can check preservation.
+    const settingsPath = path.join(home, '.claude', 'settings.json');
+    const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    data.theme = 'dark';
+    fs.writeFileSync(settingsPath, JSON.stringify(data));
+
+    const r = lib.disable('user');
+    assert.strictEqual(r.ok, true);
+    assert.strictEqual(r.action, 'cleared');
+    const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.strictEqual(after.statusLine, undefined);
+    assert.strictEqual(after.theme, 'dark', 'other fields preserved');
+  });
+});
+
+test('disable: user-custom → REFUSES, file unchanged', () => {
+  const home = tmpdir('disable-refuse');
+  plantFork(home);
+  const settings = path.join(home, '.claude', 'settings.json');
+  fs.mkdirSync(path.dirname(settings), { recursive: true });
+  fs.writeFileSync(settings, JSON.stringify({
+    statusLine: { type: 'command', command: '/usr/local/bin/starship-claude.sh' },
+  }));
+  withHome(home, () => {
+    const r = lib.disable('user');
+    assert.strictEqual(r.ok, false);
+    assert.strictEqual(r.action, 'refused');
+    // Unchanged.
+    const data = JSON.parse(fs.readFileSync(settings, 'utf8'));
+    assert.strictEqual(data.statusLine.command, '/usr/local/bin/starship-claude.sh');
+  });
+});
+
+test('disable: nothing configured → no-op', () => {
+  const home = tmpdir('disable-noop');
+  plantFork(home);
+  withHome(home, () => {
+    const r = lib.disable('user');
+    assert.strictEqual(r.ok, true);
+    assert.strictEqual(r.action, 'no-op');
+  });
+});
+
+test('inspect: corrupted JSON → broken', () => {
+  const home = tmpdir('broken');
+  plantFork(home);
+  const settings = path.join(home, '.claude', 'settings.json');
+  fs.mkdirSync(path.dirname(settings), { recursive: true });
+  fs.writeFileSync(settings, 'not json {{{');
+  withHome(home, () => {
+    const info = lib.inspect('user');
+    assert.strictEqual(info.state, 'broken');
+    assert.match(info.error, /invalid JSON/);
+  });
+});
+
+test('enable: refuses to touch broken JSON file', () => {
+  const home = tmpdir('enable-broken');
+  plantFork(home);
+  const settings = path.join(home, '.claude', 'settings.json');
+  fs.mkdirSync(path.dirname(settings), { recursive: true });
+  fs.writeFileSync(settings, 'not json {{{');
+  withHome(home, () => {
+    const r = lib.enable('user');
+    assert.strictEqual(r.ok, false);
+    assert.strictEqual(r.action, 'refused');
+    // File is unchanged (still corrupted, we don't try to repair it).
+    assert.strictEqual(fs.readFileSync(settings, 'utf8'), 'not json {{{');
+  });
+});

--- a/packages/opencues-cli/src/lib/version-markers.cjs
+++ b/packages/opencues-cli/src/lib/version-markers.cjs
@@ -105,7 +105,6 @@ function enumerateInstalledHosts(ctx) {
   const HOME = os.homedir();
   const candidates = [
     { host: 'claude-code',       root: path.join(HOME, 'claude-code-cues', '.cues') },
-    { host: 'claude-code-150',   root: path.join(HOME, 'claude-code-cues-150', '.cues') },
     { host: 'opencode',          root: path.join(HOME, 'opencode-cues', '.opencues') },
     { host: 'gemini-cli',        root: path.join(HOME, 'gemini-cli-cues', '.opencues') },
     { host: 'shell',             root: path.join(ctx.REPO_ROOT, 'integrations/shell/node_modules/@opencues') },
@@ -123,11 +122,31 @@ function enumerateInstalledHosts(ctx) {
   return results;
 }
 
+// Detect "dev relic" CC fork dirs — anything matching ~/claude-code-cues*
+// other than the canonical ~/claude-code-cues/. These are leftovers
+// from when we maintained parallel forks per-shape; the product is now
+// single-fork (upgrade in place). Surface these so doctor can suggest
+// the user delete them.
+function detectExtraCCForks() {
+  const HOME = os.homedir();
+  const out = [];
+  try {
+    for (const entry of fs.readdirSync(HOME, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (!entry.name.startsWith('claude-code-cues')) continue;
+      if (entry.name === 'claude-code-cues') continue; // the canonical one
+      out.push(path.join(HOME, entry.name));
+    }
+  } catch { /* HOME unreadable — silent */ }
+  return out;
+}
+
 module.exports = {
   writeMarker,
   readMarker,
   checkDrift,
   enumerateInstalledHosts,
+  detectExtraCCForks,
   getSourceVersions,
   FILENAME,
 };


### PR DESCRIPTION
## Summary

Five themes, one PR — they're all the same install/upgrade surface for Claude Code and shipping any one without the others would leave a sharp edge.

### A. Opt-in statusline command
- New `opencues statusline {enable|disable|status} [--project] [--force]`.
- Never auto-writes to `~/.claude/settings.json` (graceful guest); refuses to clobber user-custom statusLine commands without `--force`; backs up prior content; idempotent.
- Auto-migrates stale OpenCues paths (legacy `~/.claude/highlight-statusline.sh` etc.) silently.

### B. CC 2.1.150 native binary support
- `highlight-statusline.sh` now matches `claude-code/bin/claude` alongside `cli.js` — fixes "statusline shows nothing" on native shape.
- Statusline renders sentence-cue state (`cueBlank=true` + `cueTip=null`) via truncated `highlightedWord` fallback instead of printing nothing.
- `refreshInterval: 1` (S6 anchor is gone in 2.1.150 — polling until the new seam is found).
- `setup.sh` shape-aware fork-dir computation (cli.js = 3 parents up, native = 4).

### C. Single canonical fork
- One fork: `~/claude-code-cues`. No more user-exposed `-150` suffix.
- `opencues install claude-code` upgrades in place; shape transitions (cli.js ↔ native) re-detected from disk post-install in `validateFork`.
- `opencues run claude-code` uses the canonical fork only.
- doctor surfaces stray `~/claude-code-cues-*/` dirs as dev relics.

### D. Idempotent install + smart update
- `opencues install <host>` no-ops when the fork is healthy; `--rebuild` forces destructive re-install.
- `opencues update <host>` without `--to` upgrades to the current pin from `compat.json`; delegates to `install --rebuild` with `OPENCUES_SKIP_BANNER=1` so only the outer update banner shows.
- Update banner uses `brightWhite(bold(…))` FROM → TO version numbers; redundant info line removed.

### E. Version display
- `opencues version` adds an "Installed hosts" section showing each host's upstream version + bundled `@opencues/{core,runtime}` versions — drift between source and bundles is now visible.

## Package bumps

- `opencues` (CLI): 0.1.0 → 0.1.1
- `@opencues/claude-code`: 0.1.0 → 0.1.1
- `CLAUDE.md` version snapshot table updated.

## Test plan

- [x] `node --test packages/opencues-cli/src/lib/*.test.cjs packages/opencues-cli/src/commands/*.test.cjs` — 59 tests pass, including 14 new statusline tests
- [x] `bash -n` on every modified `.sh`
- [x] `scripts/lint-shell-portability.sh`
- [x] Manual: install on 2.1.110 (cli.js) → upgrade to 2.1.150 (native) via `opencues update claude-code` → downgrade back to 2.1.110 → statusline survives each transition
- [x] Manual: `opencues statusline enable` then `opencues statusline status` reflects user + project state correctly; `disable` clears only ours and refuses third-party

🤖 Generated with [Claude Code](https://claude.com/claude-code)