### PR TITLE
fix(update): detect stale bundle, transparently rebuild + bold install hint

### DIFF
--- a/integrations/claude-code/bin/install.cjs
+++ b/integrations/claude-code/bin/install.cjs
@@ -171,7 +171,11 @@ function doInstall() {
     const validation = validateFork(fork);
     if (validation.ok) {
       console.log(`${'\x1b[32m✓\x1b[0m'} ${fork.root} is already installed + healthy. No work needed.`);
-      console.log(`  ${'\x1b[2m'}Pass --rebuild to force a nuke-and-reinstall from scratch.${'\x1b[0m'}`);
+      // Bold the hint — users (and prior versions of us) repeatedly
+      // miss --rebuild's role and assume "healthy" means "current
+      // runtime bundle." It doesn't; bundle drift is invisible to
+      // this short-circuit. Make the actionable flag stand out.
+      console.log(`  ${'\x1b[2m'}Pass${'\x1b[0m'} ${'\x1b[1m--rebuild\x1b[0m'} ${'\x1b[2m'}to force a nuke-and-reinstall from scratch.${'\x1b[0m'}`);
       return;
     }
     console.log(`${'\x1b[33m▸\x1b[0m'} install state needs repair: ${validation.reason}`);

--- a/packages/opencues-cli/src/commands/update.cjs
+++ b/packages/opencues-cli/src/commands/update.cjs
@@ -84,11 +84,28 @@ module.exports = async function update(argv, ctx) {
     const installedPin = compatLib.readNpmPin(HOME, compat) ||
                          (compat['host-kind'] === 'git' ? compatLib.readGitPin(ctx.REPO_ROOT, compat)?.version : null);
     if (installedPin === targetVersion) {
+      // Host's own version matches — but bundled @opencues/{core,runtime}
+      // may be stale (May 2026 dual-fork bug class). When source has
+      // moved on since the install, transparently re-route to the
+      // rebuild path. Skipping this check is exactly what made the
+      // dual-fork bug silent — source had the fix, bundle didn't, and
+      // `opencues update cc` kept reporting "nothing to do".
+      const { checkDrift } = require('../lib/version-markers.cjs');
+      const installRoot = resolveInstallRoot(host, ctx);
+      const drift = installRoot ? checkDrift(installRoot, ctx) : { status: 'missing' };
+      const bundleStale = drift.status === 'stale';
       console.log(banner({ version: cliVersion(ctx), tagline: `update ${host}` }));
       console.log('');
-      console.log(`${tag('ok')} ${host} already at current-pin ${bold(targetVersion)} — nothing to do.`);
-      console.log(`  ${dim('To force a rebuild without changing version: opencues install ' + host + ' --rebuild')}`);
-      return 0;
+      if (!bundleStale) {
+        console.log(`${tag('ok')} ${host} already at current-pin ${bold(targetVersion)} — nothing to do.`);
+        console.log(`  ${dim('To force a rebuild without changing version:')} ${bold('opencues install ' + host + ' --rebuild')}`);
+        return 0;
+      }
+      // Bundle drift detected — explain, then hand off to the rebuild
+      // path. Same shape as doctor's "stale bundled runtime" finding.
+      console.log(`${tag('warn')} ${host} pinned at ${bold(targetVersion)} but bundled runtime ${bold(drift.marker.runtime)} is stale vs source ${bold(drift.source.runtime || '?')} — rebuilding.`);
+      console.log('');
+      return rebuildHostInPlace(host, ctx);
     }
     if (!installedPin) {
       console.error(`opencues update: ${host} is not installed. Run \`opencues install ${host}\` first.`);
@@ -453,6 +470,36 @@ async function doUpgradeGit(host, toVersion, compat, { dryRun }, ctx) {
   if (!compatLib.isTested(wantNorm, compat)) {
     console.log(dim(`Consider adding {version:"${wantNorm}",sha:"${wantedTag.sha}"} to integrations/${host}/compat.json's "tested" list once you've verified.`));
   }
+}
+
+/**
+ * Map host name → directory where the version marker lives. Mirrors
+ * `enumerateInstalledHosts` in version-markers.cjs so the drift check
+ * looks at the same path the installer writes to. Update when a new
+ * host integration is added.
+ */
+function resolveInstallRoot(host, ctx) {
+  const HOME = os.homedir();
+  switch (host) {
+    case 'claude-code': return path.join(HOME, 'claude-code-cues', '.cues');
+    case 'opencode':    return path.join(HOME, 'opencode-cues', '.opencues');
+    case 'gemini-cli':  return path.join(HOME, 'gemini-cli-cues', '.opencues');
+    case 'shell':       return path.join(ctx.REPO_ROOT, 'integrations/shell/node_modules/@opencues');
+    case 'chrome':      return path.join(ctx.REPO_ROOT, 'integrations/chrome/dist');
+    default: return null;
+  }
+}
+
+/**
+ * Drift-driven rebuild — used when the host's own version is at
+ * current-pin but the bundled @opencues/{core,runtime} is stale. Same
+ * underlying machinery as `runHostInstaller` (re-runs the host's
+ * installer with --rebuild) but no rollback path because the host's
+ * version isn't changing.
+ */
+function rebuildHostInPlace(host, ctx) {
+  runHostInstaller(host, ctx, { rollback: null });
+  return 0;
 }
 
 function runHostInstaller(host, ctx, { rollback }) {


### PR DESCRIPTION
## Summary

- `opencues update <host>` now detects bundle drift even when the host's own pinned version is at current-pin. When the bundled `@opencues/{core,runtime}` is older than source, it transparently rebuilds instead of short-circuiting as \"nothing to do.\"
- Bold the \`--rebuild\` flag in install's \"already healthy\" hint — the flag is the actionable bit and was lost in the dim line.

## Why this matters

Surfaced today when the LLM-routing PR bumped the runtime to 0.1.2. Doctor flagged claude-code / opencode / chrome as having stale bundles, but \`opencues update cc\` reported:

\`\`\`
🗸 claude-code already at current-pin 2.1.150 — nothing to do.
  To force a rebuild without changing version: opencues install claude-code --rebuild
\`\`\`

The update path's pin check is necessary but not sufficient. The host's own version (2.1.150) is at pin — the bundled runtime (0.1.0) is not. Same shape as the May 2026 dual-fork bug: source has the fix, one bundle doesn't, behaviour diverges per host in a way no test can catch.

## What changed

**update.cjs** — when \`installedPin === targetVersion\`, also run \`checkDrift(installRoot, ctx)\`. Fresh → unchanged \"nothing to do\" output. Stale → log the drift versions, then route to the same installer-with-rebuild path \`doUpgrade\` uses (minus the rollback hook, since host version isn't moving).

Two new internal helpers in update.cjs:
- \`resolveInstallRoot(host, ctx)\` — mirrors \`enumerateInstalledHosts\` in version-markers.cjs, returns the marker directory per host.
- \`rebuildHostInPlace(host, ctx)\` — thin wrapper around \`runHostInstaller\` with no rollback (host version unchanged).

**install.cjs** (CC integration) — bolded the \`--rebuild\` flag in the \"already installed + healthy\" hint via per-token ANSI styling (dim text + bold flag) instead of a single dim line.

## Test plan
- [x] \`opencues update cc\` short-circuits cleanly when bundle is fresh (manually verified after running rebuilds).
- [x] CLI is JS, no build needed; commands run end-to-end.
- [ ] Next time a runtime/core version bumps: drift triggers automatically and rebuilds the right install root without manual \`--rebuild\` invocation. (Tested implicitly via the next runtime bump.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)