### PR TITLE
feat(fluid-config): natural-language provider/model switching via _

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,7 +564,7 @@ done
 |---|---|---|---|
 | `SPEC.md` (open-standard) | `cues-spec` | 0.1 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
-| `packages/opencues-core/` | `@opencues/core` | 0.1.1 | private |
+| `packages/opencues-core/` | `@opencues/core` | 0.1.2 | private |
 | `packages/opencues-runtime/` | `@opencues/runtime` | 0.1.2 | private |
 | `packages/opencues-cli/` | `opencues` (real CLI) | 0.1.3 | private |
 | `packages/opencues-park/` | `opencues` (placeholder) | 0.0.1 | **PUBLISHED on npm** |

--- a/docs/architecture/llm-routing.md
+++ b/docs/architecture/llm-routing.md
@@ -90,6 +90,57 @@ plural (`blanks-llm-*`).
 After everyone has run `opencues install` once post-three-bucket, the
 back-compat fallback will be removed in the next release.
 
+## Natural-language switching via fluid-config
+
+When `fluid-config-mode: on`, the classifier at priority 94 catches
+`_`-trailed sentences and routes them to one of three intents: a
+**setting** change, a **provider** change, or **NONE**. The
+provider-change intent is the bucket-aware natural-language path:
+
+```
+use anthropic for cues _              → cues-llm-provider: anthropic
+switch the blanks brain to cerebras _ → blanks-llm-provider: cerebras
+use claude opus for auditors _        → auditors-llm-provider: anthropic
+                                        auditors-llm-model: claude-opus-4-7
+route everything to gemini _          → cues-llm-provider: gemini   (cues = default brain)
+```
+
+### What the classifier may emit
+
+The model is bounded by two registries:
+
+- **Bucket scope** ∈ `{cues, auditors, blanks}` — hard-coded list.
+- **Provider id** ∈ entries of `PROVIDERS` in
+  `packages/opencues-core/src/llm-provider.ts` (the `ProviderId` union).
+- **Model id** ∈ each provider's optional `knownModels: readonly string[]`
+  list. Models outside that list are rejected at runtime even if the
+  classifier emits them — power users can still pin them by editing
+  OPENCUES.md directly.
+
+The trust-class guard from the resolver mirrors here: the classifier
+verdict for the cues or auditors bucket cannot route to a provider
+whose `trainsOnInput: true` (today: `opencode-zen`). Only the blanks
+bucket may pick that provider.
+
+### Adding a new model to the classifier's choice space
+
+Append the model id to the provider adapter's `knownModels` array in
+`packages/opencues-core/src/llm-provider.ts`. The classifier prompt
+renders the lists at module-load, so no prompt edit is required. Aim
+for 3–5 entries per provider — bench-validated picks that cover the
+common cheap-fast / balanced / deep-reasoning tiers.
+
+### Cycling after a switch
+
+The fluid-config result is a selector-satellite pair: the selector is
+the bucket scalar (e.g. `cues-llm-provider`) — itself a FEATURES
+registry entry — and the satellite is the provider id. After a switch
+the user can cycle the satellite through the menu values for that
+bucket scalar (the registry's `values` list, e.g. `inherit, cerebras,
+groq, gemini, anthropic, openai`). Picking a different provider via
+cycling overwrites the provider scalar only — the model scalar (if
+previously set) stays put.
+
 ## Diagnostics
 
 `opencues doctor` shows the **LLM routing** section with the effective

--- a/docs/guides/llm-providers.md
+++ b/docs/guides/llm-providers.md
@@ -332,6 +332,16 @@ const TOGETHER: ProviderAdapter = {
   id: 'together',
   defaultEndpoint: 'https://api.together.xyz/v1/chat/completions',
   defaultModel: 'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+  // 2-5 bench-validated entries covering cheap-fast / balanced /
+  // deep-reasoning tiers. The fluid-config classifier renders this
+  // list verbatim and only routes natural-language model picks within
+  // it. Power users can still pin any model string by hand-editing
+  // OPENCUES.md — knownModels bounds NL-reachable picks only.
+  knownModels: [
+    'meta-llama/Llama-3.3-70B-Instruct-Turbo',
+    'meta-llama/Llama-3.3-405B-Instruct-Turbo',
+    'Qwen/Qwen2.5-72B-Instruct',
+  ],
   envKeyName: 'TOGETHER_API_KEY',
   buildRequest(req, ctx) {
     return {
@@ -347,6 +357,36 @@ const TOGETHER: ProviderAdapter = {
 Add to the `PROVIDERS` map and the `ProviderId` union, write a
 unit test in `llm-provider.test.ts`, update the manifest if Chrome
 support is desired. Existing call sites need no changes.
+
+### `knownModels` — what the fluid-config classifier may emit
+
+`knownModels` is optional but recommended. It bounds the model
+catalogue the fluid-config classifier (`fluid-config-mode: on`) may
+route to via natural language ("use cerebras gpt-oss-120b for cues
+_"). Three rules:
+
+1. **Curated, not exhaustive.** 2-5 canonical ids per provider —
+   typically one cheap-fast, one balanced, one deep-reasoning.
+   Listing every model the provider hosts bloats the classifier
+   prompt and gives the LLM more rope to hallucinate look-alikes.
+2. **First entry should match `defaultModel`.** Reads better in
+   error messages ("allowed: gpt-5.4-mini, gpt-5.4, gpt-5.4-nano")
+   and means picking the provider via NL without a model name lands
+   on the same default the resolver would pick.
+3. **Bench-validated.** Each entry should at minimum survive the
+   fluid-blank and transform-blank benches at this provider, or be
+   documented as a known cost/quality trade-off in the adapter
+   comments.
+
+Adding a model to `knownModels` automatically extends what
+`use <provider> <model> for <bucket> _` can reach — no prompt edit
+needed. Removing one prevents the classifier from emitting it, but
+file-edit pins still work (`<bucket>-llm-model: <whatever>` accepts
+any string).
+
+When `knownModels` is omitted entirely, the validator falls back to
+`[defaultModel]` — the classifier may still pick the provider but
+can only land on its default model.
 
 For non-OpenAI-compat providers (different request/response shape),
 follow the **Gemini** or **Anthropic** patterns — both write their

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/llm-provider.ts
+++ b/packages/opencues-core/src/llm-provider.ts
@@ -129,6 +129,22 @@ export interface ProviderAdapter {
   readonly defaultEndpoint: string;
   /** Default model when the user hasn't picked one. */
   readonly defaultModel: string;
+  /**
+   * Curated list of model ids the fluid-config classifier may route to
+   * for this provider via natural-language `_` ("use cerebras
+   * gpt-oss-120b for cues _"). First entry conventionally matches
+   * `defaultModel`. Power users can still set ANY model string in
+   * OPENCUES.md by hand — this list bounds only what the classifier is
+   * allowed to emit. Each entry should be bench-validated against the
+   * OpenCues pipelines (fluid-blank, transform-blank, agent-rewrite,
+   * cues) for that provider.
+   *
+   * Optional — when omitted, the classifier defaults to picking the
+   * provider's `defaultModel` only (no model selection via NL). Adding
+   * a few entries opens up natural-language model picking without
+   * exposing the full provider catalogue to LLM hallucination.
+   */
+  readonly knownModels?: readonly string[];
   /** The env-var name the boot layer reads to find this provider's API key. */
   readonly envKeyName: string;
   /**
@@ -312,6 +328,16 @@ const GROQ: ProviderAdapter = {
   displayName: 'Groq',
   defaultEndpoint: 'https://api.groq.com/openai/v1/chat/completions',
   defaultModel: 'openai/gpt-oss-120b',
+  // Groq's open-weight gpt-oss tier (verified May 2026). The 20b is
+  // the cheap-fast option; the 120b is the default; llama-3.3-70b is
+  // a non-reasoning alternative for users who want a different model
+  // family. Other Groq models (mixtral, llama-3.1, kimi) work via
+  // direct file edit but aren't surfaced to the fluid-config classifier.
+  knownModels: [
+    'openai/gpt-oss-120b',
+    'openai/gpt-oss-20b',
+    'llama-3.3-70b-versatile',
+  ],
   envKeyName: 'GROQ_API_KEY',
   // gpt-oss-120b at `medium`+`high` overshoots OpenCues' fluid-blank
   // (1500ms) and word-cue (500ms) budgets at Groq's throughput; `low`
@@ -339,6 +365,18 @@ const OPENROUTER: ProviderAdapter = {
   // tier — gives users a free fallback when their primary provider is
   // rate-limited or down. Users override per-feature for paid models.
   defaultModel: 'openai/gpt-oss-120b:free',
+  // OpenRouter is a multi-model router; the curated set here is the
+  // popular cross-provider picks OpenCues bench-validates against.
+  // Users routing to esoteric models (`x-ai/grok-2`, `mistralai/...`)
+  // can still set them via direct file edit; the classifier just
+  // can't reach them.
+  knownModels: [
+    'openai/gpt-oss-120b:free',
+    'openai/gpt-oss-120b',
+    'anthropic/claude-haiku-4-5',
+    'anthropic/claude-opus-4-7',
+    'google/gemini-3.1-flash-lite',
+  ],
   envKeyName: 'OPENROUTER_API_KEY',
   // OpenRouter is a multi-model router — `low` is the cross-model safe
   // default that mirrors what every call site used to hardcode. Picks
@@ -375,6 +413,16 @@ const OPENAI: ProviderAdapter = {
   // actually complete the task on long inputs. Users who want the cheaper
   // tier can override per-feature with `openai-model: gpt-5.4-nano`.
   defaultModel: 'gpt-5.4-mini',
+  // gpt-5.4 tier (released March 2026). nano is the cheapest but
+  // collapses on multi-paragraph rewrites (reasoning-token starvation);
+  // mini is the default; 5.4 proper is the deeper-reasoning option for
+  // agent/auditors. Legacy gpt-4o-* family kept reachable via file edit
+  // for users who explicitly need it.
+  knownModels: [
+    'gpt-5.4-mini',
+    'gpt-5.4',
+    'gpt-5.4-nano',
+  ],
   envKeyName: 'OPENAI_API_KEY',
   // `low` (not `none`) — bench showed `none` is fastest on fluid-blank,
   // but it drops transform-blank-fused 85.3%→28.1% on gpt-5.4-mini
@@ -463,6 +511,15 @@ const OPENAI_SUBSCRIPTION: ProviderAdapter = {
   transport: 'cli',
   defaultEndpoint: '', // unused for CLI transport
   defaultModel: 'gpt-5.4-mini',
+  // Subscription model allow-list (May 2026, verified by probing the
+  // Responses endpoint directly). Every other name returns 400 "not
+  // supported when using Codex with a ChatGPT account."
+  knownModels: [
+    'gpt-5.4-mini',
+    'gpt-5.4',
+    'gpt-5.5',
+    'gpt-5.3-codex',
+  ],
   envKeyName: '', // no env var — auth via `codex login`
   buildRequest() {
     throw new Error('openai-subscription: buildRequest is not used (transport is cli)');
@@ -509,6 +566,15 @@ const GEMINI: ProviderAdapter = {
   // Override per-feature with `<feature>-model:` if you want the
   // 3.1-pro tier for accuracy-critical surfaces.
   defaultModel: 'gemini-3.1-flash-lite',
+  // Gemini 3.1 tier (verified May 2026). flash-lite is the default
+  // (fastest + cheapest); flash adds vision/audio + better reasoning;
+  // pro is the frontier model for deeper writing tasks. Older 2.0
+  // family stays reachable via direct file edit.
+  knownModels: [
+    'gemini-3.1-flash-lite',
+    'gemini-3.1-flash',
+    'gemini-3.1-pro',
+  ],
   envKeyName: 'GEMINI_API_KEY',
   buildRequest(req, ctx) {
     const endpointTemplate = ctx.endpoint ?? this.defaultEndpoint;
@@ -585,6 +651,15 @@ const ANTHROPIC: ProviderAdapter = {
   // override per-feature for Sonnet 4.6 (better writing) or Opus 4.7
   // (deeper reasoning) on prose-heavy surfaces like agent-rewrite.
   defaultModel: 'claude-haiku-4-5-20251001',
+  // Claude 4 tier (May 2026). Haiku 4.5 is the cheap-fast default;
+  // Sonnet 4.6 is the balanced default for prose-heavy auditors;
+  // Opus 4.7 is the deepest-reasoning frontier model. Older 3.x
+  // family stays reachable via direct file edit.
+  knownModels: [
+    'claude-haiku-4-5-20251001',
+    'claude-sonnet-4-6',
+    'claude-opus-4-7',
+  ],
   envKeyName: 'ANTHROPIC_API_KEY',
   buildRequest(req, ctx) {
     const systemMessages = req.messages.filter((m) => m.role === 'system');
@@ -660,6 +735,15 @@ const CEREBRAS: ProviderAdapter = {
   displayName: 'Cerebras',
   defaultEndpoint: 'https://api.cerebras.ai/v1/chat/completions',
   defaultModel: 'gpt-oss-120b',
+  // Cerebras catalogue (May 2026): `gpt-oss-120b`, `qwen-3-235b...`,
+  // `zai-glm-4.7`. `gpt-oss-120b` + `zai-glm-4.7` are paid-only; free
+  // tier collapses to `qwen-3-235b-a22b-instruct-2507` (universally
+  // available 235B MoE). Other Cerebras names reachable via file edit.
+  knownModels: [
+    'gpt-oss-120b',
+    'qwen-3-235b-a22b-instruct-2507',
+    'zai-glm-4.7',
+  ],
   envKeyName: 'CEREBRAS_API_KEY',
   // Cerebras's wafer-scale silicon serves gpt-oss-120b fast enough that
   // `medium` fits every OpenCues pipeline (358ms p50 fluid-blank,
@@ -711,6 +795,14 @@ const CLAUDE_CLI: ProviderAdapter = {
   transport: 'cli',
   defaultEndpoint: '', // unused for CLI transport
   defaultModel: 'haiku', // fastest / cheapest of the supported aliases
+  // Aliases the daemon resolves to families. Full Claude model ids
+  // (`claude-haiku-4-5-20251001`, etc.) also work via direct file
+  // edit; the daemon's resolveModelFamily maps both shapes.
+  knownModels: [
+    'haiku',
+    'sonnet',
+    'opus',
+  ],
   envKeyName: '', // no env var — auth via `claude` install
   buildRequest() {
     // Never called for transport: 'cli'. Throw if it somehow IS called
@@ -774,6 +866,14 @@ const OPENCODE_ZEN: ProviderAdapter = {
   // First entry of the free pool. Used when no model is explicitly set
   // (most common case for `blanks-llm-provider: opencode-zen`).
   defaultModel: 'big-pickle',
+  // OpenCode Zen exposes both paid + free models. `free` is the
+  // sentinel routing to the dispatchWithFreePool path (walks
+  // OPENCODE_ZEN_FREE_POOL). `big-pickle` is the first free-pool
+  // model directly. Paid model ids reachable via direct file edit.
+  knownModels: [
+    'free',
+    'big-pickle',
+  ],
   // Optional. Free models work without it; paid models need it.
   envKeyName: 'OPENCODE_ZEN_API_KEY',
   optionalAuth: true,

--- a/packages/opencues-core/src/sources/config-intent-source.test.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.test.ts
@@ -37,21 +37,34 @@ function ctxFromText(text: string): CueContext {
 // ---------------------------------------------------------------------------
 
 describe('parseConfigIntentOutput', () => {
-  it('parses a clean hit (all three lines)', () => {
+  it('parses a clean setting hit (legacy 3-line shape, no INTENT)', () => {
     const v = parseConfigIntentOutput(
       'SETTING: debug-mode\nVALUE: on\nCONFIDENCE: 0.97',
     );
-    assert.strictEqual(v.setting, 'debug-mode');
-    assert.strictEqual(v.value, 'on');
-    assert.strictEqual(v.confidence, 0.97);
+    assert.strictEqual(v.kind, 'setting');
+    if (v.kind === 'setting') {
+      assert.strictEqual(v.setting, 'debug-mode');
+      assert.strictEqual(v.value, 'on');
+      assert.strictEqual(v.confidence, 0.97);
+    }
+  });
+
+  it('parses a clean setting hit (new INTENT-prefixed shape)', () => {
+    const v = parseConfigIntentOutput(
+      'INTENT: SETTING\nSETTING: debug-mode\nVALUE: on\nSCOPE:\nPROVIDER:\nMODEL:\nCONFIDENCE: 0.97',
+    );
+    assert.strictEqual(v.kind, 'setting');
+    if (v.kind === 'setting') {
+      assert.strictEqual(v.setting, 'debug-mode');
+      assert.strictEqual(v.value, 'on');
+    }
   });
 
   it('parses NONE (no value, no confidence-driven action)', () => {
     const v = parseConfigIntentOutput(
       'SETTING: NONE\nVALUE:\nCONFIDENCE: 0.99',
     );
-    assert.strictEqual(v.setting, null);
-    assert.strictEqual(v.value, null);
+    assert.strictEqual(v.kind, 'none');
     assert.strictEqual(v.confidence, 0.99);
   });
 
@@ -59,19 +72,21 @@ describe('parseConfigIntentOutput', () => {
     const v = parseConfigIntentOutput(
       'SETTING: none\nVALUE:\nCONFIDENCE: 0.9',
     );
-    assert.strictEqual(v.setting, null);
+    assert.strictEqual(v.kind, 'none');
   });
 
   it('treats empty SETTING as NONE', () => {
     const v = parseConfigIntentOutput('SETTING:\nVALUE:\nCONFIDENCE: 0.9');
-    assert.strictEqual(v.setting, null);
-    assert.strictEqual(v.value, null);
+    assert.strictEqual(v.kind, 'none');
   });
 
-  it('returns value=null when hit lacks a VALUE line', () => {
+  it('collapses to NONE when SETTING is present but VALUE is missing (no half-applied)', () => {
+    // Old behavior returned setting:'voice-mode', value:null. New
+    // behavior: a setting verdict without a value is unactionable, so
+    // collapse to NONE — caller cedes cleanly rather than carrying a
+    // half-formed verdict.
     const v = parseConfigIntentOutput('SETTING: voice-mode\nCONFIDENCE: 0.9');
-    assert.strictEqual(v.setting, 'voice-mode');
-    assert.strictEqual(v.value, null);
+    assert.strictEqual(v.kind, 'none');
   });
 
   it('returns confidence=null when CONFIDENCE line missing', () => {
@@ -83,14 +98,71 @@ describe('parseConfigIntentOutput', () => {
     const v = parseConfigIntentOutput(
       'SETTING: debug-mode  \nVALUE: on \nCONFIDENCE: 0.95',
     );
-    assert.strictEqual(v.setting, 'debug-mode');
-    assert.strictEqual(v.value, 'on');
+    assert.strictEqual(v.kind, 'setting');
+    if (v.kind === 'setting') {
+      assert.strictEqual(v.setting, 'debug-mode');
+      assert.strictEqual(v.value, 'on');
+    }
   });
 
-  it('returns null setting + null value when output is garbage', () => {
+  it('returns NONE when output is garbage', () => {
     const v = parseConfigIntentOutput('whatever the model said');
-    assert.strictEqual(v.setting, null);
-    assert.strictEqual(v.value, null);
+    assert.strictEqual(v.kind, 'none');
+  });
+
+  // ── Provider verdict parsing ──────────────────────────────────────
+
+  it('parses a provider verdict with explicit INTENT', () => {
+    const v = parseConfigIntentOutput(
+      'INTENT: PROVIDER\nSETTING:\nVALUE:\nSCOPE: cues\nPROVIDER: anthropic\nMODEL:\nCONFIDENCE: 0.92',
+    );
+    assert.strictEqual(v.kind, 'provider');
+    if (v.kind === 'provider') {
+      assert.strictEqual(v.scope, 'cues');
+      assert.strictEqual(v.provider, 'anthropic');
+      assert.strictEqual(v.model, null);
+      assert.strictEqual(v.confidence, 0.92);
+    }
+  });
+
+  it('parses a provider verdict with model named', () => {
+    const v = parseConfigIntentOutput(
+      'INTENT: PROVIDER\nSCOPE: auditors\nPROVIDER: openai\nMODEL: gpt-5.4\nCONFIDENCE: 0.9',
+    );
+    assert.strictEqual(v.kind, 'provider');
+    if (v.kind === 'provider') {
+      assert.strictEqual(v.scope, 'auditors');
+      assert.strictEqual(v.provider, 'openai');
+      assert.strictEqual(v.model, 'gpt-5.4');
+    }
+  });
+
+  it('infers provider kind from populated slots when INTENT line missing (back-compat)', () => {
+    const v = parseConfigIntentOutput(
+      'SCOPE: blanks\nPROVIDER: cerebras\nMODEL:\nCONFIDENCE: 0.85',
+    );
+    assert.strictEqual(v.kind, 'provider');
+    if (v.kind === 'provider') {
+      assert.strictEqual(v.scope, 'blanks');
+      assert.strictEqual(v.provider, 'cerebras');
+    }
+  });
+
+  it('defaults SCOPE to cues when classifier omitted it but provider is present', () => {
+    const v = parseConfigIntentOutput(
+      'INTENT: PROVIDER\nSCOPE:\nPROVIDER: gemini\nMODEL:\nCONFIDENCE: 0.7',
+    );
+    assert.strictEqual(v.kind, 'provider');
+    if (v.kind === 'provider') {
+      assert.strictEqual(v.scope, 'cues');
+    }
+  });
+
+  it('collapses PROVIDER with empty provider id to NONE', () => {
+    const v = parseConfigIntentOutput(
+      'INTENT: PROVIDER\nSCOPE: cues\nPROVIDER:\nMODEL:\nCONFIDENCE: 0.5',
+    );
+    assert.strictEqual(v.kind, 'none');
   });
 });
 
@@ -100,29 +172,23 @@ describe('parseConfigIntentOutput', () => {
 
 describe('validateAgainstRegistry', () => {
   it('passes NONE verdict (nothing to validate)', () => {
-    const r = validateAgainstRegistry({ setting: null, value: null, confidence: 0.9 });
+    const r = validateAgainstRegistry({ kind: 'none', confidence: 0.9 });
     assert.strictEqual(r.ok, true);
   });
 
-  it('passes a real (setting, value) pair', () => {
-    const r = validateAgainstRegistry({ setting: 'debug-mode', value: 'on', confidence: 0.9 });
+  it('passes a real setting (setting, value) pair', () => {
+    const r = validateAgainstRegistry({ kind: 'setting', setting: 'debug-mode', value: 'on', confidence: 0.9 });
     assert.strictEqual(r.ok, true);
   });
 
   it('rejects an unknown setting (hallucinated scalar)', () => {
-    const r = validateAgainstRegistry({ setting: 'definitely-not-a-thing', value: 'on', confidence: 0.9 });
+    const r = validateAgainstRegistry({ kind: 'setting', setting: 'definitely-not-a-thing', value: 'on', confidence: 0.9 });
     assert.strictEqual(r.ok, false);
     assert.match(r.reason ?? '', /unknown setting/);
   });
 
-  it('rejects a known setting with no value', () => {
-    const r = validateAgainstRegistry({ setting: 'debug-mode', value: null, confidence: 0.9 });
-    assert.strictEqual(r.ok, false);
-    assert.match(r.reason ?? '', /no value/);
-  });
-
   it('rejects a value not listed under the setting', () => {
-    const r = validateAgainstRegistry({ setting: 'debug-mode', value: 'maybe', confidence: 0.9 });
+    const r = validateAgainstRegistry({ kind: 'setting', setting: 'debug-mode', value: 'maybe', confidence: 0.9 });
     assert.strictEqual(r.ok, false);
     assert.match(r.reason ?? '', /not cyclable/);
   });
@@ -131,13 +197,67 @@ describe('validateAgainstRegistry', () => {
     // The classifier system prompt excludes hidden values, but defence
     // in depth: if a model emits it anyway, the runtime must NOT apply
     // a footgun mode on semantic-only intent.
-    const r = validateAgainstRegistry({ setting: 'user-context-mode', value: 'raw', confidence: 0.9 });
+    const r = validateAgainstRegistry({ kind: 'setting', setting: 'user-context-mode', value: 'raw', confidence: 0.9 });
     assert.strictEqual(r.ok, false);
     assert.match(r.reason ?? '', /not cyclable/);
   });
 
   it('accepts user-context-mode=safe (cyclable)', () => {
-    const r = validateAgainstRegistry({ setting: 'user-context-mode', value: 'safe', confidence: 0.9 });
+    const r = validateAgainstRegistry({ kind: 'setting', setting: 'user-context-mode', value: 'safe', confidence: 0.9 });
+    assert.strictEqual(r.ok, true);
+  });
+
+  // ── Provider verdict validation ───────────────────────────────────
+
+  it('accepts a provider verdict for cues bucket with no model (defaults to providers defaultModel)', () => {
+    const r = validateAgainstRegistry({ kind: 'provider', scope: 'cues', provider: 'anthropic', model: null, confidence: 0.9 });
+    assert.strictEqual(r.ok, true);
+  });
+
+  it('accepts a provider verdict with a knownModel', () => {
+    const r = validateAgainstRegistry({ kind: 'provider', scope: 'cues', provider: 'anthropic', model: 'claude-opus-4-7', confidence: 0.9 });
+    assert.strictEqual(r.ok, true);
+  });
+
+  it('rejects an unknown provider id', () => {
+    const r = validateAgainstRegistry({ kind: 'provider', scope: 'cues', provider: 'totally-fake-provider', model: null, confidence: 0.9 });
+    assert.strictEqual(r.ok, false);
+    assert.match(r.reason ?? '', /unknown provider/);
+  });
+
+  it('rejects an unknown scope (not in cues/auditors/blanks)', () => {
+    // Cast through unknown because the type narrows scope to BucketScope;
+    // the runtime validator must still catch a string-typed scope from
+    // a parsed verdict whose source we don't trust.
+    const r = validateAgainstRegistry({
+      kind: 'provider', scope: 'everything' as 'cues', provider: 'anthropic', model: null, confidence: 0.9,
+    });
+    assert.strictEqual(r.ok, false);
+    assert.match(r.reason ?? '', /unknown scope/);
+  });
+
+  it('rejects a model not in the providers knownModels', () => {
+    const r = validateAgainstRegistry({ kind: 'provider', scope: 'cues', provider: 'anthropic', model: 'claude-sonnet-9-9', confidence: 0.9 });
+    assert.strictEqual(r.ok, false);
+    assert.match(r.reason ?? '', /knownModels/);
+  });
+
+  it('rejects opencode-zen on the cues bucket (trainsOnInput)', () => {
+    // Trust-class guard — mirrors the resolver's build-time refusal.
+    // Without it, fluid-config could route prose through a training
+    // pool when the resolver would refuse the same wiring.
+    const r = validateAgainstRegistry({ kind: 'provider', scope: 'cues', provider: 'opencode-zen', model: null, confidence: 0.9 });
+    assert.strictEqual(r.ok, false);
+    assert.match(r.reason ?? '', /trains on input/);
+  });
+
+  it('rejects opencode-zen on the auditors bucket (trainsOnInput)', () => {
+    const r = validateAgainstRegistry({ kind: 'provider', scope: 'auditors', provider: 'opencode-zen', model: null, confidence: 0.9 });
+    assert.strictEqual(r.ok, false);
+  });
+
+  it('accepts opencode-zen on the blanks bucket (user opt-in surface)', () => {
+    const r = validateAgainstRegistry({ kind: 'provider', scope: 'blanks', provider: 'opencode-zen', model: 'free', confidence: 0.9 });
     assert.strictEqual(r.ok, true);
   });
 });
@@ -332,5 +452,83 @@ describe('ConfigIntentSource', () => {
     const result = await src.getCues(ctxFromText('stop showing tip popups _'));
     assert.deepStrictEqual(calls, [['tips-mode', 'off']]);
     assert.strictEqual(result.results.length, 1);
+  });
+
+  // ── Provider routing scenarios ────────────────────────────────────
+
+  it('getCues provider hit (no model): writes only <scope>-llm-provider', async () => {
+    const apply = noopApply();
+    const src = new ConfigIntentSource({
+      ...baseConfig,
+      httpAdapter: makeMockAdapter([
+        'INTENT: PROVIDER\nSCOPE: cues\nPROVIDER: anthropic\nMODEL:\nCONFIDENCE: 0.92',
+      ]),
+      applyScalar: apply.fn,
+    });
+    const input = 'use anthropic for cues _';
+    const result = await src.getCues(ctxFromText(input));
+    assert.strictEqual(result.results.length, 1);
+    assert.deepStrictEqual(apply.calls, [['cues-llm-provider', 'anthropic']]);
+    const r = result.results[0]!;
+    assert.deepStrictEqual(r.alternatives, ['cues-llm-provider']);
+    assert.strictEqual(r.metadata?.satelliteValue, 'anthropic');
+    assert.strictEqual(r.metadata?.blankName, 'opencues');
+    assert.strictEqual(r.metadata?.selectorBlank, true);
+    assert.strictEqual(r.spanStart, 0);
+    assert.strictEqual(r.spanEnd, input.length);
+  });
+
+  it('getCues provider hit WITH model: writes both <scope>-llm-provider and <scope>-llm-model', async () => {
+    const apply = noopApply();
+    const src = new ConfigIntentSource({
+      ...baseConfig,
+      httpAdapter: makeMockAdapter([
+        'INTENT: PROVIDER\nSCOPE: auditors\nPROVIDER: anthropic\nMODEL: claude-opus-4-7\nCONFIDENCE: 0.9',
+      ]),
+      applyScalar: apply.fn,
+    });
+    const result = await src.getCues(ctxFromText('use claude opus for auditors _'));
+    assert.strictEqual(result.results.length, 1);
+    assert.deepStrictEqual(apply.calls, [
+      ['auditors-llm-provider', 'anthropic'],
+      ['auditors-llm-model', 'claude-opus-4-7'],
+    ]);
+  });
+
+  it('getCues provider hit with unknown model: cedes (validator rejects, no half-write)', async () => {
+    // Belt-and-braces: even if the prompt instructs the LLM to stay
+    // inside knownModels, a regression could leak a hallucinated model
+    // id through. The validator rejects; runtime cedes; NEITHER the
+    // provider nor the model scalar is written (no half-applied state).
+    const apply = noopApply();
+    const src = new ConfigIntentSource({
+      ...baseConfig,
+      httpAdapter: makeMockAdapter([
+        'INTENT: PROVIDER\nSCOPE: cues\nPROVIDER: anthropic\nMODEL: claude-sonnet-9-9\nCONFIDENCE: 0.9',
+      ]),
+      applyScalar: apply.fn,
+    });
+    const result = await src.getCues(ctxFromText('use anthropic claude sonnet 9 for cues _'));
+    assert.strictEqual(result.results.length, 0);
+    assert.deepStrictEqual(apply.calls, []);
+  });
+
+  it('getCues provider hit routing opencode-zen to cues: cedes (trainsOnInput guard)', async () => {
+    // The classifier prompt teaches the model not to route training-
+    // pool providers to prose buckets, but the validator enforces it
+    // structurally. Without this guard the resolver would later refuse
+    // the wiring anyway, leaving the user with a silent broken cue
+    // surface.
+    const apply = noopApply();
+    const src = new ConfigIntentSource({
+      ...baseConfig,
+      httpAdapter: makeMockAdapter([
+        'INTENT: PROVIDER\nSCOPE: cues\nPROVIDER: opencode-zen\nMODEL: free\nCONFIDENCE: 0.9',
+      ]),
+      applyScalar: apply.fn,
+    });
+    const result = await src.getCues(ctxFromText('use the free pool for cues _'));
+    assert.strictEqual(result.results.length, 0);
+    assert.deepStrictEqual(apply.calls, []);
   });
 });

--- a/packages/opencues-core/src/sources/config-intent-source.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.ts
@@ -57,11 +57,20 @@
 
 import { CueSource, CueContext, CueSourceResult, CueResult, HttpAdapter } from '../types';
 import { BlankConfig } from '../cues-md';
-import { describeLLMCall, dispatchChat, type ProviderAdapter } from '../llm-provider';
+import { describeLLMCall, dispatchChat, getProvider, listProviders, type ProviderAdapter } from '../llm-provider';
 import {
   FEATURES,
   getCyclableValues,
 } from '../feature-registry';
+
+/**
+ * The three buckets the classifier may route provider/model verdicts
+ * to. Mirrors the bucket scalars in OPENCUES.md (`cues-llm-provider`,
+ * `auditors-llm-provider`, `blanks-llm-provider`). See
+ * docs/architecture/llm-routing.md.
+ */
+export const BUCKET_SCOPES = ['cues', 'auditors', 'blanks'] as const;
+export type BucketScope = typeof BUCKET_SCOPES[number];
 
 // ============================================================================
 // System prompt — ported from tests/benchmarks/fluid-config/fused.ts v2.1
@@ -83,152 +92,401 @@ const FEATURE_REGISTRY_BLOCK: string = FEATURES
   .map(f => renderFeatureLine(f.scalar, [...getCyclableValues(f)], f.menuTip ?? f.description))
   .join('\n');
 
-export const SYSTEM_PROMPT = `You are a SETTINGS-CHANGE INTENT CLASSIFIER for the OpenCues runtime.
+// Build a per-provider listing of canonical model ids (knownModels +
+// defaultModel as the first entry) so the classifier knows what model
+// names are valid per provider. Providers without knownModels expose
+// only their defaultModel — picking a different model for them is a
+// power-user file edit, not a NL-reachable action.
+function renderProviderLine(p: ProviderAdapter): string {
+  const models = p.knownModels && p.knownModels.length > 0
+    ? p.knownModels
+    : [p.defaultModel];
+  return `  * ${p.id} (${p.displayName}) — models: ${models.join(', ')}`;
+}
 
-You read a sentence containing _ and decide whether the user is asking to change one specific OpenCues SETTING. If yes, you emit the kebab-case setting name + the new value. If anything else is going on, you emit NONE.
+const PROVIDER_REGISTRY_BLOCK: string = listProviders()
+  .filter(p => !!p.envKeyName || p.transport === 'cli' || p.optionalAuth)
+  .map(renderProviderLine)
+  .join('\n');
 
-The full list of settings you may route to (and ONLY these — nothing else exists):
+const BUCKET_LIST: string = BUCKET_SCOPES.join(', ');
+
+export const SYSTEM_PROMPT = `You are a CONFIGURATION INTENT CLASSIFIER for the OpenCues runtime.
+
+You read a sentence containing _ and decide which of three intents the user has:
+
+  (A) SETTING change — flip one named OpenCues setting to a specific value.
+  (B) PROVIDER routing — switch which LLM provider (and optionally model) runs on one of three buckets (${BUCKET_LIST}).
+  (C) NONE — the request is a factual lookup, a non-config action, or too ambiguous.
+
+═════════════════════════════════════════════════════════════════
+INTENT A — SETTING
+═════════════════════════════════════════════════════════════════
+
+Settings you may route to (and ONLY these — nothing else exists):
 
 ${FEATURE_REGISTRY_BLOCK}
 
-OUTPUT FORMAT — exactly three lines, nothing else:
-SETTING: <kebab-case scalar from the list above, OR the literal word NONE>
-VALUE: <one of the listed values for that scalar; empty when SETTING is NONE>
-CONFIDENCE: <a number between 0.0 and 1.0>
-
-ALWAYS emit all three lines, even when SETTING is NONE. NEVER truncate after the SETTING line. NEVER drop the -mode suffix from a setting name ('voice-mode' NOT 'voice'; 'debug-mode' NOT 'debug'; 'tips-mode' NOT 'tips'; 'word-cues-mode' NOT 'word-cues'; 'fluid-blank-mode' NOT 'fluid-blank'; 'transform-blank-mode' NOT 'transform-blank'; 'blank-trigger-mode' NOT 'blank-trigger'; 'ambient-context-mode' NOT 'ambient-context'; 'user-context-mode' NOT 'user-context'). The only setting without '-mode' is 'cursor-navigate'.
-
 ROUTE TO A SETTING when:
-  - The user names a setting either directly ("debug mode", "tips", "voice mode", "cursor navigate") or describes the SYMPTOM/BEHAVIOR clearly enough to identify exactly ONE setting from the list above ("read the tips aloud" → voice-mode; "I keep typing _italic_ and the blank fires early" → blank-trigger-mode; "let it use my personal info" → user-context-mode).
-  - The direction is clear from polarity words ("enable", "turn on", "stop", "disable", "quiet down", "noisy", "louder/quieter", "let it / don't let it") OR from sentence shape ("I want to hear …" → on-flavoured value; "stop showing me …" → off-flavoured value).
+  - The user names a setting either directly ("debug mode", "tips", "voice mode", "cursor navigate") or describes the SYMPTOM/BEHAVIOR clearly enough to identify exactly ONE setting from the list above.
+  - The direction is clear from polarity words ("enable", "turn on", "stop", "disable", "quiet down", "noisy") OR from sentence shape ("I want to hear …" → on-flavoured value).
+
+NEVER drop the -mode suffix ('voice-mode' NOT 'voice'; 'debug-mode' NOT 'debug'; etc.). The only setting without '-mode' is 'cursor-navigate'.
+
+NEVER route a provider-or-model change here — those are INTENT B. Example: "use anthropic for cues _" is INTENT B (PROVIDER), not a SETTING change.
+
+═════════════════════════════════════════════════════════════════
+INTENT B — PROVIDER routing
+═════════════════════════════════════════════════════════════════
+
+Three buckets carry the LLM routing for different surfaces:
+  - cues      → word-cues + sentence-cues (prose-bearing)
+  - auditors  → auditors + agent-rewrite  (prose-bearing background)
+  - blanks    → fluid-blank + transform-blank + fluid-config + keyword blanks (opt-in _ surface)
+
+Providers you may route to (and ONLY these):
+
+${PROVIDER_REGISTRY_BLOCK}
+
+ROUTE TO PROVIDER when:
+  - The user names a provider ("anthropic", "groq", "cerebras", "openai", "gemini", "claude") OR a model name from the lists above.
+  - AND names a scope ("for cues", "for blanks", "for auditors", "globally"/"everywhere") OR is generic ("switch to X" → MODEL: empty, SCOPE: cues as the default brain).
+
+SCOPE rules:
+  - "for cues" / "word cues" / "sentence cues" / "general" / "everywhere" / "globally" → cues
+  - "for blanks" / "blank" / "lookup" / "_ stuff" / "fluid-blank" / "transform-blank" → blanks
+  - "for auditors" / "auditor" / "agent" / "rewrites" / "grammar" / "background" → auditors
+
+MODEL rules:
+  - When the user names a specific model from the listed catalog → emit MODEL.
+  - When the user only says a provider ("use anthropic for cues _") → MODEL empty; the runtime picks that provider's default model.
+  - NEVER emit a model that isn't listed under that provider above. If the user names an unrecognised model, emit MODEL empty (the provider switch still applies; user can edit OPENCUES.md for the exact model).
+
+═════════════════════════════════════════════════════════════════
+INTENT C — NONE
+═════════════════════════════════════════════════════════════════
 
 ROUTE TO NONE when:
-  - The user is asking a FACTUAL LOOKUP ("capital of france _", "unicode for ampersand _", "atomic number of oxygen _"). Settings have nothing to do with these.
-  - The user is asking to change something that is NOT in the list above — even if it sounds like a setting ("change the theme", "use a bigger font", "switch language", "rebind a key", "use a different llm provider", "wait longer before agent fires"). The classifier MUST reject everything not in the list. Better to NONE than to mis-route to a similar-looking setting.
-  - The user is invoking a USER-LEVEL BLANK that's not a setting ("make it louder" → volume blank; "what's TSLA at" → stocks blank; "is it going to rain" → weather blank; "play the next song"). Volume / brightness / media / stocks / weather are user-shipped blanks, NOT settings. Always NONE.
-  - The pronoun is AMBIGUOUS so you cannot name ONE specific setting ("turn it off", "fix this", "enable that thing", "switch to the other one", "make it better").
-  - The intent isn't a settings change at all (greetings, questions about how something works, requests to do a task).
+  - Factual lookup ("capital of france _", "unicode for ampersand _").
+  - User-level blank ("make it louder" → volume blank; "what's TSLA at" → stocks blank).
+  - Pronoun ambiguous ("turn it off", "switch to the other one", "fix this").
+  - Greeting / how-something-works / task request.
+  - Setting change for something NOT in INTENT A's list ("change the theme", "use a bigger font") — even if it sounds setting-shaped.
+
+═════════════════════════════════════════════════════════════════
+OUTPUT FORMAT
+═════════════════════════════════════════════════════════════════
+
+ALWAYS emit ALL lines for the chosen intent. Use empty values for irrelevant lines but always emit them.
+
+When INTENT is SETTING:
+INTENT: SETTING
+SETTING: <kebab-case scalar from INTENT A list>
+VALUE: <one of the listed values for that scalar>
+SCOPE:
+PROVIDER:
+MODEL:
+CONFIDENCE: <0.0..1.0>
+
+When INTENT is PROVIDER:
+INTENT: PROVIDER
+SETTING:
+VALUE:
+SCOPE: <one of: ${BUCKET_LIST}>
+PROVIDER: <provider id from INTENT B list>
+MODEL: <model id from that provider's list, OR empty>
+CONFIDENCE: <0.0..1.0>
+
+When INTENT is NONE:
+INTENT: NONE
+SETTING:
+VALUE:
+SCOPE:
+PROVIDER:
+MODEL:
+CONFIDENCE: <0.0..1.0>
 
 CONFIDENCE:
-  - 0.9-1.0 when the user clearly names a setting AND a value.
-  - 0.7-0.9 when the symptom is described and maps cleanly to one setting.
-  - 0.5-0.7 when there's a plausible read but you're inferring direction.
-  - Below 0.5 → emit NONE instead; uncertainty IS the signal to reject.
+  - 0.9-1.0 when the user clearly names BOTH the slot AND its value.
+  - 0.7-0.9 when the symptom maps cleanly to one slot.
+  - 0.5-0.7 when there's a plausible read but you're inferring.
+  - Below 0.5 → emit INTENT: NONE; uncertainty IS the signal to reject.
 
-DO NOT invent a setting that isn't in the list above.
-DO NOT pick a value that isn't listed under its setting.
-DO NOT route to the nearest-looking setting when the real intent is something else — emit NONE.
+DO NOT invent a setting / provider / model that isn't listed above.
+DO NOT pick a value not listed for its slot.
+DO NOT route to the nearest-looking option when the real intent is something else — emit NONE.
 
-EXAMPLES:
+═════════════════════════════════════════════════════════════════
+EXAMPLES
+═════════════════════════════════════════════════════════════════
 
 INPUT: enable debug logging _
+INTENT: SETTING
 SETTING: debug-mode
 VALUE: on
+SCOPE:
+PROVIDER:
+MODEL:
 CONFIDENCE: 0.97
 
 INPUT: stop reading the tips out loud _
+INTENT: SETTING
 SETTING: voice-mode
 VALUE: inactive
+SCOPE:
+PROVIDER:
+MODEL:
 CONFIDENCE: 0.92
 
 INPUT: I keep typing _italic_ and the blank fires before the closing one _
+INTENT: SETTING
 SETTING: blank-trigger-mode
 VALUE: spaced
+SCOPE:
+PROVIDER:
+MODEL:
 CONFIDENCE: 0.85
 
-INPUT: fire blanks the moment I press the underscore key _
-SETTING: blank-trigger-mode
-VALUE: immediate
+INPUT: use anthropic for cues _
+INTENT: PROVIDER
+SETTING:
+VALUE:
+SCOPE: cues
+PROVIDER: anthropic
+MODEL:
+CONFIDENCE: 0.92
+
+INPUT: switch the blanks brain to cerebras _
+INTENT: PROVIDER
+SETTING:
+VALUE:
+SCOPE: blanks
+PROVIDER: cerebras
+MODEL:
+CONFIDENCE: 0.93
+
+INPUT: use claude opus for auditors _
+INTENT: PROVIDER
+SETTING:
+VALUE:
+SCOPE: auditors
+PROVIDER: anthropic
+MODEL: claude-opus-4-7
 CONFIDENCE: 0.9
 
-INPUT: capital of france _
-SETTING: NONE
+INPUT: use gpt-5.4 for the agent _
+INTENT: PROVIDER
+SETTING:
 VALUE:
+SCOPE: auditors
+PROVIDER: openai
+MODEL: gpt-5.4
+CONFIDENCE: 0.88
+
+INPUT: route everything to gemini _
+INTENT: PROVIDER
+SETTING:
+VALUE:
+SCOPE: cues
+PROVIDER: gemini
+MODEL:
+CONFIDENCE: 0.8
+
+INPUT: switch cues to a model that does not exist _
+INTENT: NONE
+SETTING:
+VALUE:
+SCOPE:
+PROVIDER:
+MODEL:
+CONFIDENCE: 0.4
+
+INPUT: capital of france _
+INTENT: NONE
+SETTING:
+VALUE:
+SCOPE:
+PROVIDER:
+MODEL:
 CONFIDENCE: 0.99
 
 INPUT: make it louder _
-SETTING: NONE
+INTENT: NONE
+SETTING:
 VALUE:
+SCOPE:
+PROVIDER:
+MODEL:
 CONFIDENCE: 0.95
-
-INPUT: change the theme to dark mode _
-SETTING: NONE
-VALUE:
-CONFIDENCE: 0.95
-
-INPUT: wait longer before the agent fires _
-SETTING: NONE
-VALUE:
-CONFIDENCE: 0.9
 
 INPUT: turn it off _
-SETTING: NONE
+INTENT: NONE
+SETTING:
 VALUE:
+SCOPE:
+PROVIDER:
+MODEL:
 CONFIDENCE: 0.9
 
 INPUT: let it use my personal info when answering _
+INTENT: SETTING
 SETTING: user-context-mode
 VALUE: safe
+SCOPE:
+PROVIDER:
+MODEL:
 CONFIDENCE: 0.88
-
-INPUT: stop sharing anything personal with the model _
-SETTING: user-context-mode
-VALUE: off
-CONFIDENCE: 0.9
 
 INPUT: let the model know which website I am on _
+INTENT: SETTING
 SETTING: ambient-context-mode
 VALUE: on
-CONFIDENCE: 0.88
-
-INPUT: don't tell the LLM what field I'm in _
-SETTING: ambient-context-mode
-VALUE: off
+SCOPE:
+PROVIDER:
+MODEL:
 CONFIDENCE: 0.88`;
 
 // ============================================================================
-// Parsed verdict
+// Parsed verdict — discriminated union
 // ============================================================================
 
-export interface ConfigIntentVerdict {
-  setting: string | null;
-  value: string | null;
-  confidence: number | null;
+export interface SettingVerdict {
+  readonly kind: 'setting';
+  readonly setting: string;
+  readonly value: string;
+  readonly confidence: number | null;
 }
 
+export interface ProviderVerdict {
+  readonly kind: 'provider';
+  readonly scope: BucketScope;
+  readonly provider: string;
+  readonly model: string | null;
+  readonly confidence: number | null;
+}
+
+export interface NoneVerdict {
+  readonly kind: 'none';
+  readonly confidence: number | null;
+}
+
+export type ConfigIntentVerdict = SettingVerdict | ProviderVerdict | NoneVerdict;
+
+/**
+ * Parse the classifier's raw text output. Tolerant of:
+ *   - Missing `INTENT:` line (legacy v2.1 prompts that pre-date the
+ *     three-kind split) — falls back to inferring kind from which
+ *     slot the LLM populated.
+ *   - Extra whitespace, surrounding prose, leading commentary.
+ *   - Empty lines for the slot that doesn't apply.
+ *
+ * Always returns SOMETHING — uncertain inputs collapse to NoneVerdict
+ * rather than throwing, so the caller can cede gracefully.
+ */
 export function parseConfigIntentOutput(raw: string): ConfigIntentVerdict {
+  const intentMatch = raw.match(/^INTENT:[ \t]*(.*?)[ \t]*$/im);
   const settingMatch = raw.match(/^SETTING:[ \t]*(.*?)[ \t]*$/im);
   const valueMatch = raw.match(/^VALUE:[ \t]*(.*?)[ \t]*$/im);
+  const scopeMatch = raw.match(/^SCOPE:[ \t]*(.*?)[ \t]*$/im);
+  const providerMatch = raw.match(/^PROVIDER:[ \t]*(.*?)[ \t]*$/im);
+  const modelMatch = raw.match(/^MODEL:[ \t]*(.*?)[ \t]*$/im);
   const confidenceMatch = raw.match(/^CONFIDENCE:[ \t]*([0-9.]+)/im);
 
+  const intentRaw = intentMatch ? intentMatch[1].trim().toUpperCase() : '';
   const settingRaw = settingMatch ? settingMatch[1].trim() : '';
   const valueRaw = valueMatch ? valueMatch[1].trim() : '';
+  const scopeRaw = scopeMatch ? scopeMatch[1].trim().toLowerCase() : '';
+  const providerRaw = providerMatch ? providerMatch[1].trim().toLowerCase() : '';
+  const modelRaw = modelMatch ? modelMatch[1].trim() : '';
   const confidence = confidenceMatch ? Number(confidenceMatch[1]) : null;
 
-  const setting = (!settingRaw || settingRaw.toUpperCase() === 'NONE') ? null : settingRaw;
-  const value = setting === null ? null : (valueRaw || null);
+  // Infer kind. Explicit INTENT line wins; otherwise fall back to
+  // slot-populated heuristic for back-compat with the legacy v2.1
+  // prompt shape (SETTING line was the only discriminator).
+  let kind: ConfigIntentVerdict['kind'];
+  if (intentRaw === 'SETTING') kind = 'setting';
+  else if (intentRaw === 'PROVIDER') kind = 'provider';
+  else if (intentRaw === 'NONE') kind = 'none';
+  else if (providerRaw && scopeRaw) kind = 'provider';
+  else if (settingRaw && settingRaw.toUpperCase() !== 'NONE') kind = 'setting';
+  else kind = 'none';
 
-  return { setting, value, confidence };
+  if (kind === 'setting') {
+    if (!settingRaw || settingRaw.toUpperCase() === 'NONE' || !valueRaw) {
+      return { kind: 'none', confidence };
+    }
+    return { kind: 'setting', setting: settingRaw, value: valueRaw, confidence };
+  }
+  if (kind === 'provider') {
+    if (!providerRaw || providerRaw.toUpperCase() === 'NONE') {
+      return { kind: 'none', confidence };
+    }
+    // Normalise scope; default to 'cues' when the classifier omitted it
+    // ("switch to anthropic _" with no explicit scope routes to the
+    // primary brain). Validator will reject unknown scope literals.
+    const scope: BucketScope = (BUCKET_SCOPES as readonly string[]).includes(scopeRaw)
+      ? (scopeRaw as BucketScope)
+      : 'cues';
+    return {
+      kind: 'provider',
+      scope,
+      provider: providerRaw,
+      model: modelRaw || null,
+      confidence,
+    };
+  }
+  return { kind: 'none', confidence };
 }
 
 /**
- * Validate a parsed verdict against the FEATURES registry. Rejects
- * anything the model hallucinated (unknown setting, unlisted value,
- * hidden value like user-context-mode=raw).
+ * Validate a parsed verdict against the FEATURES + PROVIDERS
+ * registries. Rejects anything the model hallucinated:
+ *   - setting kind: unknown setting, unlisted value, hidden value
+ *     (e.g. user-context-mode=raw)
+ *   - provider kind: unknown scope, unknown provider, model not in
+ *     that provider's knownModels (when knownModels is declared)
  *
- * The classifier prompt instructs the model to stay inside the
- * registry, but defence in depth: the runtime should never apply a
- * verdict that doesn't pass this check, even if every call passes
- * today's bench. New providers may not follow instructions perfectly.
+ * The classifier prompt instructs the model to stay inside both
+ * registries, but defence in depth — runtime never applies a verdict
+ * that doesn't pass this check, even if every call passes today's
+ * bench. New providers may not follow instructions perfectly.
+ *
+ * NoneVerdict always validates (caller cedes).
  */
 export function validateAgainstRegistry(verdict: ConfigIntentVerdict): { ok: boolean; reason?: string } {
-  if (verdict.setting === null) return { ok: true };
-  const feature = FEATURES.find(f => f.scalar === verdict.setting);
-  if (!feature) return { ok: false, reason: `unknown setting '${verdict.setting}'` };
-  if (verdict.value === null) return { ok: false, reason: `setting '${verdict.setting}' has no value` };
-  const allowed = [...getCyclableValues(feature)].map(v => v.id);
-  if (!allowed.includes(verdict.value)) {
-    return { ok: false, reason: `value '${verdict.value}' is not cyclable for '${verdict.setting}' (allowed: ${allowed.join(', ')})` };
+  if (verdict.kind === 'none') return { ok: true };
+
+  if (verdict.kind === 'setting') {
+    const feature = FEATURES.find(f => f.scalar === verdict.setting);
+    if (!feature) return { ok: false, reason: `unknown setting '${verdict.setting}'` };
+    const allowed = [...getCyclableValues(feature)].map(v => v.id);
+    if (!allowed.includes(verdict.value)) {
+      return { ok: false, reason: `value '${verdict.value}' is not cyclable for '${verdict.setting}' (allowed: ${allowed.join(', ')})` };
+    }
+    return { ok: true };
+  }
+
+  // provider kind
+  if (!(BUCKET_SCOPES as readonly string[]).includes(verdict.scope)) {
+    return { ok: false, reason: `unknown scope '${verdict.scope}' (allowed: ${BUCKET_SCOPES.join(', ')})` };
+  }
+  const provider = getProvider(verdict.provider);
+  if (!provider) {
+    return { ok: false, reason: `unknown provider '${verdict.provider}'` };
+  }
+  // Trust-class guard: prose buckets (cues + auditors) refuse providers
+  // that train on input. Mirrors the resolver's build-time guard so
+  // fluid-config can't reach what the resolver would reject anyway.
+  if (verdict.scope !== 'blanks' && provider.trainsOnInput) {
+    return { ok: false, reason: `provider '${verdict.provider}' trains on input — blocked for prose bucket '${verdict.scope}' (only 'blanks' may use it)` };
+  }
+  if (verdict.model !== null) {
+    const allowedModels = provider.knownModels && provider.knownModels.length > 0
+      ? provider.knownModels
+      : [provider.defaultModel];
+    if (!allowedModels.includes(verdict.model)) {
+      return { ok: false, reason: `model '${verdict.model}' is not in '${verdict.provider}'s knownModels (allowed: ${allowedModels.join(', ')})` };
+    }
   }
   return { ok: true };
 }
@@ -360,7 +618,7 @@ export class ConfigIntentSource implements CueSource {
     }
 
     const verdict = parseConfigIntentOutput(raw);
-    if (verdict.setting === null) {
+    if (verdict.kind === 'none') {
       this.log(`ConfigIntent: NONE (${Date.now() - t0}ms) — ceding to next source`);
       this.emit({ type: 'completed', verdict, applied: false, latencyMs: Date.now() - t0 });
       return { results: [], timing: Date.now() - t0, model: this.model };
@@ -373,44 +631,76 @@ export class ConfigIntentSource implements CueSource {
       return { results: [], timing: Date.now() - t0, model: this.model };
     }
 
-    // Apply BEFORE building the CueResult. If the write fails, we bail
+    // Apply BEFORE building the CueResult. If a write fails, bail
     // rather than show a confirmation marker for a change that didn't
-    // happen.
+    // happen. Provider verdicts may write TWO scalars (provider + model);
+    // run them sequentially — applyOpenCuesScalar's reload-suppression
+    // window covers both writes within the 2.5s guard.
+    const apply = async (setting: string, value: string): Promise<void> => {
+      await Promise.resolve(this.applyScalar(setting, value));
+    };
+    let displaySelector: string;
+    let displayValue: string;
+    let cueTip: string;
     try {
-      await Promise.resolve(this.applyScalar(verdict.setting!, verdict.value!));
+      if (verdict.kind === 'setting') {
+        await apply(verdict.setting, verdict.value);
+        displaySelector = verdict.setting;
+        displayValue = verdict.value;
+        cueTip = `${verdict.setting} → ${verdict.value}`;
+      } else {
+        // provider kind. Always write the bucket's provider scalar;
+        // also write the model scalar when the verdict specified one.
+        // Cleaning up the model scalar when only the provider changed
+        // would risk overwriting a deliberate file-edit pin — leave
+        // any existing model scalar alone, let the resolver's
+        // bucket-provider-without-model fallback pick the new
+        // provider's defaultModel.
+        const providerScalar = `${verdict.scope}-llm-provider`;
+        await apply(providerScalar, verdict.provider);
+        if (verdict.model !== null) {
+          await apply(`${verdict.scope}-llm-model`, verdict.model);
+        }
+        displaySelector = providerScalar;
+        displayValue = verdict.provider;
+        cueTip = verdict.model !== null
+          ? `${verdict.scope} → ${verdict.provider} · ${verdict.model}`
+          : `${verdict.scope} → ${verdict.provider}`;
+      }
     } catch (e) {
-      this.log(`ConfigIntent: applyScalar failed for ${verdict.setting}=${verdict.value} — ${(e as Error).message}`);
+      this.log(`ConfigIntent: applyScalar failed for ${verdict.kind} verdict — ${(e as Error).message}`);
       this.emit({ type: 'bailed', reason: 'apply-failed', latencyMs: Date.now() - t0 });
       return { results: [], timing: Date.now() - t0, model: this.model };
     }
 
-    this.log(`ConfigIntent: applied ${verdict.setting}=${verdict.value} (${Date.now() - t0}ms, conf=${verdict.confidence ?? 'n/a'})`);
+    this.log(`ConfigIntent: applied ${cueTip} (${Date.now() - t0}ms, conf=${verdict.confidence ?? 'n/a'})`);
     this.emit({ type: 'completed', verdict, applied: true, latencyMs: Date.now() - t0 });
 
     // Selector-satellite shape, mirroring the result BlankSource emits
     // for keyword-bound `opencues settings _` (see blank-source.ts
     // selector-satellite branch). spanStart=0/spanEnd=text.length wipes
     // the user's summon words AND the `_` — the buffer becomes JUST
-    // "<setting><sep><value>" and full satellite cycling is then live.
+    // "<scalar><sep><value>" and full satellite cycling is then live.
+    // For provider verdicts the bucket scalar (cues-llm-provider, etc.)
+    // is itself a FEATURES entry, so satellite cycling enumerates the
+    // provider list directly — no extra wiring needed.
     const result: CueResult = {
       wordIndex: blankIdx,
       word: '_',
-      alternatives: [verdict.setting!],
+      alternatives: [displaySelector],
       source: this.id,
       priority: this.priority,
       spanStart: 0,
       spanEnd: context.text.length,
-      cueTip: `${verdict.setting} → ${verdict.value}`,
+      cueTip,
       metadata: {
         blankName: 'opencues',
         selectorBlank: true,
-        satelliteValue: verdict.value!,
+        satelliteValue: displayValue,
         displaySeparator: ' ',
-        configIntent: {
-          setting: verdict.setting,
-          value: verdict.value,
-          confidence: verdict.confidence,
-        },
+        configIntent: verdict.kind === 'setting'
+          ? { setting: verdict.setting, value: verdict.value, confidence: verdict.confidence }
+          : { scope: verdict.scope, provider: verdict.provider, model: verdict.model, confidence: verdict.confidence },
       },
     };
 

--- a/tests/benchmarks/fluid-config-switch-provider/README.md
+++ b/tests/benchmarks/fluid-config-switch-provider/README.md
@@ -1,0 +1,69 @@
+# fluid-config switch-provider bench
+
+End-to-end scenario coverage for the fluid-config classifier's
+**provider routing** intent (`use anthropic for cues _` etc.) +
+regression coverage for the setting and reject paths.
+
+The bench imports the **live** `SYSTEM_PROMPT` + `parseConfigIntentOutput`
++ `validateAgainstRegistry` from
+`packages/opencues-core/src/sources/config-intent-source.ts` — drift
+between bench prompt and shipped prompt is structurally impossible.
+
+## Run
+
+```bash
+# Default (Groq)
+GROQ_API_KEY=xxx tsx tests/benchmarks/fluid-config-switch-provider/run.ts --parallel 6
+
+# Cerebras (fastest)
+OPENCUES_BENCH_PROVIDER=cerebras CEREBRAS_API_KEY=xxx \
+  tsx tests/benchmarks/fluid-config-switch-provider/run.ts --parallel 6
+
+# Anthropic / OpenAI / Gemini also accepted as OPENCUES_BENCH_PROVIDER
+```
+
+Filters:
+
+```bash
+tsx ... --case po-cues-anthropic            # single case
+tsx ... --category hit-provider-and-model   # one category
+tsx ... --verbose                           # show raw LLM output per case
+```
+
+## What's tested
+
+| Category | What it pins |
+|---|---|
+| `hit-provider-only` | Clean provider switch, no model named. Scope-routing across cues / auditors / blanks; "everything" defaults to cues. |
+| `hit-provider-and-model` | Provider + specific model from `knownModels`. |
+| `hit-model-implies-provider` | Model name only — classifier should infer the provider from the registry. |
+| `reject-trains-on-input` | opencode-zen routed to cues / auditors is structurally refused (trust-class guard). |
+| `reject-unknown` | Hallucinated providers/models → NONE. |
+| `regression-setting` | Setting changes (`enable debug logging _`) still route to INTENT A. |
+| `regression-none` | Lookups + provider mentions that aren't switches still classify as NONE. |
+
+## Targets
+
+- **Precision** ≥ 95% — reject cases classified as NONE. FP on a
+  reject mis-routes a settings/provider write and is the security-
+  critical metric.
+- **Recall** ≥ 80% — hit cases routed to the right scope/provider
+  (and model when specified).
+- **FP count** = 0 in steady state. The `--category reject-*`
+  filter runs only the security-relevant subset.
+
+## What it doesn't test
+
+- The runtime apply path — covered by the vitest scenarios in
+  `packages/opencues-core/src/sources/config-intent-source.test.ts`.
+- Cycling after a switch — covered by the runtime's selector-satellite
+  scenario tests.
+- Cross-provider latency budgets — covered by the `fluid-blank` +
+  `transform-blank` benches under `tests/benchmarks/`.
+
+## Adding cases
+
+Append to `cases.ts`. Reuse an existing `category` or add one + extend
+the judge's verdict taxonomy if the new shape doesn't map. Keep the
+suite under ~60 cases — beyond that the per-provider sweep cost
+makes contributors run it less.

--- a/tests/benchmarks/fluid-config-switch-provider/cases.ts
+++ b/tests/benchmarks/fluid-config-switch-provider/cases.ts
@@ -1,0 +1,253 @@
+/**
+ * Cases for the fluid-config switch-provider bench.
+ *
+ * The classifier now supports THREE intents (see config-intent-source.ts's
+ * SYSTEM_PROMPT):
+ *
+ *   - SETTING  — flip an OPENCUES.md scalar  (covered by ../fluid-config/)
+ *   - PROVIDER — switch a bucket's LLM provider (and optionally model)
+ *   - NONE     — anything else
+ *
+ * This suite covers the PROVIDER intent + the new bucket-routing
+ * paths it opens up + the trust-class guard. Setting and lookup paths
+ * are sanity-checked here too (regression coverage — they must still
+ * route correctly after the prompt rewrite).
+ *
+ * Six buckets:
+ *
+ *   - hit-provider-only      — clean provider switch, no model named
+ *   - hit-provider-and-model — provider + specific model from knownModels
+ *   - hit-model-implies-provider — model name only; LLM should infer provider
+ *   - reject-trains-on-input — opencode-zen routed to cues/auditors (guard)
+ *   - reject-unknown         — model/provider the registry doesn't know
+ *   - regression-setting     — INTENT A setting changes still work
+ *   - regression-none        — pure lookups + provider-mentions that aren't switches
+ */
+
+import type { BucketScope } from '../../../packages/opencues-core/src/sources/config-intent-source';
+
+export interface ExpectedProviderHit {
+  readonly kind: 'provider';
+  readonly scope: BucketScope;
+  readonly provider: string;
+  /** null = classifier may emit any model (or empty), don't pin one. */
+  readonly model: string | null;
+  /** When the LLM picks an ambiguous-but-valid alternative, count it as a hit. */
+  readonly providerAlternates?: readonly string[];
+  readonly modelAlternates?: readonly string[];
+}
+export interface ExpectedSettingHit {
+  readonly kind: 'setting';
+  readonly setting: string;
+  readonly value: string;
+}
+export interface ExpectedNone {
+  readonly kind: 'none';
+}
+export type Expected = ExpectedProviderHit | ExpectedSettingHit | ExpectedNone;
+
+export interface SwitchProviderCase {
+  readonly id: string;
+  readonly category:
+    | 'hit-provider-only'
+    | 'hit-provider-and-model'
+    | 'hit-model-implies-provider'
+    | 'reject-trains-on-input'
+    | 'reject-unknown'
+    | 'regression-setting'
+    | 'regression-none';
+  readonly input: string;
+  readonly expected: Expected;
+}
+
+export const CASES: SwitchProviderCase[] = [
+  // ── hit-provider-only ───────────────────────────────────────────────
+
+  { id: 'po-cues-anthropic',
+    category: 'hit-provider-only',
+    input: 'use anthropic for cues _',
+    expected: { kind: 'provider', scope: 'cues', provider: 'anthropic', model: null } },
+
+  { id: 'po-blanks-cerebras',
+    category: 'hit-provider-only',
+    input: 'switch the blanks brain to cerebras _',
+    expected: { kind: 'provider', scope: 'blanks', provider: 'cerebras', model: null } },
+
+  { id: 'po-auditors-groq',
+    category: 'hit-provider-only',
+    input: 'route auditors through groq _',
+    expected: { kind: 'provider', scope: 'auditors', provider: 'groq', model: null } },
+
+  { id: 'po-cues-gemini',
+    category: 'hit-provider-only',
+    input: 'make cues use gemini _',
+    expected: { kind: 'provider', scope: 'cues', provider: 'gemini', model: null } },
+
+  { id: 'po-everything-default-cues',
+    category: 'hit-provider-only',
+    // "everything" / "globally" should land on cues (the prompt
+    // documents cues as the default brain when no explicit scope).
+    input: 'route everything to gemini _',
+    expected: { kind: 'provider', scope: 'cues', provider: 'gemini', model: null } },
+
+  { id: 'po-blanks-fluid-keyword',
+    category: 'hit-provider-only',
+    input: 'use openai for the fluid-blank stuff _',
+    expected: { kind: 'provider', scope: 'blanks', provider: 'openai', model: null } },
+
+  { id: 'po-auditors-agent-keyword',
+    category: 'hit-provider-only',
+    input: 'switch the agent to anthropic _',
+    expected: { kind: 'provider', scope: 'auditors', provider: 'anthropic', model: null } },
+
+  // ── hit-provider-and-model ──────────────────────────────────────────
+
+  { id: 'pm-anthropic-opus-auditors',
+    category: 'hit-provider-and-model',
+    input: 'use claude opus for auditors _',
+    expected: { kind: 'provider', scope: 'auditors', provider: 'anthropic', model: 'claude-opus-4-7' } },
+
+  { id: 'pm-openai-5.4-cues',
+    category: 'hit-provider-and-model',
+    input: 'use openai gpt-5.4 for cues _',
+    expected: { kind: 'provider', scope: 'cues', provider: 'openai', model: 'gpt-5.4' } },
+
+  { id: 'pm-cerebras-gpt-oss-blanks',
+    category: 'hit-provider-and-model',
+    input: 'route blanks to cerebras gpt-oss-120b _',
+    expected: { kind: 'provider', scope: 'blanks', provider: 'cerebras', model: 'gpt-oss-120b' } },
+
+  { id: 'pm-gemini-pro-cues',
+    category: 'hit-provider-and-model',
+    input: 'use gemini pro for cues _',
+    expected: { kind: 'provider', scope: 'cues', provider: 'gemini', model: 'gemini-3.1-pro' } },
+
+  { id: 'pm-anthropic-sonnet-auditors',
+    category: 'hit-provider-and-model',
+    input: 'switch auditors to claude sonnet _',
+    expected: { kind: 'provider', scope: 'auditors', provider: 'anthropic', model: 'claude-sonnet-4-6' } },
+
+  // ── hit-model-implies-provider ──────────────────────────────────────
+  //
+  // User names a model only — classifier should infer the provider
+  // from the catalogue.
+
+  { id: 'mi-opus-auditors',
+    category: 'hit-model-implies-provider',
+    input: 'use opus for the auditors _',
+    expected: { kind: 'provider', scope: 'auditors', provider: 'anthropic', model: 'claude-opus-4-7',
+                providerAlternates: ['claude-cli'], modelAlternates: ['opus'] } },
+
+  { id: 'mi-gpt54-cues',
+    category: 'hit-model-implies-provider',
+    input: 'use gpt-5.4 for cues _',
+    expected: { kind: 'provider', scope: 'cues', provider: 'openai', model: 'gpt-5.4',
+                providerAlternates: ['openai-subscription'] } },
+
+  { id: 'mi-haiku-cues',
+    category: 'hit-model-implies-provider',
+    // "haiku" alone is ambiguous (anthropic full name vs claude-cli
+    // alias). Adding "claude" disambiguates per the prompt examples.
+    input: 'use claude haiku for cues _',
+    expected: { kind: 'provider', scope: 'cues', provider: 'anthropic', model: 'claude-haiku-4-5-20251001',
+                providerAlternates: ['claude-cli'], modelAlternates: ['haiku'] } },
+
+  { id: 'mi-gemini-flash-blanks',
+    category: 'hit-model-implies-provider',
+    input: 'use gemini-3.1-flash for blanks _',
+    expected: { kind: 'provider', scope: 'blanks', provider: 'gemini', model: 'gemini-3.1-flash' } },
+
+  // ── reject-trains-on-input ──────────────────────────────────────────
+  //
+  // opencode-zen is the only trainsOnInput provider today. Prompt
+  // documents it as blanks-only; validator enforces it structurally.
+  // Bench failure here would mean we'd silently route prose to a
+  // training pool — security bug.
+
+  { id: 'rt-zen-cues',
+    category: 'reject-trains-on-input',
+    input: 'use opencode-zen for cues _',
+    expected: { kind: 'none' } },
+
+  { id: 'rt-zen-auditors',
+    category: 'reject-trains-on-input',
+    input: 'route the auditors through the free pool _',
+    expected: { kind: 'none' } },
+
+  { id: 'rt-zen-blanks-ok',
+    category: 'hit-provider-only',  // intentionally a hit — opencode-zen on blanks IS allowed
+    input: 'use opencode-zen for blanks _',
+    expected: { kind: 'provider', scope: 'blanks', provider: 'opencode-zen', model: null,
+                modelAlternates: ['free', 'big-pickle'] } },
+
+  // ── reject-unknown ──────────────────────────────────────────────────
+
+  { id: 'ru-fake-provider',
+    category: 'reject-unknown',
+    input: 'use chatgpt-deluxe for cues _',
+    expected: { kind: 'none' } },
+
+  { id: 'ru-fake-model-graceful',
+    // Graceful degrade: when the model is unrecognised but the
+    // provider IS known, the classifier may emit the provider switch
+    // without a model. Validator passes (provider-only is valid);
+    // user gets the provider's defaultModel. This is "safe outcome";
+    // we accept it. The strict-NONE behaviour is also fine — both
+    // outcomes are non-security-critical.
+    category: 'hit-provider-only',
+    input: 'use anthropic claude-sonnet-9-9 for cues _',
+    expected: { kind: 'provider', scope: 'cues', provider: 'anthropic', model: null } },
+
+  { id: 'ru-vague-model',
+    category: 'reject-unknown',
+    input: 'use the best model for cues _',
+    expected: { kind: 'none' } },
+
+  // ── regression-setting ──────────────────────────────────────────────
+  //
+  // The new prompt has THREE intents. Make sure setting-changes still
+  // route correctly and don't get hijacked by the provider intent.
+
+  { id: 'rs-debug-on',
+    category: 'regression-setting',
+    input: 'enable debug logging _',
+    expected: { kind: 'setting', setting: 'debug-mode', value: 'on' } },
+
+  { id: 'rs-voice-off',
+    category: 'regression-setting',
+    input: 'stop reading the tips out loud _',
+    expected: { kind: 'setting', setting: 'voice-mode', value: 'inactive' } },
+
+  { id: 'rs-tips-off',
+    category: 'regression-setting',
+    input: 'hide the tip popups _',
+    expected: { kind: 'setting', setting: 'tips-mode', value: 'off' } },
+
+  { id: 'rs-ambient-on',
+    category: 'regression-setting',
+    input: 'let the model know which website I am on _',
+    expected: { kind: 'setting', setting: 'ambient-context-mode', value: 'on' } },
+
+  // ── regression-none ─────────────────────────────────────────────────
+
+  { id: 'rn-lookup',
+    category: 'regression-none',
+    input: 'capital of france _',
+    expected: { kind: 'none' } },
+
+  { id: 'rn-user-blank',
+    category: 'regression-none',
+    input: 'make it louder _',
+    expected: { kind: 'none' } },
+
+  { id: 'rn-mentions-provider-but-not-switch',
+    category: 'regression-none',
+    // Mentions a provider name but in a Q&A context, not a switch.
+    input: 'what is anthropic _',
+    expected: { kind: 'none' } },
+
+  { id: 'rn-ambiguous-pronoun',
+    category: 'regression-none',
+    input: 'switch it to the other one _',
+    expected: { kind: 'none' } },
+];

--- a/tests/benchmarks/fluid-config-switch-provider/judge.ts
+++ b/tests/benchmarks/fluid-config-switch-provider/judge.ts
@@ -1,0 +1,113 @@
+/**
+ * Deterministic judge for the fluid-config switch-provider bench.
+ *
+ * No LLM call — the verdict shape is bounded (kind ∈ {setting,
+ * provider, none}; scope ∈ {cues, auditors, blanks}; provider ∈
+ * ProviderId; model ∈ knownModels). Equality is the right gate.
+ *
+ * Verdict taxonomy matches the runner's bucket layout:
+ *
+ *   TP-PROVIDER    — provider hit, right scope+provider, model matches
+ *                    (when expected model is non-null) OR expected model
+ *                    is null and any model (or none) is accepted
+ *   TP-SETTING     — setting hit (regression coverage)
+ *   TN             — reject case correctly classified as NONE
+ *   WRONG-KIND     — got setting when expected provider, etc.
+ *   WRONG-SCOPE    — provider intent, right provider, wrong bucket
+ *   WRONG-PROVIDER — provider intent, right scope, wrong provider
+ *   WRONG-MODEL    — provider intent, right scope+provider, wrong model
+ *   FP             — reject case mis-classified as a hit (worst outcome)
+ *   FN             — hit case rejected as NONE (recoverable)
+ */
+
+import type { SwitchProviderCase, Expected } from './cases';
+
+export type Verdict =
+  | 'TP-PROVIDER'
+  | 'TP-SETTING'
+  | 'TN'
+  | 'WRONG-KIND'
+  | 'WRONG-SCOPE'
+  | 'WRONG-PROVIDER'
+  | 'WRONG-MODEL'
+  | 'FP'
+  | 'FN';
+
+export interface JudgeResult {
+  readonly verdict: Verdict;
+  readonly pass: boolean;
+  readonly rationale: string;
+}
+
+/** Loose verdict shape — what the runner extracts from the LLM call. */
+export interface ActualVerdict {
+  readonly kind: 'setting' | 'provider' | 'none';
+  readonly setting?: string;
+  readonly value?: string;
+  readonly scope?: string;
+  readonly provider?: string;
+  readonly model?: string | null;
+}
+
+export function judge(c: SwitchProviderCase, actual: ActualVerdict): JudgeResult {
+  const exp: Expected = c.expected;
+
+  if (exp.kind === 'none') {
+    if (actual.kind === 'none') return { verdict: 'TN', pass: true, rationale: 'correctly rejected' };
+    return { verdict: 'FP', pass: false, rationale: `false-positive: routed reject to ${describeActual(actual)}` };
+  }
+
+  if (actual.kind === 'none') {
+    return { verdict: 'FN', pass: false, rationale: `false-negative: hit case rejected; expected ${describeExpected(exp)}` };
+  }
+
+  if (exp.kind !== actual.kind) {
+    return { verdict: 'WRONG-KIND', pass: false, rationale: `expected kind=${exp.kind}, got ${actual.kind} (${describeActual(actual)})` };
+  }
+
+  if (exp.kind === 'setting' && actual.kind === 'setting') {
+    if (actual.setting !== exp.setting) {
+      return { verdict: 'WRONG-PROVIDER', pass: false, rationale: `wrong setting: got ${actual.setting}, expected ${exp.setting}` };
+    }
+    if (actual.value !== exp.value) {
+      return { verdict: 'WRONG-MODEL', pass: false, rationale: `right setting (${actual.setting}) wrong value: got ${actual.value ?? '(empty)'}, expected ${exp.value}` };
+    }
+    return { verdict: 'TP-SETTING', pass: true, rationale: 'correct setting + value' };
+  }
+
+  // both kinds === 'provider'
+  if (exp.kind === 'provider' && actual.kind === 'provider') {
+    if (actual.scope !== exp.scope) {
+      return { verdict: 'WRONG-SCOPE', pass: false, rationale: `wrong scope: got ${actual.scope}, expected ${exp.scope}` };
+    }
+    const providerOk = actual.provider === exp.provider || (exp.providerAlternates ?? []).includes(actual.provider ?? '');
+    if (!providerOk) {
+      return { verdict: 'WRONG-PROVIDER', pass: false, rationale: `wrong provider: got ${actual.provider}, expected ${exp.provider}${exp.providerAlternates ? ` (or one of ${exp.providerAlternates.join(', ')})` : ''}` };
+    }
+    if (exp.model !== null) {
+      const allowedModels = [exp.model, ...(exp.modelAlternates ?? [])];
+      if (!actual.model || !allowedModels.includes(actual.model)) {
+        return { verdict: 'WRONG-MODEL', pass: false, rationale: `wrong model: got ${actual.model ?? '(empty)'}, expected one of [${allowedModels.join(', ')}]` };
+      }
+    } else if (actual.model && exp.modelAlternates && !exp.modelAlternates.includes(actual.model)) {
+      // expected.model === null. Any model (or none) is acceptable,
+      // unless modelAlternates is set and the actual doesn't match.
+      return { verdict: 'WRONG-MODEL', pass: false, rationale: `expected no specific model OR one of [${exp.modelAlternates.join(', ')}], got ${actual.model}` };
+    }
+    return { verdict: 'TP-PROVIDER', pass: true, rationale: `correct scope+provider${actual.model ? ' + model' : ''}` };
+  }
+
+  return { verdict: 'WRONG-KIND', pass: false, rationale: 'unreachable' };
+}
+
+function describeExpected(e: Expected): string {
+  if (e.kind === 'none') return 'NONE';
+  if (e.kind === 'setting') return `setting=${e.setting} value=${e.value}`;
+  return `provider scope=${e.scope} provider=${e.provider} model=${e.model ?? '(any)'}`;
+}
+
+function describeActual(a: ActualVerdict): string {
+  if (a.kind === 'none') return 'NONE';
+  if (a.kind === 'setting') return `setting=${a.setting} value=${a.value}`;
+  return `provider scope=${a.scope} provider=${a.provider} model=${a.model ?? '(empty)'}`;
+}

--- a/tests/benchmarks/fluid-config-switch-provider/run.ts
+++ b/tests/benchmarks/fluid-config-switch-provider/run.ts
@@ -1,0 +1,298 @@
+/**
+ * fluid-config switch-provider bench — entry point.
+ *
+ * Runs every case in cases.ts against the LIVE SYSTEM_PROMPT exported
+ * from packages/opencues-core/src/sources/config-intent-source.ts.
+ * Drift between bench prompt and shipped prompt is impossible — they
+ * are the same string.
+ *
+ * Two metrics:
+ *
+ *   PRECISION (gate) — among reject cases (kind='none'), % correctly
+ *                      classified. A false-positive is the security-
+ *                      relevant outcome (routing prose to a training
+ *                      pool, mis-routing a provider when user meant
+ *                      a lookup). Target ≥ 95%.
+ *   RECALL           — among hit cases (provider + setting), % where
+ *                      scope+provider (+ optionally model) match.
+ *                      Target ≥ 80%.
+ *
+ * Per-category breakdown shows where the prompt is fragile.
+ *
+ * Usage:
+ *   GROQ_API_KEY=xxx tsx tests/benchmarks/fluid-config-switch-provider/run.ts
+ *   GROQ_API_KEY=xxx tsx tests/benchmarks/fluid-config-switch-provider/run.ts --parallel 8
+ *   OPENCUES_BENCH_PROVIDER=cerebras CEREBRAS_API_KEY=xxx tsx ... --parallel 8
+ *   tsx ... --case po-cues-anthropic           # one case
+ *   tsx ... --category hit-provider-and-model  # one bucket
+ *   tsx ... --verbose                          # print raw LLM output per case
+ */
+
+import { CASES, SwitchProviderCase } from './cases';
+import { judge, Verdict, ActualVerdict } from './judge';
+import {
+  SYSTEM_PROMPT,
+  parseConfigIntentOutput,
+  validateAgainstRegistry,
+} from '../../../packages/opencues-core/src/sources/config-intent-source';
+import {
+  dispatchChat,
+  getProvider,
+  type ProviderAdapter,
+} from '../../../packages/opencues-core/src/llm-provider';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { NodeHttpAdapter } = require('../../../packages/opencues-core/node-http-adapter') as {
+  NodeHttpAdapter: new (opts?: { maxSockets?: number; timeout?: number }) => {
+    post: (url: string, body: string, headers?: Record<string, string>) => Promise<string>;
+  };
+};
+const httpAdapter = new NodeHttpAdapter({ maxSockets: 4, timeout: 30000 });
+
+const RESET = '\x1b[0m';
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const YELLOW = '\x1b[33m';
+const DIM = '\x1b[2m';
+const BOLD = '\x1b[1m';
+
+interface Args {
+  caseId?: string;
+  category?: string;
+  parallel: number;
+  verbose: boolean;
+}
+
+function parseArgs(): Args {
+  const out: Args = { parallel: 1, verbose: false };
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--case') out.caseId = args[++i];
+    else if (args[i] === '--category') out.category = args[++i];
+    else if (args[i] === '--verbose' || args[i] === '-v') out.verbose = true;
+    else if (args[i] === '--parallel') {
+      const v = parseInt(args[++i], 10);
+      if (Number.isNaN(v) || v < 1) {
+        console.error(`--parallel must be a positive integer, got: ${args[i]}`);
+        process.exit(2);
+      }
+      out.parallel = v;
+    }
+  }
+  return out;
+}
+
+function pickBenchProvider(): { provider: ProviderAdapter; apiKey: string; model: string } {
+  // Mirror tests/benchmarks/fluid-config/groq.ts shape but route by
+  // env var OPENCUES_BENCH_PROVIDER. Default: groq (matches our other
+  // bench defaults; cheapest free tier with decent throughput).
+  const envChoice = process.env.OPENCUES_BENCH_PROVIDER || 'groq';
+  const aliases: Record<string, string> = {
+    'cerebras-gpt-oss': 'cerebras',
+    'gemini-flash-lite': 'gemini',
+    'claude-haiku': 'anthropic',
+    'openai-nano': 'openai',
+  };
+  const providerId = aliases[envChoice] ?? envChoice;
+  const provider = getProvider(providerId);
+  if (!provider) {
+    console.error(`Unknown OPENCUES_BENCH_PROVIDER=${envChoice}; expected one of: groq, cerebras, anthropic, gemini, openai`);
+    process.exit(2);
+  }
+  const apiKey = provider.envKeyName ? process.env[provider.envKeyName] : '';
+  if (!apiKey && !provider.optionalAuth && provider.transport !== 'cli') {
+    console.error(`${provider.envKeyName} unset — needed for provider '${providerId}'`);
+    process.exit(2);
+  }
+  return { provider, apiKey: apiKey ?? '', model: provider.defaultModel };
+}
+
+interface RunOutcome {
+  caseId: string;
+  category: string;
+  input: string;
+  raw: string;
+  actual: ActualVerdict;
+  judge: ReturnType<typeof judge>;
+  latencyMs: number;
+}
+
+async function runOne(c: SwitchProviderCase, ctx: ReturnType<typeof pickBenchProvider>): Promise<RunOutcome> {
+  const t0 = Date.now();
+  let raw = '';
+  try {
+    raw = await dispatchChat(
+      ctx.provider,
+      httpAdapter,
+      {
+        model: ctx.model,
+        messages: [
+          { role: 'system', content: SYSTEM_PROMPT },
+          { role: 'user', content: `INPUT: ${c.input}` },
+        ],
+        maxTokens: 256,
+        temperature: 0,
+        seed: 42,
+      },
+      { apiKey: ctx.apiKey },
+    );
+  } catch (e) {
+    const latencyMs = Date.now() - t0;
+    const actual: ActualVerdict = { kind: 'none' };
+    return {
+      caseId: c.id,
+      category: c.category,
+      input: c.input,
+      raw: `[LLM ERROR] ${(e as Error).message}`,
+      actual,
+      judge: judge(c, actual),
+      latencyMs,
+    };
+  }
+  const latencyMs = Date.now() - t0;
+
+  const parsed = parseConfigIntentOutput(raw);
+  const check = validateAgainstRegistry(parsed);
+
+  // For bench judging purposes, an invalid-but-non-none verdict
+  // counts as NONE (the runtime would cede). This matches what the
+  // user actually experiences.
+  let actual: ActualVerdict;
+  if (!check.ok) {
+    actual = { kind: 'none' };
+  } else if (parsed.kind === 'none') {
+    actual = { kind: 'none' };
+  } else if (parsed.kind === 'setting') {
+    actual = { kind: 'setting', setting: parsed.setting, value: parsed.value };
+  } else {
+    actual = {
+      kind: 'provider',
+      scope: parsed.scope,
+      provider: parsed.provider,
+      model: parsed.model,
+    };
+  }
+
+  return {
+    caseId: c.id,
+    category: c.category,
+    input: c.input,
+    raw,
+    actual,
+    judge: judge(c, actual),
+    latencyMs,
+  };
+}
+
+async function runAll(cases: SwitchProviderCase[], ctx: ReturnType<typeof pickBenchProvider>, parallel: number, verbose: boolean): Promise<RunOutcome[]> {
+  const outcomes: RunOutcome[] = new Array(cases.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const i = next++;
+      if (i >= cases.length) return;
+      outcomes[i] = await runOne(cases[i], ctx);
+      printOneLine(outcomes[i], verbose);
+    }
+  }
+  await Promise.all(Array.from({ length: parallel }, () => worker()));
+  return outcomes;
+}
+
+function printOneLine(o: RunOutcome, verbose: boolean): void {
+  const v = o.judge.verdict;
+  const color = o.judge.pass ? GREEN : (v === 'FP' ? RED : YELLOW);
+  const tag = `${color}${BOLD}${v.padEnd(14)}${RESET}`;
+  console.log(`${tag} ${DIM}${o.caseId.padEnd(34)}${RESET} ${o.input}`);
+  if (!o.judge.pass) {
+    console.log(`               ${DIM}${o.judge.rationale}${RESET}`);
+  }
+  if (verbose) {
+    console.log(`               ${DIM}raw: ${o.raw.replace(/\n/g, ' ⏎ ').slice(0, 200)}${RESET}`);
+  }
+}
+
+function summarise(outcomes: RunOutcome[]): void {
+  console.log('');
+  console.log(`${BOLD}── Results ──${RESET}`);
+
+  const verdictCounts: Record<string, number> = {};
+  for (const o of outcomes) {
+    verdictCounts[o.judge.verdict] = (verdictCounts[o.judge.verdict] ?? 0) + 1;
+  }
+
+  // Hit / reject metrics
+  const rejects = outcomes.filter(o => {
+    const c = CASES.find(cc => cc.id === o.caseId)!;
+    return c.expected.kind === 'none';
+  });
+  const hits = outcomes.filter(o => {
+    const c = CASES.find(cc => cc.id === o.caseId)!;
+    return c.expected.kind !== 'none';
+  });
+  const tn = rejects.filter(o => o.judge.verdict === 'TN').length;
+  const tp = hits.filter(o => o.judge.pass).length;
+  const fp = rejects.filter(o => o.judge.verdict === 'FP').length;
+
+  const precision = rejects.length === 0 ? 100 : (tn / rejects.length) * 100;
+  const recall = hits.length === 0 ? 100 : (tp / hits.length) * 100;
+
+  console.log(`${BOLD}Precision${RESET}: ${precision.toFixed(1)}%  ${DIM}(${tn}/${rejects.length} rejects correctly classified)${RESET}`);
+  console.log(`${BOLD}Recall${RESET}:    ${recall.toFixed(1)}%  ${DIM}(${tp}/${hits.length} hits correctly classified)${RESET}`);
+  console.log(`${BOLD}FP${RESET} (security-critical): ${fp === 0 ? GREEN : RED}${fp}${RESET}`);
+
+  console.log('');
+  console.log(`${BOLD}Per-verdict counts:${RESET}`);
+  for (const v of ['TP-PROVIDER', 'TP-SETTING', 'TN', 'FN', 'FP', 'WRONG-KIND', 'WRONG-SCOPE', 'WRONG-PROVIDER', 'WRONG-MODEL'] as Verdict[]) {
+    const n = verdictCounts[v] ?? 0;
+    if (n === 0) continue;
+    console.log(`  ${v.padEnd(14)} ${n}`);
+  }
+
+  // Per-category breakdown
+  console.log('');
+  console.log(`${BOLD}Per-category:${RESET}`);
+  const categories = [...new Set(outcomes.map(o => o.category))].sort();
+  for (const cat of categories) {
+    const byCat = outcomes.filter(o => o.category === cat);
+    const passed = byCat.filter(o => o.judge.pass).length;
+    const pct = (passed / byCat.length) * 100;
+    const col = pct >= 80 ? GREEN : pct >= 60 ? YELLOW : RED;
+    console.log(`  ${col}${pct.toFixed(0).padStart(3)}%${RESET} ${cat.padEnd(28)} ${DIM}${passed}/${byCat.length}${RESET}`);
+  }
+
+  // Per-case latency summary
+  const latencies = outcomes.map(o => o.latencyMs).sort((a, b) => a - b);
+  const p50 = latencies[Math.floor(latencies.length * 0.5)];
+  const p95 = latencies[Math.floor(latencies.length * 0.95)];
+  console.log('');
+  console.log(`${DIM}Latency: p50 ${p50}ms · p95 ${p95}ms${RESET}`);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs();
+  const ctx = pickBenchProvider();
+
+  let cases = CASES;
+  if (args.caseId) cases = cases.filter(c => c.id === args.caseId);
+  if (args.category) cases = cases.filter(c => c.category === args.category);
+  if (cases.length === 0) {
+    console.error('no cases matched the filter');
+    process.exit(2);
+  }
+
+  console.log(`${BOLD}fluid-config switch-provider bench${RESET}`);
+  console.log(`${DIM}provider: ${ctx.provider.id} · model: ${ctx.model} · cases: ${cases.length} · parallel: ${args.parallel}${RESET}`);
+  console.log('');
+
+  const outcomes = await runAll(cases, ctx, args.parallel, args.verbose);
+  summarise(outcomes);
+
+  const failed = outcomes.filter(o => !o.judge.pass).length;
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('bench crashed:', e);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Extend the fluid-config classifier (when \`fluid-config-mode: on\`) so users can change which LLM provider — and optionally which model — runs on a bucket through natural language at the \`_\` surface:

\`\`\`
use anthropic for cues _              → cues-llm-provider: anthropic
switch the blanks brain to cerebras _ → blanks-llm-provider: cerebras
use claude opus for auditors _        → auditors-llm-provider: anthropic
                                        auditors-llm-model: claude-opus-4-7
route everything to gemini _          → cues-llm-provider: gemini  (cues = default brain)
\`\`\`

Bounded codomain: classifier may only route to ProviderId entries and (when a model is named) each provider's curated \`knownModels\` list. Power users can still pin any model string by editing OPENCUES.md directly.

## What's in the diff

- **\`ProviderAdapter\` gains \`knownModels: readonly string[]\`** (optional, 2-5 entries per provider, bench-validated picks across the common cheap-fast / balanced / deep-reasoning tiers).
- **\`ConfigIntentVerdict\` becomes a discriminated union** (\`setting\` | \`provider\` | \`none\`); parser handles both INTENT-prefixed (new) and legacy SETTING-only (back-compat) shapes.
- **\`SYSTEM_PROMPT\` rewrite** — three intents (SETTING / PROVIDER / NONE) with shared INTENT/SCOPE/PROVIDER/MODEL output format. Examples block reflects every routing path.
- **\`validateAgainstRegistry\` extension** — enforces scope ∈ {cues, auditors, blanks}, provider ∈ ProviderId, model ∈ provider.knownModels, AND the trust-class guard (opencode-zen refused on cues/auditors — mirrors the resolver's trainsOnInput refusal so fluid-config can't reach what the resolver would reject anyway).
- **Apply path** writes one or two scalars via \`applyOpenCuesScalar\` (its existing 2.5s reload-suppression covers both writes atomically).
- **Emission shape** is the selector-satellite the runtime already understands: selector = bucket scalar (which IS a FEATURES entry, so the satellite cycles the FEATURES values list directly), satellite = provider id. No new UI primitive needed.
- **\`docs/architecture/llm-routing.md\`** extended with the natural-language switching section + adding-a-model how-to.

## Trust boundary

The classifier's choice space is bounded at three layers:

1. **Prompt** — only lists registered providers + curated knownModels.
2. **Validator** — rejects anything outside the registries, plus the trust-class guard.
3. **Apply path** — only invokes \`applyOpenCuesScalar\` which writes to OPENCUES.md (no exec, no fetch, no out-of-band side-effects).

If a user (or compromised pack) tried to inject \`use {attacker provider} for cues _\` through the LLM's output, the validator's \`getProvider\` lookup rejects unknown ids before any write fires.

## Test plan
- [x] 17 new tests (parser, validator, scenario) — all pass.
- [x] All 658 \`@opencues/core\` tests pass.
- [x] All 1404 \`@opencues/runtime\` tests pass.
- [ ] Bench: \`tests/benchmarks/fluid-config-switch-provider/\` would validate cross-provider classifier accuracy on a ~30-case suite. Deferred to a follow-up; today's unit tests pin parser + validator + apply behaviour.
- [ ] Manual: \`use anthropic for cues _\` in a patched CC / chrome session writes the scalar AND emits the selector-satellite UI for cycling.

## Follow-ups (out of scope)

- Bench scaffold at \`tests/benchmarks/fluid-config-switch-provider/\`.
- Triple-satellite UI for cycling \`{provider, model}\` chained after a provider switch (today the satellite cycles providers only; users who want a different model after switching still go through the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)