### PR TITLE
chore(cc): test 2.1.158 — append to compat.tested, add fork row

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Two Claude Code installs exist on this machine. **OpenCues work targets `claude-
 |---|---|---|---|
 | `claude-cues` | `~/claude-code-cues` (local npm) | 2.1.110 (cli.js, pegged) | OpenCues patches applied here — npm cli.js shape |
 | `claude-cues-150` | `~/claude-code-cues-150` (local npm) | 2.1.150 (native bun-binary) | OpenCues patches applied here — native-binary shape (post-2.1.113 cutover) |
+| `claude-cues-158` | `~/claude-code-cues-158` (local npm) | 2.1.158 (native bun-binary) | OpenCues patches applied here — latest tested, same v2.1 adapter band as 150 (all 4 seams S1/S2/S3/S7 still hit) |
 | `claude` | `~/.local/bin/claude` (native) | latest | Clean/unpatched — development use |
 
 - Both `claude-cues` and `claude-cues-150` are patched instances. `setup.sh` targets the cli.js fork; the native-binary fork is patched via tweakcc 4.0.13+'s `.bun` ELF section extract/repack.

--- a/integrations/claude-code/compat.json
+++ b/integrations/claude-code/compat.json
@@ -9,7 +9,7 @@
     "field": "dependencies.@anthropic-ai/claude-code",
     "fork-default": "~/claude-code-cues"
   },
-  "tested": ["2.1.110", "2.1.150"],
+  "tested": ["2.1.110", "2.1.150", "2.1.158"],
   "compat-range": "2.1.x",
   "//notes": {
     "binary-cutover": "2.1.113 (not 2.1.119 — that was an earlier guess). From 2.1.113 onward, @anthropic-ai/claude-code ships a thin Node wrapper + a bun-compile native binary in @anthropic-ai/claude-code-<platform>. Tweakcc 4.0.13+ extracts cli.js from the binary's .bun ELF section, patches the text, and repacks (handles ELF/MachO/PE). Same tweakcc anchor regexes work on both formats; the cli.js text inside the .bun section runs unchanged at startup (bun honours text over its own precompiled bytecode).",


### PR DESCRIPTION
## Summary

Same-minor bump from current pin 2.1.150. Seam probe against the binary-extracted cli.js confirms all four anchors v2.1 relies on:

| Seam | 2.1.158 |
|---|---|
| S1 KeyDispatcher | ✓ \`function wH(WH,EH){switch(WH.name){case"escape":...}\` |
| S2 InputStateHandler | ✓ \`function f48({value:H,onChange:$,...\` |
| S3 RenderedValue | ✓ \`renderedValue:U.render(\` |
| S7 RenderKick | ✓ \`function X48({inputState:H,...\` |
| S6 StatusLineRefresh | missing (same as 2.1.150 — falls back to polling) |

No adapter band changes — \`cc/v2.1\` covers 2.1.150 and 2.1.158.

## End-to-end validation

Drove a live 2.1.158 fork via PTY through three fluid-config provider switches:

| Input | Expected scalars written | Log signal |
|---|---|---|
| \`switch to anthropic _\` (bare → blanks default) | \`blanks-llm-provider: anthropic\` | \`[cc] applied blanks → anthropic (581ms)\` |
| \`use cerebras for cues _\` (explicit scope) | \`cues-llm-provider: cerebras\` | \`[cc] applied cues → cerebras (1148ms)\` |
| \`use claude opus for auditors _\` (dual write) | \`auditors-llm-provider: anthropic\` AND \`auditors-llm-model: claude-opus-4-7\` | \`[cc] applied auditors → anthropic · claude-opus-4-7 (1967ms)\` |

PR #25's apply-scalar race fix verified on 158 — both auditors scalars land 100% of the time.

## Why current-pin stays at 2.1.150

\`current-pin\` controls what \`opencues install claude-code\` defaults to for new users. Flipping it makes 2.1.158 the default before broader real-session use surfaces any unanticipated regression. Add to \`tested\` first; promote to \`current-pin\` in a follow-up.

## Test plan
- [x] Seam probe HIT all four anchors v2.1 needs.
- [x] \`setup.sh\` against \`~/claude-code-cues-158/\` completed without errors.
- [x] Binary boots: \`claude.exe --version\` → \`2.1.158 (Claude Code)\`.
- [x] PTY launcher arms the bridge; ConfigLoader + Resolver wire correctly.
- [x] All three scenario steps PASS end-to-end with \`[cc]\`-prefixed log lines confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)