### PR TITLE
feat(runtime): chain sequential LLM-blank substitutes into walkable history

### DIFF
--- a/packages/opencues-runtime/src/modules/blank-chain.scenarios.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-chain.scenarios.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Scenario tests for sequential LLM-blank substitutions building a
+ * walkable chain in WordDef.alternatives.
+ *
+ * User journey this pins:
+ *   1. User types "hello world translate to japanese _"
+ *   2. FluidBlank/TransformBlank fires → buffer becomes "こんにちは世界"
+ *   3. User appends " translate to chinese _"
+ *   4. Same pipeline fires → buffer becomes "你好世界"
+ *   5. Pressing Down should walk: 你好世界 → "こんにちは世界 translate to
+ *      chinese _" → こんにちは世界 → "hello world translate to japanese _"
+ *
+ * Before this feature, step 4 clobbered the def from step 2 — the
+ * japanese waypoint and the original english prompt were both lost.
+ * Now `dyn-defs.findChainableLlmDef` detects that the prior result
+ * sits verbatim inside the new substitute's span and the resolver
+ * extends the alternatives list instead of replacing.
+ *
+ * Invalidation rules pinned here:
+ *   - User edit inside the prior result → chain breaks (verbatim check
+ *     fails) → fresh def, no chain.
+ *   - User cycled mid-chain before re-summoning → abandoned tail is
+ *     truncated (alt-history equivalent of git branch).
+ *   - Different pipelines don't graft (fluid → transform stays
+ *     independent).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Resolver } from './resolver';
+import { ConfigLoader } from './config-loader';
+import { HighlightState } from '../state/highlight-state';
+import { DynDefs, type WordDef } from '../state/dyn-defs';
+import { MockAdapter } from '../../testing/mock-adapter';
+
+const TIPS = JSON.stringify({ concepts: [] });
+const CUES_MD = `---
+name: test-cues
+domain: test
+version: 1
+---
+`;
+
+interface ScriptedResult {
+  wordIndex: number;
+  word: string;
+  alternatives: string[];
+  spanStart?: number;
+  spanEnd?: number;
+  source: 'fluid-blank' | 'transform-blank';
+  priority?: number;
+  metadata?: Record<string, unknown>;
+}
+
+function setupChainScenario(initialText: string) {
+  const adapter = new MockAdapter({
+    cwd: '/proj',
+    files: { '/mock/CUES.md': TIPS, '/proj/CUES.md': CUES_MD },
+  });
+  adapter.pushText(initialText);
+  const hlState = new HighlightState();
+  const dynDefs = new DynDefs();
+  const loader = new ConfigLoader(adapter, { settingsFile: '/proj/CUES.md' });
+  const resolver = new Resolver(adapter, hlState, dynDefs, loader, {
+    endpoint: 'http://test', apiKey: 'x', defaultModel: 'm', debounceMs: 10, httpAdapter: {},
+  });
+  let scripted: ScriptedResult[] = [];
+  (resolver as unknown as { _resolver: { resolve(ctx: unknown): Promise<{ results: ScriptedResult[] }> } })._resolver = {
+    resolve: async () => ({ results: scripted }),
+  };
+  function scriptNext(results: ScriptedResult[]): void { scripted = results; }
+  return { adapter, dynDefs, resolver, scriptNext };
+}
+
+// Locate the `_` token's word index — production FluidBlankSource uses
+// this as result.wordIndex so the resolver's `target = wordSpans[
+// r.wordIndex]` lands on the `_` and the synonym filter
+// `a !== target.word` correctly drops the literal "_" from alternatives.
+function blankWordIndex(currentText: string): number {
+  const words = currentText.split(/\s+/).filter(Boolean);
+  const idx = words.lastIndexOf('_');
+  return idx >= 0 ? idx : 0;
+}
+
+// Build a fluid-blank WIPE-mode result that replaces the entire current
+// buffer text with `answer`.
+function fluidWipe(currentText: string, answer: string): ScriptedResult {
+  return {
+    wordIndex: blankWordIndex(currentText),
+    word: '_',
+    alternatives: ['_', answer],
+    spanStart: 0,
+    spanEnd: currentText.length,
+    source: 'fluid-blank',
+    priority: 92,
+  };
+}
+
+function transformWhole(currentText: string, rewritten: string): ScriptedResult {
+  return {
+    wordIndex: blankWordIndex(currentText),
+    word: '_',
+    alternatives: [currentText, rewritten],
+    spanStart: 0,
+    spanEnd: currentText.length,
+    source: 'transform-blank',
+    priority: 93,
+    // No transformTarget set — drives the whole-body merge path
+    metadata: { transformInstruction: 'translate' },
+  };
+}
+
+describe('fluid-blank chain — sequential WIPE substitutions', () => {
+  it('captures the user\'s question as alternatives[0] (not just "_")', async () => {
+    const { adapter, dynDefs, resolver, scriptNext } = setupChainScenario(
+      'translate hello to japanese _',
+    );
+    scriptNext([fluidWipe('translate hello to japanese _', 'こんにちは')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    expect(adapter.getText()).toBe('こんにちは');
+    const def = findFluidBlankDef(dynDefs);
+    expect(def).toBeDefined();
+    // Down-arrow target = the prompt the user typed, not a bare "_".
+    expect(def!.alternatives[0]).toBe('translate hello to japanese _');
+    expect(def!.alternatives[1]).toBe('こんにちは');
+    expect(def!.currentIndex).toBe(1);
+  });
+
+  it('extends the chain when a second WIPE encompasses the first result', async () => {
+    const { adapter, dynDefs, resolver, scriptNext } = setupChainScenario(
+      'translate hello to japanese _',
+    );
+    scriptNext([fluidWipe('translate hello to japanese _', 'こんにちは')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    // User appends a chinese translate prompt on top of the japanese result.
+    adapter.pushText('こんにちは translate to chinese _');
+    scriptNext([fluidWipe('こんにちは translate to chinese _', '你好')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    expect(adapter.getText()).toBe('你好');
+    const def = findFluidBlankDef(dynDefs);
+    expect(def).toBeDefined();
+    // Chain depth 4: [original english prompt, japanese result,
+    //                 mid-chain question, chinese result]
+    expect(def!.alternatives).toEqual([
+      'translate hello to japanese _',
+      'こんにちは',
+      'こんにちは translate to chinese _',
+      '你好',
+    ]);
+    expect(def!.currentIndex).toBe(3);
+  });
+
+  it('does NOT extend when the prior result was edited inside (verbatim check fails)', async () => {
+    const { adapter, dynDefs, resolver, scriptNext } = setupChainScenario(
+      'translate hello to japanese _',
+    );
+    scriptNext([fluidWipe('translate hello to japanese _', 'こんにちは')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    // User edits the substituted text itself — they CHOSE different content.
+    // The previous chain entry's currentAlt ("こんにちは") is no longer at the
+    // recorded span; the chain must reset.
+    adapter.pushText('hola translate to chinese _');
+    scriptNext([fluidWipe('hola translate to chinese _', '你好')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    const def = findFluidBlankDef(dynDefs);
+    expect(def).toBeDefined();
+    // Fresh def — no japanese in the chain.
+    expect(def!.alternatives).toEqual([
+      'hola translate to chinese _',
+      '你好',
+    ]);
+    expect(def!.currentIndex).toBe(1);
+  });
+
+  it('truncates the abandoned tail when the user cycled mid-chain before re-summoning', async () => {
+    const { adapter, dynDefs, resolver, scriptNext } = setupChainScenario(
+      'translate hello to japanese _',
+    );
+    scriptNext([fluidWipe('translate hello to japanese _', 'こんにちは')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    adapter.pushText('こんにちは translate to chinese _');
+    scriptNext([fluidWipe('こんにちは translate to chinese _', '你好')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    // User cycles back to "こんにちは" (currentIndex 1) then re-summons.
+    const def = findFluidBlankDef(dynDefs);
+    expect(def).toBeDefined();
+    // Simulate the cycled state — production code does this via applyAltCycle,
+    // but we set it directly to keep the test focused on truncate semantics.
+    rewriteDef(dynDefs, def!, {
+      currentIndex: 1,
+      spanStart: 0,
+      spanEnd: 'こんにちは'.length,
+    });
+    adapter.pushText('こんにちは translate to korean _');
+    scriptNext([fluidWipe('こんにちは translate to korean _', '안녕하세요')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    const finalDef = findFluidBlankDef(dynDefs);
+    expect(finalDef).toBeDefined();
+    // Tail "[こんにちは translate to chinese _, 你好]" was discarded;
+    // new branch "[こんにちは translate to korean _, 안녕하세요]" took its place.
+    expect(finalDef!.alternatives).toEqual([
+      'translate hello to japanese _',
+      'こんにちは',
+      'こんにちは translate to korean _',
+      '안녕하세요',
+    ]);
+    expect(finalDef!.currentIndex).toBe(3);
+  });
+});
+
+describe('transform-blank chain — sequential whole-buffer rewrites', () => {
+  it('extends the chain when a second transform-blank fires on the prior result', async () => {
+    const { adapter, dynDefs, resolver, scriptNext } = setupChainScenario(
+      'translate hello to japanese _',
+    );
+    scriptNext([transformWhole('translate hello to japanese _', 'こんにちは')]);
+    await resolver.resolveAndApply(adapter.getText());
+    expect(adapter.getText()).toBe('こんにちは');
+
+    adapter.pushText('こんにちは translate to chinese _');
+    scriptNext([transformWhole('こんにちは translate to chinese _', '你好')]);
+    await resolver.resolveAndApply(adapter.getText());
+    expect(adapter.getText()).toBe('你好');
+
+    const def = findTransformBlankDef(dynDefs);
+    expect(def).toBeDefined();
+    expect(def!.alternatives).toEqual([
+      'translate hello to japanese _',
+      'こんにちは',
+      'こんにちは translate to chinese _',
+      '你好',
+    ]);
+    expect(def!.currentIndex).toBe(3);
+  });
+
+  it('does NOT graft a fluid-blank onto a transform-blank chain', async () => {
+    const { adapter, dynDefs, resolver, scriptNext } = setupChainScenario(
+      'translate hello to japanese _',
+    );
+    scriptNext([transformWhole('translate hello to japanese _', 'こんにちは')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    adapter.pushText('こんにちは translate to chinese _');
+    scriptNext([fluidWipe('こんにちは translate to chinese _', '你好')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    // Two independent defs: one transform-blank (japanese chain), one
+    // fresh fluid-blank (chinese substitute). The fluid-blank's alts[0]
+    // = the question; alts[1] = 你好 — no japanese leaked in.
+    const transformDef = findTransformBlankDef(dynDefs);
+    const fluidDef = findFluidBlankDef(dynDefs);
+    expect(fluidDef).toBeDefined();
+    expect(fluidDef!.alternatives).toEqual([
+      'こんにちは translate to chinese _',
+      '你好',
+    ]);
+    // The transform-blank def may have been pruned (its span [0, 'こんにちは'.length)
+    // overlaps the fluid-blank wipe range). What we care about: NO chain merge.
+    if (transformDef) {
+      expect(transformDef.alternatives).not.toContain('你好');
+    }
+  });
+});
+
+// Locate the canonical fluid-blank def in the map. Sequential WIPE
+// substitutes produce at most one entry; this surfaces it without
+// hard-coding a word index that shifts as the chain grows.
+function findFluidBlankDef(dynDefs: DynDefs): WordDef | undefined {
+  for (const [, def] of dynDefs.entries()) {
+    if (def.blankName === 'fluid-blank') return def;
+  }
+  return undefined;
+}
+
+function findTransformBlankDef(dynDefs: DynDefs): WordDef | undefined {
+  for (const [, def] of dynDefs.entries()) {
+    if (def.blankName === 'transform-blank') return def;
+  }
+  return undefined;
+}
+
+// WordDef.alternatives + currentIndex are readonly at the type level,
+// so simulating "user cycled to alt N" requires deleting + re-inserting
+// the def with the cycled state. Mirrors what applyAltCycle does at the
+// observable level (currentIndex bump + span recompute).
+function rewriteDef(dynDefs: DynDefs, def: WordDef, patch: Partial<WordDef>): void {
+  for (const [idx, d] of dynDefs.entries()) {
+    if (d === def) {
+      dynDefs.delete(idx);
+      dynDefs.set(idx, { ...def, ...patch } as WordDef);
+      return;
+    }
+  }
+}

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -987,13 +987,24 @@ export class Resolver {
       const target = wordSpans[r.wordIndex];
       if (!target) continue;
       const existing = this.dynDefs.get(r.wordIndex);
+      // Chainable LLM-blank substitutes (fluid-blank / transform-blank)
+      // are EXEMPT from the mid-cycle and blankName guards below — they
+      // explicitly extend an existing same-class chain at this position
+      // via findChainableLlmDef, instead of clobbering it. A blocked
+      // skip here would prevent the chain branch from ever running, so
+      // sequential "translate to japanese → translate to chinese" calls
+      // would silently no-op after the first.
+      const isChainableLlmSource = r.source === 'fluid-blank' || r.source === 'transform-blank';
+      const sameClassChainable = isChainableLlmSource
+        && !!existing?.blankName
+        && existing.blankName === r.source;
       // Don't clobber a user mid-cycle on this word.
-      if (existing && existing.currentIndex > 0) continue;
+      if (existing && existing.currentIndex > 0 && !sameClassChainable) continue;
       // Don't clobber blank-attributed entries (volume/brightness blank
       // fills, satellite cycles, etc.) — those route through their own
       // cycling path and have a script set/get protocol the LLM alts
       // would silently break.
-      if (existing && existing.blankName) continue;
+      if (existing && existing.blankName && !sameClassChainable) continue;
       // Already resolved — same word at the same index, fresh from a
       // prior LLM pass. Without this, every subsequent text-change
       // (typing the next word, adding a space) clobbers the existing
@@ -1086,17 +1097,54 @@ export class Resolver {
         const newWordIndex = newWord ? newWord.index : r.wordIndex;
         const newSpanEnd = newWord ? newWord.end : sub.newCursor;
 
-        const fluidDef: WordDef = {
-          originalWord: '_',
-          alternatives: ['_', ...alts],
-          currentIndex: 1,
-          spanStart: start,
-          spanEnd: newSpanEnd,
-          // blankName locks this def against re-resolution by the LLM —
-          // same mechanism blank-bound entries use to prevent the answer
-          // from being clobbered by RoutedWordSourceGroup synonyms.
-          blankName: 'fluid-blank',
-        };
+        // The "question" — the buffer slice we're replacing. For WIPE
+        // mode this is the user's full prompt phrase (e.g. "translate
+        // hello to japanese _"); for FILL mode it's just "_". Captured
+        // as alts[0] so cycling Down restores what the user typed before
+        // the LLM ran — they can edit the prompt and re-summon.
+        const question = text.slice(start, end);
+
+        // Chain extension: if a prior fluid-blank def sits inside the
+        // new span and is still verbatim at its recorded position, the
+        // user is doing a sequence of substitutions on the same content
+        // (translate to japanese → translate to chinese). Extend the
+        // existing alternatives with [question, answer] so Down walks
+        // back through the full chain. Truncate-on-branch: if the user
+        // cycled back mid-chain before re-summoning, discard the
+        // abandoned tail (alt-history equivalent of git branch).
+        const existingChain = this.dynDefs.findChainableLlmDef(
+          text, start, end, ['fluid-blank'],
+        );
+        let fluidDef: WordDef;
+        if (existingChain) {
+          const baseAlts = existingChain.def.alternatives
+            .slice(0, existingChain.def.currentIndex + 1);
+          const chainedAlts = [...baseAlts, question, alts[0]];
+          fluidDef = {
+            originalWord: existingChain.def.originalWord,
+            alternatives: chainedAlts,
+            currentIndex: chainedAlts.length - 1,
+            spanStart: start,
+            spanEnd: newSpanEnd,
+            blankName: 'fluid-blank',
+          };
+          if (existingChain.wordIndex !== newWordIndex) {
+            this.dynDefs.delete(existingChain.wordIndex);
+          }
+          this.adapter.log('info', `FluidBlank: extending chain (depth=${chainedAlts.length}, prevWordIdx=${existingChain.wordIndex}, newWordIdx=${newWordIndex})`);
+        } else {
+          fluidDef = {
+            originalWord: question,
+            alternatives: [question, alts[0]],
+            currentIndex: 1,
+            spanStart: start,
+            spanEnd: newSpanEnd,
+            // blankName locks this def against re-resolution by the LLM —
+            // same mechanism blank-bound entries use to prevent the answer
+            // from being clobbered by RoutedWordSourceGroup synonyms.
+            blankName: 'fluid-blank',
+          };
+        }
         this.dynDefs.set(newWordIndex, fluidDef);
         wrote++;
 
@@ -1510,18 +1558,51 @@ export class Resolver {
         const newWordIndex = firstSpliceWord ? firstSpliceWord.index : 0;
         const newSpanEnd = newWords.length > 0 ? newWords[newWords.length - 1].end : bufferText.length;
 
-        const transformDef: WordDef = {
-          originalWord: originalText,
-          // alternatives[0] = original full text (cycle Down to revert)
-          // alternatives[1] = the post-substitution buffer (cycle Up returns here)
-          alternatives: [originalText, bufferText],
-          currentIndex: 1,            // showing rewrite
-          spanStart: 0,
-          spanEnd: newSpanEnd,
-          // blankName locks this def from re-resolution by the LLM —
-          // same mechanism fluid-blank uses.
-          blankName: 'transform-blank',
-        };
+        // Chain extension: if a prior transform-blank def's current alt
+        // is still verbatim inside the pre-substitute buffer, the user
+        // is doing a sequence of rewrites on the same content
+        // (translate to japanese → translate to chinese). Extend the
+        // existing chain with [pre-substitute-buffer, post-substitute-
+        // buffer] so Down walks back through every rewrite waypoint
+        // AND the user's prompt-additions between them.
+        // Truncate-on-branch: if the user cycled mid-chain before
+        // re-summoning, discard the abandoned tail.
+        const existingChain = this.dynDefs.findChainableLlmDef(
+          originalText, 0, originalText.length, ['transform-blank'],
+        );
+        let transformDef: WordDef;
+        let extendedFromIdx: number | null = null;
+        if (existingChain) {
+          const baseAlts = existingChain.def.alternatives
+            .slice(0, existingChain.def.currentIndex + 1);
+          const chainedAlts = [...baseAlts, originalText, bufferText];
+          transformDef = {
+            originalWord: existingChain.def.originalWord,
+            alternatives: chainedAlts,
+            currentIndex: chainedAlts.length - 1,
+            spanStart: 0,
+            spanEnd: newSpanEnd,
+            blankName: 'transform-blank',
+          };
+          extendedFromIdx = existingChain.wordIndex;
+          if (existingChain.wordIndex !== newWordIndex) {
+            this.dynDefs.delete(existingChain.wordIndex);
+          }
+          this.adapter.log('info', `TransformBlank: extending chain (depth=${chainedAlts.length}, prevWordIdx=${existingChain.wordIndex}, newWordIdx=${newWordIndex})`);
+        } else {
+          transformDef = {
+            originalWord: originalText,
+            // alternatives[0] = original full text (cycle Down to revert)
+            // alternatives[1] = the post-substitution buffer (cycle Up returns here)
+            alternatives: [originalText, bufferText],
+            currentIndex: 1,            // showing rewrite
+            spanStart: 0,
+            spanEnd: newSpanEnd,
+            // blankName locks this def from re-resolution by the LLM —
+            // same mechanism fluid-blank uses.
+            blankName: 'transform-blank',
+          };
+        }
         // Prune stale defs the substitute invalidated.
         // (a) Sentence-cue defs were resolved against pre-substitute text;
         //     their spanStart/spanEnd indices now point at unrelated content
@@ -1533,6 +1614,7 @@ export class Resolver {
         let prunedCount = 0;
         for (const [idx, d] of this.dynDefs.entries()) {
           if (idx === newWordIndex) continue;            // keep the one we just set
+          if (extendedFromIdx !== null && idx === extendedFromIdx) continue; // skip the old chain key (already deleted above if differing)
           const isSentenceCue = d.blankName?.startsWith('sentence-cue:') ?? false;
           const outOfRange = d.spanEnd !== undefined && d.spanEnd > bufferText.length;
           if (isSentenceCue || outOfRange) {

--- a/packages/opencues-runtime/src/state/dyn-defs.ts
+++ b/packages/opencues-runtime/src/state/dyn-defs.ts
@@ -285,6 +285,49 @@ export class DynDefs {
    * Returns the FIRST edited span found, or null. One per text-change
    * event is enough; the next event re-scans.
    */
+  /**
+   * Find an existing LLM-blank def whose current alt is still verbatim in
+   * `liveText` at its recorded span, AND whose span is fully contained in
+   * the new substitute's `[newSpanStart, newSpanEnd)`. Used by the
+   * fluid-blank / transform-blank chain extension at substitute time so a
+   * sequence of LLM rewrites builds one walkable history instead of
+   * clobbering the prior result.
+   *
+   * Containment + verbatim is the structural fix that scopes "extend the
+   * chain" to "this new substitute fully encompasses an unchanged prior
+   * substitute". User edits inside the prior result break verbatim → fresh
+   * def, no chain. User edits outside the prior result preserve verbatim →
+   * chain extends with the new outer body as the pre-substitute question.
+   *
+   * `blankNames` lets the caller scope which class of chain to look for
+   * (e.g. only `['transform-blank']` so a fluid-blank doesn't graft onto a
+   * transform-blank chain — different pipelines, different intent).
+   *
+   * Returns the FIRST match. Sequential whole-buffer LLM substitutes
+   * structurally produce at most one matching def; FILL-mode FB at the
+   * same word position likewise. Ambiguity is not expected in practice.
+   */
+  findChainableLlmDef(
+    liveText: string,
+    newSpanStart: number,
+    newSpanEnd: number,
+    blankNames: readonly string[],
+  ): { wordIndex: number; def: WordDef } | null {
+    for (const [wordIndex, def] of this._defs.entries()) {
+      if (!def.blankName || !blankNames.includes(def.blankName)) continue;
+      // Existing def's span must be fully contained in the new substitute's range.
+      if (def.spanStart < newSpanStart) continue;
+      if (def.spanEnd > newSpanEnd) continue;
+      // Verbatim check — the current alt must still be at its recorded
+      // position. Any edit inside the prior result breaks the chain.
+      const currentAlt = def.alternatives[def.currentIndex];
+      if (currentAlt === undefined) continue;
+      if (liveText.slice(def.spanStart, def.spanEnd) !== currentAlt) continue;
+      return { wordIndex, def };
+    }
+    return null;
+  }
+
   findEditedSpan(
     currentText: string,
     filter?: (def: WordDef) => boolean,


### PR DESCRIPTION
## Summary

Sequential fluid-blank and transform-blank substitutes on the same content (translate to japanese → translate to chinese → translate to korean) now build a walkable history chain instead of clobbering each prior result. Cycling Down walks back through every waypoint **and** the user's prompt fragments between them.

**The user journey this unlocks:**

1. Type `translate hello to japanese _` → 'こんにちは'
2. Append ` translate to chinese _` → '你好'
3. Down → `こんにちは translate to chinese _` (the question)
4. Down → `こんにちは` (the prior result)
5. Down → `translate hello to japanese _` (the original question)

Before: step 2 silently discarded the japanese waypoint. Down only reached '_'.

## Mechanism

`DynDefs.findChainableLlmDef` detects when a new substitute's span fully contains an existing same-class def whose current alt is still verbatim at its recorded position. The resolver appends `[pre-substitute buffer, new result]` to the existing alternatives instead of replacing.

The resolver's mid-cycle / blankName skip guards (`resolver.ts:991-996`) gain a narrow exemption for same-class chainable sources so the chain branch gets to run. Non-LLM blank entries (volume / brightness / satellite) still lock as before.

## Invalidation rules (pinned in scenario tests)

- **Edit inside the prior result** → verbatim check fails → fresh def, no chain. User's edit is their explicit choice; we don't retain stale history that no longer matches reality.
- **Cycled mid-chain before re-summoning** → abandoned tail is truncated (alt-history equivalent of `git branch`).
- **Different pipelines don't graft** — a fluid-blank substitute after a transform-blank substitute creates an independent def. Cross-pipeline merging would conflate different intents.

## Side-effect fix

Pre-existing UX gap fixed in the same edit: fluid-blank WIPE defs previously stored `alternatives[0] = '_'`, so Down arrow wiped the user's whole prompt back to a bare underscore. Now `alternatives[0] = preSubstituteText` so Down restores the question — the user can edit the prompt and re-summon.

## Test plan

- [x] 6 new scenario tests in `blank-chain.scenarios.test.ts` covering: question capture, fluid chain extension, edit-invalidation, truncate-on-branch, transform chain extension, cross-pipeline isolation
- [x] Full runtime suite passes (1392 tests)
- [x] Manual: type `translate hello to japanese _`, wait for substitute, type ` translate to chinese _`, wait, press Down × 4 — buffer should walk back through chinese → mid-question → japanese → original
- [x] Manual: same but edit the japanese before triggering chinese — chain should reset, no japanese in revert history

## Upgrade path (for testers)

1. `pnpm --filter @opencues/runtime build` (done in this PR's CI)
2. For chrome users: rebuild + push the extension's `dist/` bundle
3. For CC users on `claude-cues` AND `claude-cues-150`: re-run `integrations/claude-code/patches/setup.sh` for **each** fork (per the rebuild-every-fork rule — source-only fixes don't deploy until each bundled runtime is rebuilt)
4. No config changes required — the chain behaviour is automatic, no scalar to flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)