### PR TITLE
fix(resolver): await disk write in applyOpencuesScalar to serialise back-to-back calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -565,7 +565,7 @@ done
 | `SPEC.md` (open-standard) | `cues-spec` | 0.1 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
 | `packages/opencues-core/` | `@opencues/core` | 0.1.3 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.1.2 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.1.3 | private |
 | `packages/opencues-cli/` | `opencues` (real CLI) | 0.1.3 | private |
 | `packages/opencues-park/` | `opencues` (placeholder) | 0.0.1 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.1.1 | private |

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -514,12 +514,18 @@ export class Resolver {
       //      inactive). Cycling's path always pairs the in-memory
       //      update with a `set` invocation; ConfigIntent was missing
       //      the second half.
-      applyOpencuesScalar: (setting: string, value: string) => {
+      applyOpencuesScalar: async (setting: string, value: string) => {
         this.configLoader.applyOpenCuesScalar(setting, value);
-        // Fire-and-forget the file write via the opencues blank's
-        // script. Looked up at call time so a missing blank entry
-        // (degraded install) degrades gracefully — the in-memory
-        // flip still takes effect, just with no persistence.
+        // Await the file write so back-to-back applyScalar calls (e.g.
+        // ConfigIntent's provider-verdict apply path that writes
+        // `<scope>-llm-provider` AND `<scope>-llm-model` sequentially)
+        // serialise on disk. Pre-2026-05 this was fire-and-forget,
+        // which caused a race where the SECOND apply's read-modify-
+        // write would see the file BEFORE the FIRST apply's write
+        // landed — final file had only one of the two scalars.
+        // Looked up at call time so a missing blank entry (degraded
+        // install) degrades gracefully — the in-memory flip still
+        // takes effect, just without persistence.
         const oc = this.configLoader.lookupBlank('opencues');
         const scriptPath = oc?.blank.blankScript;
         if (!scriptPath && !this.adapter.blankInvoke) return;
@@ -530,15 +536,16 @@ export class Resolver {
             args: [setting, value],
             timeoutMs: 4000,
           });
-          if (native) return;
+          if (native) { await native.result; return; }
           if (!scriptPath) return;
           if (!this.adapter.capabilities.includes('spawn-process')) return;
-          this.adapter.spawnProcess({
+          const proc = this.adapter.spawnProcess({
             command: 'bash',
             args: [scriptPath, 'set', setting, value],
             detached: true,
             timeoutMs: 4000,
           });
+          if (proc) await proc.result;
         } catch (err) {
           this.adapter.log('error', `ConfigIntent: file write failed for ${setting}=${value}`, err);
         }


### PR DESCRIPTION
## Summary

ConfigIntent's provider-verdict path writes two scalars sequentially (\`<scope>-llm-provider\`, then \`<scope>-llm-model\`). Each write hops through the resolver's \`applyOpencuesScalar\` callback, which did:

1. update in-memory state (sync)
2. fire-and-forget the disk write via \`blankInvoke\` / \`spawnProcess\`

Step 2 returning without awaiting meant two back-to-back \`applyScalar\` invocations raced on disk read-modify-write.

**Observed failure**: \`use claude opus for auditors _\` wrote \`auditors-llm-model: claude-opus-4-7\` but \`auditors-llm-provider\` stayed at the pre-existing \`inherit\` value because the second invocation's read happened before the first invocation's write landed.

## Fix

Await the \`ProcessHandle.result\` from \`blankInvoke\` / \`spawnProcess\` so the second apply doesn't start its read until the first's write is durable.

- Single-write callers (cycling.ts satellite cycling, \`enable debug logging _\` setting flips) see one extra await tick before the result paint — negligible.
- Multi-write callers (fluid-config's provider+model verdicts) now reliably write both scalars.

## Test plan
- [x] All 1404 \`@opencues/runtime\` tests pass.
- [x] Manual end-to-end against a live opencode session: \`use claude opus for auditors _\` writes both \`auditors-llm-provider: anthropic\` and \`auditors-llm-model: claude-opus-4-7\` 100% of the time; previously the second scalar would clobber.

Bumps \`@opencues/runtime\` to 0.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)