### PR TITLE
fix(update): close SIGINT race that orphans the update lock

### DIFF
--- a/packages/opencues-cli/src/commands/update.cjs
+++ b/packages/opencues-cli/src/commands/update.cjs
@@ -143,13 +143,28 @@ async function doUpdate(host, { skipPull, dryRun }, ctx) {
   // Detect concurrent runs. Two opencues update invocations racing the
   // same fork = half-patched cli.js + corrupt bundled runtime. We lock
   // before printing the plan; rejected races exit cleanly with a hint.
-  const lock = acquireLock();
+  //
+  // Signal handlers are wired BEFORE acquireLock writes the file — the
+  // earlier ordering (handlers registered AFTER acquireLock) had a
+  // microsecond race where a SIGINT arriving between the file write and
+  // the handler registration would land on Node's default handler
+  // (terminate by signal), leaving the lock file orphaned. The lock var
+  // is closed over and read lazily, so signals received before the lock
+  // is captured see `null` and just exit cleanly.
+  let lock = null;
+  process.on('exit',    () => { if (lock) releaseLock(lock); });
+  process.on('SIGINT',  () => { if (lock) releaseLock(lock); process.exit(130); });
+  process.on('SIGTERM', () => { if (lock) releaseLock(lock); process.exit(143); });
+
+  // Test hook: tests inject a delay BETWEEN handler registration and
+  // acquireLock to deterministically exercise the race window. Without
+  // this hook, the race only fires on slow CI runners (microsecond
+  // window). Production never sets either env var.
+  const preLockHangMs = parseInt(process.env.OPENCUES_UPDATE_TEST_PRE_LOCK_HANG_MS || '0', 10);
+  if (preLockHangMs > 0) await new Promise(r => setTimeout(r, preLockHangMs));
+
+  lock = acquireLock();
   if (!lock) return;          // process exited inside acquireLock with a message
-  // Release on every exit path. Lock-file content is the PID + start
-  // time so a stale lock from a crashed run can be diagnosed.
-  process.on('exit', () => releaseLock(lock));
-  process.on('SIGINT', () => { releaseLock(lock); process.exit(130); });
-  process.on('SIGTERM', () => { releaseLock(lock); process.exit(143); });
 
   // Test hook: integration tests need an interruptible window in which
   // the lock exists to verify SIGINT cleanup. Production never sets

--- a/packages/opencues-cli/src/commands/update.integration.test.cjs
+++ b/packages/opencues-cli/src/commands/update.integration.test.cjs
@@ -153,6 +153,62 @@ test('SIGINT during update releases the lock', async () => {
   fs.rmSync(home, { recursive: true, force: true });
 });
 
+test('SIGINT arriving in the handler-register window releases the lock — regression for CI race', async () => {
+  // Regression test for a race in update.cjs where the SIGINT/SIGTERM
+  // handlers were registered AFTER acquireLock wrote the lockfile.
+  // A SIGINT arriving in that microsecond window would fall to Node's
+  // default handler (terminate by signal), leaving the lockfile
+  // orphaned. Observed on CI run 26712395507 against master 63d83b1.
+  //
+  // Deterministic reproduction via `OPENCUES_UPDATE_TEST_PRE_LOCK_HANG_MS`:
+  // injects a 200ms gap between handler registration and acquireLock.
+  // We wait for the JS to start (gap window opens), then SIGINT into
+  // the window. With handlers correctly registered FIRST, the SIGINT
+  // handler sees `lock === null`, runs `process.exit(130)` cleanly,
+  // and the lockfile never gets created. Without the fix, the SIGINT
+  // arrives before the handler exists, Node terminates by signal, and
+  // the test fails on a non-zero exitCode.
+  const home = freshHome('sigint-race-window');
+  const lockFile = path.join(home, '.opencues', '.update.lock');
+
+  const child = spawn('node', [CLI_BIN, 'update', '--dry-run', '--no-pull'], {
+    env: {
+      ...process.env,
+      HOME: home,
+      OPENCUES_NO_UPDATE_CHECK: '1',
+      // 200ms gap between handler registration and acquireLock — the
+      // window in which signals must already be handled.
+      OPENCUES_UPDATE_TEST_PRE_LOCK_HANG_MS: '200',
+    },
+    stdio: 'pipe',
+  });
+
+  // 50ms is solidly inside the 200ms gap. Long enough for child to
+  // start the JS + register handlers (~10ms), well before acquireLock.
+  await new Promise(r => setTimeout(r, 50));
+  child.kill('SIGINT');
+  await new Promise(r => child.once('exit', r));
+
+  // With the fix: handler ran, exit code 130, no lockfile written.
+  // Without the fix: signal killed Node before handler attached,
+  // exitCode null and lockfile may or may not exist (it never got
+  // written either way because acquireLock hadn't been called) —
+  // but we assert exit code 130 to prove the handler RAN.
+  assert.strictEqual(
+    child.exitCode,
+    130,
+    `SIGINT handler must run cleanly (exit 130); got exitCode=${child.exitCode}, signal=${child.signalCode}. ` +
+      `Handlers must be registered BEFORE acquireLock — see update.cjs near line 146.`,
+  );
+  assert.strictEqual(
+    fs.existsSync(lockFile),
+    false,
+    'lockfile must not exist after SIGINT inside the pre-lock window',
+  );
+
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
 test('--dry-run prints a plan without touching the workspace', () => {
   const home = freshHome('dryrun');
   const res = spawnSync('node', [CLI_BIN, 'update', '--dry-run', '--no-pull'], {


### PR DESCRIPTION
## Summary

Closes the microsecond race in `opencues update` where a SIGINT arriving between `acquireLock` writing the lockfile and the SIGINT handler being registered would fall to Node's default behaviour (terminate by signal). The process died without running `releaseLock`, leaving `~/.opencues/.update.lock` orphaned and blocking subsequent runs.

Observed on master in CI run [26712395507](https://github.com/opencues/opencues/actions/runs/26712395507) (commit `63d83b1`). The existing SIGINT test's error message — `child exit code: null` — is the signature of "killed by signal before any handler ran", not a flake.

## The race (before)

```js
const lock = acquireLock();                         // writes lockfile
if (!lock) return;
process.on('exit',    () => releaseLock(lock));     // ← race window
process.on('SIGINT',  () => { releaseLock(lock); process.exit(130); });
process.on('SIGTERM', () => { releaseLock(lock); process.exit(143); });
```

A SIGINT arriving in the gap between `acquireLock` returning and `process.on('SIGINT')` running falls to Node's default handler. Default for SIGINT on Node is "terminate by signal" — no exit code, no handler, no `releaseLock`.

## The fix

Hoist signal handlers BEFORE `acquireLock`. The `lock` variable is captured by closure and assigned afterward; signals received before the assignment see `null` and exit cleanly without trying to release.

```js
let lock = null;
process.on('exit',    () => { if (lock) releaseLock(lock); });
process.on('SIGINT',  () => { if (lock) releaseLock(lock); process.exit(130); });
process.on('SIGTERM', () => { if (lock) releaseLock(lock); process.exit(143); });

lock = acquireLock();
if (!lock) return;
```

## Deterministic regression test

A pre-existing test (`SIGINT during update releases the lock`) is stochastic — it relies on the race actually firing, which only happens under CI load (microsecond window). The new test makes it deterministic:

- Adds an `OPENCUES_UPDATE_TEST_PRE_LOCK_HANG_MS` test hook that injects a 200ms delay BETWEEN the handler-registration site and `acquireLock`.
- Spawns the child, waits 50ms (well into the gap), sends SIGINT.
- Asserts `exitCode === 130` (proves the handler ran) AND lockfile absent.

**Verified the test deterministically catches the bug**: with handlers registered AFTER `acquireLock`, the test fails reliably every run (exit by signal, exitCode null). With the fix, it passes every run.

## Test plan

- [x] `node --test packages/opencues-cli/src/commands/update.integration.test.cjs` — 6 pass, 0 fail
- [x] Full CLI suite: 60 pass, 0 fail
- [x] Reverted the fix locally → new regression test fails deterministically with the expected `exitCode=null` symptom
- [x] Restored the fix → test passes deterministically

🤖 Generated with [Claude Code](https://claude.com/claude-code)