### PR TITLE
fix(update): export isTested + isKnownIncompatible from compatLib

### DIFF
--- a/packages/opencues-cli/src/lib/compat.cjs
+++ b/packages/opencues-cli/src/lib/compat.cjs
@@ -186,6 +186,8 @@ module.exports = {
   semverCompare,
   matchesRange,
   classifyVersion,
+  isTested,
+  isKnownIncompatible,
   readNpmPin,
   readGitPin,
   writeGitPin,


### PR DESCRIPTION
## Summary

\`opencues update <host> --to <ver>\` crashed AFTER a successful pin update + reinstall, in the post-install hint path that suggests adding the version to \`compat.tested\` when it isn't already there:

\`\`\`
🗸 claude-code now pinned at 2.1.158 and installed.
opencues update: TypeError: compatLib.isTested is not a function
\`\`\`

The \`isTested\` function existed in \`packages/opencues-cli/src/lib/compat.cjs\` but wasn't in its \`module.exports\` block. The host had already pinned + installed by the time the crash hit, so the user impact is just the confusing stack — but it's an actual upgrade-path regression.

Also exporting \`isKnownIncompatible\` here — same shape, equally callable externally.

## Test plan
- [x] Re-running \`opencues update claude-code --to 2.1.158\` on a fork already at 2.1.158 now exits cleanly with the success line, no trailing stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)