### PR TITLE
chore(versions): bump runtime → 0.1.1 + cli → 0.1.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,12 +564,12 @@ done
 | `SPEC.md` (open-standard) | `cues-spec` | 0.1 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
 | `packages/opencues-core/` | `@opencues/core` | 0.1.0 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.1.0 | private |
-| `packages/opencues-cli/` | `opencues` (real CLI) | 0.1.1 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.1.1 | private |
+| `packages/opencues-cli/` | `opencues` (real CLI) | 0.1.2 | private |
 | `packages/opencues-park/` | `opencues` (placeholder) | 0.0.1 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.1.1 | private |
 | `integrations/opencode/` | `@opencues/opencode` | 0.1.0 | private |
-| `integrations/chrome/` | `@opencues/chrome` | 0.1.0 | private |
+| `integrations/chrome/` | `@opencues/chrome` | 0.1.1 | private |
 | `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.1.0 | private |
 | `integrations/shell/` | `@opencues/shell` | 0.1.0 | private |
 

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Summary

Two missed bumps from recent merges, caught reviewing the package version map snapshot in `CLAUDE.md`.

- **`@opencues/runtime` 0.1.0 → 0.1.1.** PR #17 (`4eab36f`) added the public export `DynDefs.findChainableLlmDef` and changed the `WordDef` chain semantics surfaced through `Resolver.resolveAndApply`. Per `docs/architecture/versioning.md`: bump runtime on public-export / state-class-shape change.
- **`opencues` CLI 0.1.1 → 0.1.2.** Commit `3ae37ac` (Option-B self-heal) added HEAL phase 3.5 to `seed-configs.cjs`. Per the same doc: bump CLI on `seed-configs` behaviour change.

Integrations stay put — PR #17 didn't touch any integration code (per policy: integrations bump only when their own code changes, not because runtime bumped). `@opencues/chrome` 0.1.1 from the Option-B PR is still correct.

Also refreshes the `CLAUDE.md` "Package version map" snapshot table (chrome row was stale at 0.1.0 even before this PR).

## Test plan

- [x] `git diff` reviewed — only three files: two package.json bumps + CLAUDE.md table.
- [x] CI smoke (build + test + typecheck across the workspace) — should be a no-op since the bumps don't change any source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)