### PR TITLE
feat(fluid-config): bare provider switches default to blanks bucket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,7 +564,7 @@ done
 |---|---|---|---|
 | `SPEC.md` (open-standard) | `cues-spec` | 0.1 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
-| `packages/opencues-core/` | `@opencues/core` | 0.1.2 | private |
+| `packages/opencues-core/` | `@opencues/core` | 0.1.3 | private |
 | `packages/opencues-runtime/` | `@opencues/runtime` | 0.1.2 | private |
 | `packages/opencues-cli/` | `opencues` (real CLI) | 0.1.3 | private |
 | `packages/opencues-park/` | `opencues` (placeholder) | 0.0.1 | **PUBLISHED on npm** |

--- a/docs/architecture/llm-routing.md
+++ b/docs/architecture/llm-routing.md
@@ -102,7 +102,9 @@ use anthropic for cues _              → cues-llm-provider: anthropic
 switch the blanks brain to cerebras _ → blanks-llm-provider: cerebras
 use claude opus for auditors _        → auditors-llm-provider: anthropic
                                         auditors-llm-model: claude-opus-4-7
-route everything to gemini _          → cues-llm-provider: gemini   (cues = default brain)
+route everything to gemini _          → blanks-llm-provider: gemini (blanks = default scope)
+switch to anthropic _                 → blanks-llm-provider: anthropic
+use cerebras _                        → blanks-llm-provider: cerebras
 ```
 
 ### What the classifier may emit

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/config-intent-source.test.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.test.ts
@@ -148,13 +148,16 @@ describe('parseConfigIntentOutput', () => {
     }
   });
 
-  it('defaults SCOPE to cues when classifier omitted it but provider is present', () => {
+  it('defaults SCOPE to blanks when classifier omitted it but provider is present', () => {
+    // Bare phrases like "switch to anthropic _" route to the blanks
+    // bucket — the user-opt-in `_` surface is the most likely target
+    // of a bucket-less provider switch.
     const v = parseConfigIntentOutput(
       'INTENT: PROVIDER\nSCOPE:\nPROVIDER: gemini\nMODEL:\nCONFIDENCE: 0.7',
     );
     assert.strictEqual(v.kind, 'provider');
     if (v.kind === 'provider') {
-      assert.strictEqual(v.scope, 'cues');
+      assert.strictEqual(v.scope, 'blanks');
     }
   });
 

--- a/packages/opencues-core/src/sources/config-intent-source.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.ts
@@ -150,7 +150,7 @@ ${PROVIDER_REGISTRY_BLOCK}
 
 ROUTE TO PROVIDER when:
   - The user names a provider ("anthropic", "groq", "cerebras", "openai", "gemini", "claude") OR a model name from the lists above.
-  - AND names a scope ("for cues", "for blanks", "for auditors", "globally"/"everywhere") OR is generic ("switch to X" → MODEL: empty, SCOPE: cues as the default brain).
+  - AND names a scope ("for cues", "for blanks", "for auditors", "globally"/"everywhere") OR is generic ("switch to X" → MODEL: empty, SCOPE: blanks as the default — blanks is the user-opt-in \`_\` surface that a bare provider switch most likely targets).
 
 SCOPE rules:
   - "for cues" / "word cues" / "sentence cues" / "general" / "everywhere" / "globally" → cues
@@ -287,10 +287,28 @@ INPUT: route everything to gemini _
 INTENT: PROVIDER
 SETTING:
 VALUE:
-SCOPE: cues
+SCOPE: blanks
 PROVIDER: gemini
 MODEL:
 CONFIDENCE: 0.8
+
+INPUT: switch to anthropic _
+INTENT: PROVIDER
+SETTING:
+VALUE:
+SCOPE: blanks
+PROVIDER: anthropic
+MODEL:
+CONFIDENCE: 0.85
+
+INPUT: use cerebras _
+INTENT: PROVIDER
+SETTING:
+VALUE:
+SCOPE: blanks
+PROVIDER: cerebras
+MODEL:
+CONFIDENCE: 0.85
 
 INPUT: switch cues to a model that does not exist _
 INTENT: NONE
@@ -421,12 +439,13 @@ export function parseConfigIntentOutput(raw: string): ConfigIntentVerdict {
     if (!providerRaw || providerRaw.toUpperCase() === 'NONE') {
       return { kind: 'none', confidence };
     }
-    // Normalise scope; default to 'cues' when the classifier omitted it
-    // ("switch to anthropic _" with no explicit scope routes to the
-    // primary brain). Validator will reject unknown scope literals.
+    // Normalise scope; default to 'blanks' when the classifier omitted
+    // it ("switch to anthropic _" with no explicit scope routes to the
+    // user-opt-in `_` surface — that's the most likely target for a
+    // bare provider switch). Validator will reject unknown scope literals.
     const scope: BucketScope = (BUCKET_SCOPES as readonly string[]).includes(scopeRaw)
       ? (scopeRaw as BucketScope)
-      : 'cues';
+      : 'blanks';
     return {
       kind: 'provider',
       scope,

--- a/tests/benchmarks/fluid-config-switch-provider/cases.ts
+++ b/tests/benchmarks/fluid-config-switch-provider/cases.ts
@@ -83,12 +83,28 @@ export const CASES: SwitchProviderCase[] = [
     input: 'make cues use gemini _',
     expected: { kind: 'provider', scope: 'cues', provider: 'gemini', model: null } },
 
-  { id: 'po-everything-default-cues',
+  { id: 'po-everything-default-blanks',
     category: 'hit-provider-only',
-    // "everything" / "globally" should land on cues (the prompt
-    // documents cues as the default brain when no explicit scope).
+    // "everything" / "globally" / bare phrases default to the blanks
+    // bucket — the user-opt-in `_` surface is the most likely target
+    // for a bucket-less provider switch.
     input: 'route everything to gemini _',
-    expected: { kind: 'provider', scope: 'cues', provider: 'gemini', model: null } },
+    expected: { kind: 'provider', scope: 'blanks', provider: 'gemini', model: null } },
+
+  { id: 'po-bare-switch-to-anthropic',
+    category: 'hit-provider-only',
+    input: 'switch to anthropic _',
+    expected: { kind: 'provider', scope: 'blanks', provider: 'anthropic', model: null } },
+
+  { id: 'po-bare-use-cerebras',
+    category: 'hit-provider-only',
+    input: 'use cerebras _',
+    expected: { kind: 'provider', scope: 'blanks', provider: 'cerebras', model: null } },
+
+  { id: 'po-bare-switch-to-gemini',
+    category: 'hit-provider-only',
+    input: 'switch to gemini _',
+    expected: { kind: 'provider', scope: 'blanks', provider: 'gemini', model: null } },
 
   { id: 'po-blanks-fluid-keyword',
     category: 'hit-provider-only',


### PR DESCRIPTION
## Summary

When the fluid-config classifier hits a provider intent without an explicit scope (\`switch to anthropic _\`, \`use cerebras _\`, \`route everything to gemini _\`), it now writes the **blanks** bucket instead of cues.

\`\`\`
switch to anthropic _   → blanks-llm-provider: anthropic
use cerebras _          → blanks-llm-provider: cerebras
route everything to gemini _ → blanks-llm-provider: gemini
\`\`\`

Cues and auditors still require explicit scope:
\`\`\`
use anthropic for cues _       → cues-llm-provider: anthropic
use claude opus for auditors _ → auditors-llm-provider: anthropic + auditors-llm-model: claude-opus-4-7
\`\`\`

## Why

Blanks is the user-opt-in \`_\` surface — the bucket most likely targeted by a bucket-less provider switch. Cues + auditors fire automatically; users intentionally pin those when they care. A bare phrase at the \`_\` surface expresses "change what the \`_\` thing uses," not "change the background brain."

## What changed

- SYSTEM_PROMPT: bare default rule updated; three in-prompt examples pin the behaviour.
- parseConfigIntentOutput: scope fallback when classifier omits SCOPE is now 'blanks' (was 'cues').
- Unit test updated.
- Bench: 3 new bare-phrase cases + the existing \`route everything\` case retargeted. **33 cases, 100% precision, 100% recall, 0 FP on Groq + gpt-oss-120b.**
- docs/architecture/llm-routing.md updated.

Bumps @opencues/core to 0.1.3.

## Test plan
- [x] Bench at 100% precision/recall/0 FP.
- [x] All 117 core tests pass.
- [ ] After merge: rebuild every fork so the bundled @opencues/core picks up the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)