### PR TITLE
fix(update): suppress 'add to tested list' hint when version already tested

### DIFF
--- a/packages/opencues-cli/src/commands/update.cjs
+++ b/packages/opencues-cli/src/commands/update.cjs
@@ -409,7 +409,9 @@ function doUpgradeNpm(host, toVersion, compat, { dryRun }, ctx) {
   console.log(`\nPin updated. Re-installing ${host} at ${toVersion}...\n`);
   runHostInstaller(host, ctx, { rollback: () => fixupRollbackHint(pkgPath, loc.field, oldValue, host) });
   console.log(`\n${tag('ok')} ${host} now pinned at ${bold(toVersion)} and installed.`);
-  console.log(dim(`Consider adding ${toVersion} to integrations/${host}/compat.json's "tested" list once you've verified.`));
+  if (!compatLib.isTested(toVersion, compat)) {
+    console.log(dim(`Consider adding ${toVersion} to integrations/${host}/compat.json's "tested" list once you've verified.`));
+  }
 }
 
 async function doUpgradeGit(host, toVersion, compat, { dryRun }, ctx) {
@@ -448,7 +450,9 @@ async function doUpgradeGit(host, toVersion, compat, { dryRun }, ctx) {
     },
   });
   console.log(`\n${tag('ok')} ${host} now pinned at ${bold(`${wantNorm}@${wantedTag.sha}`)} and installed.`);
-  console.log(dim(`Consider adding {version:"${wantNorm}",sha:"${wantedTag.sha}"} to integrations/${host}/compat.json's "tested" list once you've verified.`));
+  if (!compatLib.isTested(wantNorm, compat)) {
+    console.log(dim(`Consider adding {version:"${wantNorm}",sha:"${wantedTag.sha}"} to integrations/${host}/compat.json's "tested" list once you've verified.`));
+  }
 }
 
 function runHostInstaller(host, ctx, { rollback }) {


### PR DESCRIPTION
## Summary

`opencues update <host>` always prints `Consider adding <ver> to integrations/<host>/compat.json's "tested" list...` after a successful upgrade — even when the version is already in `tested`. Observed when upgrading to claude-code 2.1.150 (already in tested).

Fix: gate both call sites (`update.cjs:412` npm path, `:451` git path) on `!compatLib.isTested(version, compat)`. `isTested` already existed in `compat.cjs`.

## Test plan

- [x] `node --check packages/opencues-cli/src/commands/update.cjs`
- [x] `node --test packages/opencues-cli/src/commands/update.test.cjs` — 6/6 pass
- [ ] Manual: re-run `opencues update claude-code` against the current pinned (and tested) 2.1.150 — hint should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)