### PR TITLE
feat(sentinel): keyword-bound `set sentinel _` / `remove sentinel _` blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **0.1.2 → 0.1.3**: Bare provider switches default to the **blanks** bucket. `"switch to anthropic _"` now writes `blanks-llm-provider: anthropic` (was `cues-llm-provider`). Cues and auditors require explicit scope; rationale: blanks is the user-opt-in `_` surface most likely targeted by a bucket-less phrase.
 - **0.1.3 → 0.1.4** (PR #32 — Sentinels infrastructure): TransformBlankSource now consumes the SENTINELS.md catalog — `draft email _`, `write a bio _`, etc. resolve sender sentinels via the same post-processor FluidBlank uses, with `preserveUnknown: true` so non-sender placeholders (`[Recipient Name]`, `[Date]`) survive untouched. New `validateSentinelWrite` discriminated chokepoint (`sentinels-validator.ts`) enforces key shape, value caps (256 chars / 64 fields), control-character filter, and token-collision detection for any code path that mutates SENTINELS.md. Renames: file `USER.md` → `SENTINELS.md`; symbols `UserContext*` → `Sentinels*`, `parseUserMd` → `parseSentinelsMd`, etc.; scalar `user-context-mode:` → `sentinels-mode:`. Back-compat: ConfigLoader reads both scalar names; seed-configs self-heals the file + scalar rename. Audit row #24 codifies the new write-surface threat model.
 
-### Added — `@opencues/runtime` 0.1.0 → 0.1.4
+### Added — `@opencues/runtime` 0.1.0 → 0.1.5
 - **0.1.0 → 0.1.1** (PR #17 chain-history): sequential LLM-blank substitutes chain into walkable history so the user can cycle back through prior fill-ins.
 - **0.1.1 → 0.1.2**: typed bucket fields (`cuesLlmProvider` / `auditorsLlmProvider` / `blanksLlmProvider`) on `OpenCuesState` with back-compat parsing; `boot-common.buildAgentLLMResolver` reads the auditors bucket so `agent-rewrite` routes through it.
 - **0.1.2 → 0.1.3**: `applyOpencuesScalar` now awaits the disk write — back-to-back applyScalar calls (ConfigIntent's provider+model verdict path) serialise on disk instead of racing the read-modify-write.
 - **0.1.3 → 0.1.4** (PR #32 — Sentinels rename): `OpenCuesState.userContextMode` → `sentinelsMode`; `ConfigLoader` parses the new `sentinels-mode:` scalar with back-compat fall-through to legacy `user-context-mode:`. No behaviour change for users who haven't opted into sentinels.
+- **0.1.4 → 0.1.5** (PR #34 — sentinel-write blank): new `SentinelBlank` class in `BUILTIN_BLANKS` handles `set sentinel <key> <value> _` and `remove sentinel <key> _`. Every write routes through `@opencues/core`'s `validateSentinelWrite` chokepoint (no parallel paths). New `sentinelsMdIO` field on `BuiltinBlankContext`; the blank registers only when the host wires it. Errors paint visibly into the buffer as `[err] <detail>` — never silent, never throws. 7 layered defences documented in security-audit.md row #24.
 
 ### Added — `opencues` CLI 0.1.1 → 0.1.5
 - **0.1.1 → 0.1.2** (Option-B self-heal): `seed-configs` cleans up legacy built-in / user-blank collisions left over from the May 2026 user-blank migration. Per-host log prefix; per-version markers.
@@ -27,11 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **0.1.3 → 0.1.4** (PR #33): SIGINT race fix — `opencues update` registers signal handlers BEFORE `acquireLock` writes the lockfile (see CLI #33 entry above).
 - **0.1.4 → 0.1.5** (PR #32 — Sentinels CLI + migrations): new `opencues sentinels` command (interactive interview + scriptable `list` / `set` / `add` / `remove` / `rm` / `path` / `list --json`). Smart defaults from `git config` and `gh api user`. All writes route through `@opencues/core`'s `validateSentinelWrite`. `seed-configs` self-heals `~/.cues/USER.md` → `~/.cues/SENTINELS.md` (pre-SEED step so user data survives) and `user-context-mode:` → `sentinels-mode:` (legacy-value-wins when both present). `doctor` surfaces leftover legacy artifacts with `opencues seed-configs` as the fix command.
 
-### Added — `@opencues/claude-code` 0.1.0 → 0.1.1
+### Added — `@opencues/claude-code` 0.1.0 → 0.1.2
 - Single-fork CC install: one fork at `~/claude-code-cues/` handles both cli.js (≤2.1.111) and native-binary (≥2.1.113) shapes via tweakcc 4.0.13+ shape detection. `claude-code-cues-150` retired. Opt-in statusline. Native 2.1.150 support. Subsequent same-minor bumps (2.1.158 promoted to `current-pin` 2026-05-31) ride this band without a package-version bump — same adapter, same anchors, only `compat.json` updates.
+- **0.1.1 → 0.1.2** (PR #34): CC bootstrap wires `sentinelsMdIO` so the keyword-bound `set sentinel _` / `remove sentinel _` blank can write to `~/.cues/SENTINELS.md`. Writes route through `@opencues/core`'s `validateSentinelWrite`; no parallel write paths. Security-audit row #24.
 
-### Added — `@opencues/chrome` 0.1.0 → 0.1.1
+### Added — `@opencues/chrome` 0.1.0 → 0.1.2
 - Bundle ships the new `BLANK.md` frontmatter (the user-blank migration that retired the per-host built-in/user-blank duplication).
+- **0.1.1 → 0.1.2** (PR #34): Chrome bootstrap wires `sentinelsMdIO` so the sentinel blank works on contenteditables + normal inputs. Writes go through chrome.storage via the same validator chokepoint.
+
+### Added — `@opencues/opencode` 0.1.0 → 0.1.1
+- **0.1.0 → 0.1.1** (PR #34): OC bootstrap wires `sentinelsMdIO` for the sentinel blank.
+
+### Added — `@opencues/gemini-cli` 0.1.0 → 0.1.1
+- **0.1.0 → 0.1.1** (PR #34): Gemini bootstrap wires `sentinelsMdIO` for the sentinel blank.
+
+### Added — `@opencues/shell` 0.1.0 → 0.1.1
+- **0.1.0 → 0.1.1** (PR #34): Shell (`oc-edit`) bootstrap wires `sentinelsMdIO` for the sentinel blank.
 
 ### Added — new packages introduced this period
 - **`@opencues/runtime` 0.1.0** — host-agnostic runtime scaffold (HostAdapter types, MockAdapter, conformance suite). Replaces the inline runtime code that previously lived in the CC patch.

--- a/defaults/blanks/sentinel/BLANK.md
+++ b/defaults/blanks/sentinel/BLANK.md
@@ -1,0 +1,82 @@
+---
+name: sentinel
+type: blank
+blankKeywords: set sentinel, remove sentinel
+# Allow up to 16 words between the keyword and `_` so multi-word
+# values land correctly (e.g. `set sentinel signOff Best from sunny
+# London _`). 16 covers any realistic sentinel value (~80 chars of
+# prose) while keeping false-positive matches narrow — without it,
+# the proximity-0 default makes the blank silently miss every
+# non-single-word value (TransformBlank wins the slot instead). A
+# user with an unusually long value (>16 words / ~80 chars) falls
+# back to `opencues sentinels set` from the CLI, which has no
+# proximity limit. The 256-char value cap (validateSentinelWrite)
+# still gates the actual content of any matched write.
+blankProximity: 16
+blankFormat: string
+blankScript: ./sentinel-blank.sh
+blankClearKeywords: true
+blankClearOnEdit: true
+# Sandbox: off because sentinel-blank.sh writes to ~/.cues/SENTINELS.md
+# (sentinel-mode personal data) which is outside the sandbox's tmpfs
+# and would be refused by the read-only CUES root bind. Chrome routes
+# this through SentinelBlank (impl: class, no spawn) so the sandbox
+# declaration only affects native hosts.
+sandbox: off
+# Hosts that get the SentinelBlank built-in. Native hosts also fall
+# back to the shell script if blankInvoke fails.
+on-host: chrome, claude-code, gemini-cli, opencode, shell
+---
+
+# Sentinel — write to ~/.cues/SENTINELS.md from inside the editor
+
+Triggered by `set sentinel <key> <value> _` (add/update) or
+`remove sentinel <key> _`. Every write goes through the single
+validator chokepoint at `@opencues/core`'s `validateSentinelWrite`.
+
+## Examples
+
+```
+set sentinel jobTitle Founder _
+set sentinel signOff Best wishes _
+remove sentinel jobTitle _
+```
+
+## What the validator enforces
+
+- **Key shape** — `[A-Za-z][A-Za-z0-9_-]*`. Refuses path traversal
+  (`../etc/passwd`), shell metacharacters (`foo;rm`, `foo|cat`),
+  Unicode tricks.
+- **Value shape** — refuses NUL + C0/C1 control chars (defence-in-
+  depth against YAML / `sentinels-mode: raw` prompt smuggling).
+- **Value length** — 256-char cap.
+- **Capacity** — 64-field cap. Refuses unbounded growth.
+- **Token collision** — `firstName` and `first_name` both derive to
+  `[FIRST NAME]`. Validator refuses the second so the first isn't
+  silently shadowed.
+
+## Errors
+
+Errors paint visibly into the buffer as `[err] <detail>`. Never
+silent, never throws. Examples:
+
+- `[err] USER.md is full — 64/64 sentinels defined. Remove unused ones …`
+- `[err] key "../foo" must match [A-Za-z][A-Za-z0-9_-]* — letters/…`
+- `[err] value for "note" contains forbidden control characters`
+- `[err] key "first_name" derives to [FIRST NAME] — same token as existing "firstName"`
+
+## Security
+
+See `docs/architecture/security-audit.md` row #24 for the full threat
+model. Key invariants:
+
+1. **Keyword-bound only.** No LLM classification routes here.
+2. **Trust-gate protected.** The `_` keystroke is policed by the
+   credit-based trust gate (row #13); a hostile page can't
+   synthesise the trigger.
+3. **No ambient context.** Ignores page placeholder/aria/title.
+4. **Pack-shadow defended.** Built-in `sentinel` wins over any
+   user-pack with the same name (row #12, first-wins).
+5. **Validator is the only write path.** The shell-script fallback
+   routes back to `opencues sentinels set`, which uses the same
+   validator.

--- a/defaults/blanks/sentinel/sentinel-blank.sh
+++ b/defaults/blanks/sentinel/sentinel-blank.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# sentinel-blank.sh — native-host fallback for `set sentinel _` /
+# `remove sentinel _`.
+#
+# Routes every write back through `opencues sentinels set|remove` so
+# the validator (validateSentinelWrite in @opencues/core) is the
+# single chokepoint. Refuses to write directly. See
+# docs/architecture/security-audit.md row #24.
+#
+# Invocation (mirrors the Blank.get/set dispatch):
+#   get "set sentinel" <key> <value...>     → add or update
+#   get "remove sentinel" <key>             → delete
+#
+# Returns the substitution string on stdout. Errors are prefixed
+# `[err] ` so BlankFill paints them visibly into the buffer.
+
+set -u
+
+cmd="${1:-get}"
+keyword="${2:-}"
+shift 2 2>/dev/null || true
+
+# Locate the opencues CLI. Prefer $PATH (handles installed npm),
+# then a workspace-local build, then bail with a visible error.
+OC_CLI=""
+if command -v opencues >/dev/null 2>&1; then
+  OC_CLI="opencues"
+elif [ -n "${OPENCUES_REPO_ROOT:-}" ] && [ -f "${OPENCUES_REPO_ROOT}/packages/opencues-cli/bin/cli.cjs" ]; then
+  OC_CLI="node ${OPENCUES_REPO_ROOT}/packages/opencues-cli/bin/cli.cjs"
+else
+  echo "[err] sentinel blank: opencues CLI not on PATH"
+  exit 0
+fi
+
+case "$cmd" in
+  get)
+    case "$keyword" in
+      "set sentinel"|"SET SENTINEL"|"Set Sentinel")
+        key="${1:-}"; shift 2>/dev/null || true
+        value="$*"
+        if [ -z "$key" ] || [ -z "$value" ]; then
+          echo "[err] set sentinel: usage is \`set sentinel <key> <value> _\`"
+          exit 0
+        fi
+        out=$($OC_CLI sentinels set "$key" "$value" 2>&1)
+        rc=$?
+        if [ $rc -eq 0 ]; then
+          token=$($OC_CLI sentinels list --json 2>/dev/null \
+            | grep -E "\"key\":\s*\"$key\"" -A 1 \
+            | grep -E '"token"' \
+            | sed 's/.*"token":[[:space:]]*"\([^"]*\)".*/\1/')
+          if [ -n "$token" ]; then
+            echo "$token = $value"
+          else
+            echo "$key = $value"
+          fi
+        else
+          detail=$(echo "$out" | grep -E 'must match|exceeds|forbidden|full|derives to|collision|no sentinel' | head -1 | sed 's/\[error\] //;s/\[warn\] //')
+          echo "[err] ${detail:-write refused}"
+        fi
+        ;;
+      "remove sentinel"|"REMOVE SENTINEL"|"Remove Sentinel")
+        key="${1:-}"
+        if [ -z "$key" ]; then
+          echo "[err] remove sentinel: usage is \`remove sentinel <key> _\`"
+          exit 0
+        fi
+        out=$($OC_CLI sentinels remove "$key" 2>&1)
+        rc=$?
+        if [ $rc -eq 0 ]; then
+          echo "[removed $key]"
+        else
+          detail=$(echo "$out" | grep -E 'no sentinel|must match' | head -1 | sed 's/\[error\] //')
+          echo "[err] ${detail:-remove refused}"
+        fi
+        ;;
+      *)
+        echo "[err] sentinel blank: unknown keyword \"$keyword\""
+        ;;
+    esac
+    ;;
+  set)
+    # The runtime never invokes the script with action=set — `set` is
+    # only used by selector-satellite blanks where the satellite paints
+    # the current value. Sentinel writes are entirely contained in
+    # action=get's invocation. Refuse loudly so a future change that
+    # tries to route here gets a visible failure.
+    echo "[err] sentinel blank does not support action=set; use \`set sentinel <key> <value> _\` in the buffer"
+    ;;
+  *)
+    echo "[err] sentinel blank: unknown action \"$cmd\""
+    ;;
+esac

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/src/blanks/index.ts
+++ b/integrations/chrome/src/blanks/index.ts
@@ -38,15 +38,29 @@ export function createBlanks(options?: {
    */
   opencuesMdReadFile?: () => Promise<string | null>;
   opencuesMdWriteFile?: (content: string) => Promise<void>;
+  /**
+   * Optional SENTINELS.md file accessors. When supplied, the
+   * keyword-bound `set sentinel _` / `remove sentinel _` blank is
+   * registered. Chrome wires these to chrome.storage; without them
+   * the blank stays unregistered (user can still use `opencues
+   * sentinels` from the CLI). Writes go through the same validator
+   * as the CLI — see security-audit.md row #24.
+   */
+  sentinelsMdReadFile?: () => Promise<string | null>;
+  sentinelsMdWriteFile?: (content: string) => Promise<void>;
 }): Map<string, BrowserBlank> {
   const opencuesMdIO = (options?.opencuesMdReadFile && options.opencuesMdWriteFile)
     ? { readFile: options.opencuesMdReadFile, writeFile: options.opencuesMdWriteFile }
+    : undefined;
+  const sentinelsMdIO = (options?.sentinelsMdReadFile && options.sentinelsMdWriteFile)
+    ? { readFile: options.sentinelsMdReadFile, writeFile: options.sentinelsMdWriteFile }
     : undefined;
   return createDefaultBlanksRegistry({
     llmConfig: options?.llmConfig,
     finnhubApiKey: options?.finnhubApiKey,
     customTickers: options?.customTickers,
     opencuesMdIO,
+    sentinelsMdIO,
     hostName: 'chrome',
   }) as Map<string, BrowserBlank>;
 }

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -2069,6 +2069,12 @@ export function startOpenCues(opts: RuntimeStartOptions = {}): BootResult {
     // reads/writes the seeded OPENCUES.md in chrome.storage.
     opencuesMdReadFile: () => readFile(`${ROOT}/.cues/OPENCUES.md`),
     opencuesMdWriteFile: (content) => writeFile(`${ROOT}/.cues/OPENCUES.md`, content),
+    // Sentinel-write blank — keyword-bound `set sentinel _` /
+    // `remove sentinel _`. Writes go through @opencues/core's
+    // validateSentinelWrite chokepoint BEFORE this writer is called;
+    // do not add a parallel write path. Security-audit.md row #24.
+    sentinelsMdReadFile: () => readFile(`${ROOT}/.cues/SENTINELS.md`),
+    sentinelsMdWriteFile: (content) => writeFile(`${ROOT}/.cues/SENTINELS.md`, content),
   });
   blankInvoke = createBlankInvoke(blanks);
 

--- a/integrations/claude-code/package.json
+++ b/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/claude-code",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "OpenCues for Claude Code \u2014 patches Claude Code's CLI via tweakcc to add real-time word alternatives, blanks, and cue-controls.",
   "compatibility": {

--- a/integrations/claude-code/patches/opencuesRuntime.ts
+++ b/integrations/claude-code/patches/opencuesRuntime.ts
@@ -292,6 +292,9 @@ export function writeOpenCuesRuntimeV2(oldFile: string): string | null {
   const opencuesMdPathExpr =
     `(process.env.OPENCUES_HOME?(process.env.OPENCUES_HOME+"/OPENCUES.md"):` +
     `((process.env.HOME||"~")+"/.cues/OPENCUES.md"))`;
+  const sentinelsMdPathExpr =
+    `(process.env.OPENCUES_HOME?(process.env.OPENCUES_HOME+"/SENTINELS.md"):` +
+    `((process.env.HOME||"~")+"/.cues/SENTINELS.md"))`;
   // CUES roots for the sandbox + audit log. First entry is where the
   // log lands. Mirrors OC/gemini.
   const cuesRootsExpr =
@@ -387,6 +390,7 @@ export function writeOpenCuesRuntimeV2(oldFile: string): string | null {
     // bootstrap picks it up automatically via createDefaultBlanksRegistry.
     `var __ocCtl=__oc_req(${blanksPath});` +
     `var __ocFs=${requireFn}("fs");var __ocOcMd=${opencuesMdPathExpr};` +
+    `var __ocSentMd=${sentinelsMdPathExpr};` +
     `var __ocGroq=process.env.GROQ_API_KEY;` +
     `var __ocReg=__ocCtl.createDefaultBlanksRegistry({` +
     `llmConfig:__ocGroq?{apiKey:__ocGroq}:undefined,` +
@@ -394,6 +398,14 @@ export function writeOpenCuesRuntimeV2(oldFile: string): string | null {
     `opencuesMdIO:{` +
     `readFile:function(){return new Promise(function(r){__ocFs.readFile(__ocOcMd,"utf8",function(e,d){r(e?null:d);});});},` +
     `writeFile:function(c){return new Promise(function(r,j){__ocFs.writeFile(__ocOcMd,c,"utf8",function(e){e?j(e):r();});});}` +
+    `},` +
+    // Sentinel-write blank — keyword-bound `set sentinel _` /
+    // `remove sentinel _`. Validator runs INSIDE SentinelBlank before
+    // writeFile is invoked; do not add a parallel write path. See
+    // docs/architecture/security-audit.md row #24.
+    `sentinelsMdIO:{` +
+    `readFile:function(){return new Promise(function(r){__ocFs.readFile(__ocSentMd,"utf8",function(e,d){r(e?null:d);});});},` +
+    `writeFile:function(c){return new Promise(function(r,j){__ocFs.writeFile(__ocSentMd,c,"utf8",function(e){e?j(e):r();});});}` +
     `}` +
     `});` +
     // User-shipped JS blanks: walk every .cues/blanks/<name>/BLANK.md,

--- a/integrations/gemini-cli/package.json
+++ b/integrations/gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/gemini-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "OpenCues for Gemini CLI \u2014 patches a Gemini CLI fork to add real-time word alternatives, blanks, and cue-controls.",
   "compatibility": {

--- a/integrations/gemini-cli/patches/opencuesBootstrap.ts
+++ b/integrations/gemini-cli/patches/opencuesBootstrap.ts
@@ -175,6 +175,13 @@ function findOpenCuesMdPath(): string {
   return path.join(process.env['HOME'] ?? '~', '.cues', 'OPENCUES.md');
 }
 
+function findSentinelsMdPath(): string {
+  if (process.env['OPENCUES_HOME']) {
+    return path.join(process.env['OPENCUES_HOME'], 'SENTINELS.md');
+  }
+  return path.join(process.env['HOME'] ?? '~', '.cues', 'SENTINELS.md');
+}
+
 function resolveTtsScript(): string {
   const root = process.env['OPENCUES_HOME'] ?? path.join(process.env['HOME'] ?? '~', '.cues');
   return path.join(root, 'scripts/speak.sh');
@@ -191,6 +198,11 @@ const blanksRegistry: Map<string, Blank> = createDefaultBlanksRegistry({
   opencuesMdIO: {
     readFile: async () => { try { return await fs.readFile(findOpenCuesMdPath(), 'utf8'); } catch { return null; } },
     writeFile: async (content: string) => { await fs.writeFile(findOpenCuesMdPath(), content, 'utf8'); },
+  },
+  // Sentinel-write blank — see security-audit.md row #24.
+  sentinelsMdIO: {
+    readFile: async () => { try { return await fs.readFile(findSentinelsMdPath(), 'utf8'); } catch { return null; } },
+    writeFile: async (content: string) => { await fs.writeFile(findSentinelsMdPath(), content, 'utf8'); },
   },
 });
 // Discover user-shipped JS blanks (`impl: ./blank.js` in BLANK.md)

--- a/integrations/opencode/package.json
+++ b/integrations/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/opencode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "OpenCues for OpenCode \u2014 patches an OpenCode TUI fork to add real-time word alternatives, blanks, and cue-controls.",
   "compatibility": {

--- a/integrations/opencode/patches/opencuesBootstrap.ts
+++ b/integrations/opencode/patches/opencuesBootstrap.ts
@@ -115,6 +115,13 @@ function findOpenCuesMdPath(): string {
   return path.join(process.env['HOME'] ?? "~", ".cues", "OPENCUES.md")
 }
 
+function findSentinelsMdPath(): string {
+  if (process.env['OPENCUES_HOME']) {
+    return path.join(process.env['OPENCUES_HOME'], "SENTINELS.md")
+  }
+  return path.join(process.env['HOME'] ?? "~", ".cues", "SENTINELS.md")
+}
+
 // TTS script lives at user-level (~/.cues/scripts/speak.sh), seeded
 // + kept current by `opencues seed-configs` (which all host installers
 // invoke). One canonical path, no walking, no integration coupling —
@@ -135,6 +142,14 @@ const blanksRegistry: Map<string, Blank> = createDefaultBlanksRegistry({
   opencuesMdIO: {
     readFile: async () => { try { return await fs.readFile(findOpenCuesMdPath(), "utf8") } catch { return null } },
     writeFile: async (content) => { await fs.writeFile(findOpenCuesMdPath(), content, "utf8") },
+  },
+  // SENTINELS.md sibling — the keyword-bound `set sentinel _` /
+  // `remove sentinel _` blank routes writes here. validateSentinelWrite
+  // runs INSIDE SentinelBlank before writeFile is called; never bypass.
+  // See docs/architecture/security-audit.md row #24.
+  sentinelsMdIO: {
+    readFile: async () => { try { return await fs.readFile(findSentinelsMdPath(), "utf8") } catch { return null } },
+    writeFile: async (content) => { await fs.writeFile(findSentinelsMdPath(), content, "utf8") },
   },
 })
 // User-shipped JS blanks: walk every .cues/blanks/<name>/BLANK.md

--- a/integrations/shell/package.json
+++ b/integrations/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/shell",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "OpenCues for the terminal — `shell` wraps your interactive shell in a tmux session with an Alt+Shift+↑ input box that hosts the OpenCues TUI. Brings full cues, blanks, cycling, agent-rewrite to any shell.",
   "type": "module",

--- a/integrations/shell/src/bootstrap.ts
+++ b/integrations/shell/src/bootstrap.ts
@@ -80,6 +80,13 @@ function findOpenCuesMdPath(): string {
   return path.join(process.env['HOME'] ?? os.homedir(), '.cues', 'OPENCUES.md');
 }
 
+function findSentinelsMdPath(): string {
+  if (process.env['OPENCUES_HOME']) {
+    return path.join(process.env['OPENCUES_HOME'], 'SENTINELS.md');
+  }
+  return path.join(process.env['HOME'] ?? os.homedir(), '.cues', 'SENTINELS.md');
+}
+
 function resolveTtsScript(): string {
   const root = process.env['OPENCUES_HOME'] ?? path.join(process.env['HOME'] ?? os.homedir(), '.cues');
   return path.join(root, 'scripts/speak.sh');
@@ -95,6 +102,15 @@ const blanksRegistry: Map<string, Blank> = createDefaultBlanksRegistry({
     },
     writeFile: async (content) => {
       await fs.writeFile(findOpenCuesMdPath(), content, 'utf8');
+    },
+  },
+  // Sentinel-write blank — see security-audit.md row #24.
+  sentinelsMdIO: {
+    readFile: async () => {
+      try { return await fs.readFile(findSentinelsMdPath(), 'utf8'); } catch { return null; }
+    },
+    writeFile: async (content) => {
+      await fs.writeFile(findSentinelsMdPath(), content, 'utf8');
     },
   },
 });

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/blanks/index.ts
+++ b/packages/opencues-runtime/src/blanks/index.ts
@@ -20,6 +20,7 @@ export { WeatherBlank, type WeatherBlankOptions } from './weather';
 export { AnswerBlank, type AnswerBlankOptions } from './answer';
 export { PromptImproverBlank, type PromptImproverBlankOptions } from './prompt-improver';
 export { OpenCuesSettingsBlank, type OpenCuesSettingsBlankOptions } from './opencues-settings';
+export { SentinelBlank, type SentinelBlankOptions } from './sentinel';
 export { DictionaryBlank, type DictionaryBlankOptions } from './dictionary';
 export { CryptoBlank, type CryptoBlankOptions } from './crypto';
 export { CountriesBlank, type CountriesBlankOptions } from './countries';
@@ -34,6 +35,7 @@ import { WeatherBlank } from './weather';
 import { AnswerBlank } from './answer';
 import { PromptImproverBlank } from './prompt-improver';
 import { OpenCuesSettingsBlank } from './opencues-settings';
+import { SentinelBlank } from './sentinel';
 import { DictionaryBlank } from './dictionary';
 import { CryptoBlank } from './crypto';
 import { CountriesBlank } from './countries';
@@ -105,6 +107,21 @@ export interface BuiltinBlankContext {
     readonly writeFile: (content: string) => Promise<void>;
   };
   /**
+   * Read/write accessors for the user's SENTINELS.md file. Required
+   * to register the `sentinel` keyword-bound write blank. Hosts that
+   * don't supply this skip the sentinel blank — the user can still
+   * use `opencues sentinels set` from the CLI.
+   *
+   * SECURITY: the blank's writes are validated by
+   * @opencues/core's `validateSentinelWrite` BEFORE this writer is
+   * called. Hosts MUST NOT add a parallel write path that skips the
+   * validator. Audit row #24.
+   */
+  readonly sentinelsMdIO?: {
+    readonly readFile: () => Promise<string | null>;
+    readonly writeFile: (content: string) => Promise<void>;
+  };
+  /**
    * Host name passed through to OpenCuesSettingsBlank so the
    * registry's host-scoped tunables (e.g. chrome's `dim-mix`) only
    * surface in the cycling menu on their target host.
@@ -156,6 +173,14 @@ export const BUILTIN_BLANKS: readonly BuiltinBlankSpec[] = [
 
   // ── Settings / selector-satellite (skip when no IO supplied) ─────
   { name: 'opencues',      factory: ctx => ctx.opencuesMdIO ? new OpenCuesSettingsBlank({ ...ctx.opencuesMdIO, hostName: ctx.hostName }) : null },
+
+  // ── Sentinel-write (keyword-bound `set sentinel <k> <v> _` /
+  //    `remove sentinel <k> _`). Skips when no IO supplied (host
+  //    can't write SENTINELS.md). Audit row #24 — every host that
+  //    wires sentinelsMdIO MUST hand the writer the file content
+  //    AS-RETURNED by SentinelBlank.get(); never bypass the writer
+  //    or replace its content with a non-validated path.
+  { name: 'sentinel',      factory: ctx => ctx.sentinelsMdIO ? new SentinelBlank(ctx.sentinelsMdIO) : null },
 ];
 
 /**

--- a/packages/opencues-runtime/src/blanks/registry-drift.test.ts
+++ b/packages/opencues-runtime/src/blanks/registry-drift.test.ts
@@ -71,6 +71,10 @@ describe('createDefaultBlanksRegistry semantics', () => {
         readFile: async () => null,
         writeFile: async () => {},
       },
+      sentinelsMdIO: {
+        readFile: async () => null,
+        writeFile: async () => {},
+      },
     });
     for (const spec of BUILTIN_BLANKS) {
       expect(reg.has(spec.name), `missing ${spec.name} in full-context registry`).toBe(true);
@@ -91,13 +95,18 @@ describe('createDefaultBlanksRegistry semantics', () => {
     expect(reg.has('opencues')).toBe(false);
   });
 
+  it('skips the sentinel blank when sentinelsMdIO is absent', () => {
+    const reg = createDefaultBlanksRegistry({});
+    expect(reg.has('sentinel')).toBe(false);
+  });
+
   it('canonical built-ins are all present in BUILTIN_BLANKS', () => {
     // Pins the floor — if someone removes one of these from the
     // registry, hosts that depended on it break silently.
     const canonical = [
       'hackernews', 'stocks', 'weather', 'claude-status',
       'dictionary', 'crypto', 'countries',
-      'answer', 'prompt', 'opencues',
+      'answer', 'prompt', 'opencues', 'sentinel',
     ];
     const present = new Set(BUILTIN_BLANKS.map(b => b.name));
     for (const name of canonical) {

--- a/packages/opencues-runtime/src/blanks/sentinel.test.ts
+++ b/packages/opencues-runtime/src/blanks/sentinel.test.ts
@@ -1,0 +1,230 @@
+// Tests for SentinelBlank.
+//
+// The runtime class is the single chokepoint every host (chrome, CC,
+// OC, gemini, shell) routes through. These tests pin:
+//   - keyword dispatch (`set sentinel` vs `remove sentinel` vs unknown)
+//   - SUCCESS path returns the visible `[TOKEN] = value` pair
+//   - FAILURE paths return `[err] <detail>` (never silent, never throws)
+//   - validator integration: collision / cap / control-char / etc.
+//   - frontmatter serialisation preserves the file body (docstring)
+//   - SECURITY: pure-keyword args from a "hostile" buffer can't escape
+//     the validator's regex (no path traversal, no command injection)
+
+import { describe, expect, it } from 'vitest';
+import { SentinelBlank } from './sentinel';
+import { DEFAULT_SENTINEL_CAPS } from '@opencues/core';
+
+function makeIO(initial = '') {
+  let content = initial;
+  return {
+    readFile: async () => content,
+    writeFile: async (next: string) => { content = next; },
+    get text() { return content; },
+  };
+}
+
+const empty = '---\n---\n';
+
+describe('SentinelBlank — keyword dispatch', () => {
+  it('routes `set sentinel` to set', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('set sentinel', ['jobTitle', 'Founder']);
+    expect(out).toBe('[JOB TITLE] = Founder');
+    expect(io.text).toMatch(/jobTitle:\s+Founder/);
+  });
+
+  it('routes `remove sentinel` to remove', async () => {
+    const io = makeIO('---\njobTitle: Founder\n---\n');
+    const b = new SentinelBlank(io);
+    const out = await b.get('remove sentinel', ['jobTitle']);
+    expect(out).toBe('[removed jobTitle]');
+    expect(io.text).not.toMatch(/jobTitle:/);
+  });
+
+  it('case-insensitive keyword match', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('SET SENTINEL', ['jobTitle', 'Founder']);
+    expect(out).toBe('[JOB TITLE] = Founder');
+  });
+
+  it('refuses unknown keyword (defence-in-depth — BlankFill should never route here)', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('foo bar', ['x', 'y']);
+    expect(out).toMatch(/^\[err\] unknown keyword/);
+    expect(io.text).toBe(empty);
+  });
+});
+
+describe('SentinelBlank — set: success paths', () => {
+  it('multi-word value (Founder = "Staff Engineer")', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('set sentinel', ['jobTitle', 'Staff', 'Engineer']);
+    expect(out).toBe('[JOB TITLE] = Staff Engineer');
+    expect(io.text).toMatch(/jobTitle:\s+Staff Engineer/);
+  });
+
+  it('updates an existing key in place', async () => {
+    const io = makeIO('---\njobTitle: Founder\n---\n');
+    const b = new SentinelBlank(io);
+    const out = await b.get('set sentinel', ['jobTitle', 'CEO']);
+    expect(out).toBe('[JOB TITLE] = CEO');
+    expect(io.text).toMatch(/jobTitle:\s+CEO/);
+    expect(io.text).not.toMatch(/Founder/);
+  });
+
+  it('noop returns the same display without writing', async () => {
+    const io = makeIO('---\njobTitle: Founder\n---\n');
+    const b = new SentinelBlank(io);
+    let writes = 0;
+    const trackingIO = {
+      readFile: io.readFile,
+      writeFile: async (s: string) => { writes++; return io.writeFile(s); },
+    };
+    const tracker = new SentinelBlank(trackingIO);
+    const out = await tracker.get('set sentinel', ['jobTitle', 'Founder']);
+    expect(out).toBe('jobTitle = Founder');
+    expect(writes).toBe(0);
+  });
+
+  it('preserves the file body (docstring) on write', async () => {
+    const body = '\n# SENTINELS.md\n\nMy notes.\n';
+    const io = makeIO(`---\nfirstName: Wilfred\n---${body}`);
+    const b = new SentinelBlank(io);
+    await b.get('set sentinel', ['jobTitle', 'Founder']);
+    expect(io.text).toContain('My notes.');
+  });
+});
+
+describe('SentinelBlank — error surface (visible, not silent)', () => {
+  it('missing key', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('set sentinel', []);
+    expect(out).toMatch(/^\[err\] set sentinel: usage/);
+    expect(io.text).toBe(empty);
+  });
+
+  it('missing value', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('set sentinel', ['jobTitle']);
+    expect(out).toMatch(/^\[err\] set sentinel: missing value/);
+  });
+
+  it('invalid key shape — refuses path traversal', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('set sentinel', ['../../etc/passwd', 'x']);
+    expect(out).toMatch(/^\[err\] key/);
+    expect(out).toMatch(/must match/);
+    expect(io.text).toBe(empty);
+  });
+
+  it('invalid key shape — refuses shell metacharacters', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    for (const bad of ['foo;rm', 'foo|cat', 'foo$x', 'foo`x`', 'foo&y', 'foo*', 'foo<x']) {
+      const out = await b.get('set sentinel', [bad, 'x']);
+      expect(out).toMatch(/^\[err\] key/);
+    }
+    expect(io.text).toBe(empty);
+  });
+
+  it('control characters in value rejected (defence-in-depth — prompt smuggling)', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('set sentinel', ['note', `foo\x1bbar`]);
+    expect(out).toMatch(/^\[err\] value for "note" contains forbidden control characters/);
+    expect(io.text).toBe(empty);
+  });
+
+  it('value too long', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const huge = 'x'.repeat(DEFAULT_SENTINEL_CAPS.maxValueLength + 1);
+    const out = await b.get('set sentinel', ['bio', huge]);
+    expect(out).toMatch(/^\[err\] value for "bio" exceeds/);
+    expect(io.text).toBe(empty);
+  });
+
+  it('capacity exceeded', async () => {
+    const lines = Array.from({ length: DEFAULT_SENTINEL_CAPS.maxFields }, (_, i) => `k${i}: v${i}`).join('\n');
+    const io = makeIO(`---\n${lines}\n---\n`);
+    const b = new SentinelBlank(io);
+    const before = io.text;
+    const out = await b.get('set sentinel', ['overflow', 'x']);
+    expect(out).toMatch(/^\[err\] USER\.md is full/);
+    expect(out).toMatch(/remove unused/i);
+    expect(io.text).toBe(before);  // no write
+  });
+
+  it('token collision (firstName / first_name both → [FIRST NAME])', async () => {
+    const io = makeIO('---\nfirstName: Wilfred\n---\n');
+    const b = new SentinelBlank(io);
+    const out = await b.get('set sentinel', ['first_name', 'Other']);
+    expect(out).toMatch(/derives to \[FIRST NAME\]/);
+    expect(io.text).toMatch(/firstName: Wilfred/);
+    expect(io.text).not.toMatch(/first_name/);
+  });
+
+  it('remove: missing key', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('remove sentinel', []);
+    expect(out).toMatch(/^\[err\] remove sentinel: usage/);
+  });
+
+  it('remove: not-found surfaces clearly', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('remove sentinel', ['nope']);
+    expect(out).toMatch(/^\[err\] no sentinel with key "nope"/);
+  });
+});
+
+describe('SentinelBlank — security: validator is the only write path', () => {
+  it('any successful write produces a frontmatter that round-trips through the parser', async () => {
+    // If a future change accidentally emits non-YAML or mangles
+    // quoting, the parser would fail to round-trip. Pin the
+    // contract: writes always survive a reload.
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    await b.get('set sentinel', ['firstName', 'Wilfred']);
+    await b.get('set sentinel', ['twitter', '@inventor']);  // needs quoting
+    await b.get('set sentinel', ['greeting', 'yes']);        // YAML reserved word
+    // Re-parse and check the catalog is intact.
+    const { parseSentinelsMd } = await import('@opencues/core');
+    const ctx = parseSentinelsMd(io.text);
+    const map = new Map(ctx.fields.map(f => [f.key, f.value]));
+    expect(map.get('firstName')).toBe('Wilfred');
+    expect(map.get('twitter')).toBe('@inventor');
+    expect(map.get('greeting')).toBe('yes');
+  });
+
+  it('per-call caps override default for testing', async () => {
+    const io = makeIO(empty);
+    const b = new SentinelBlank({
+      ...io,
+      caps: { maxFields: 2, maxValueLength: 10 },
+    });
+    await b.get('set sentinel', ['a', '1']);
+    await b.get('set sentinel', ['b', '2']);
+    const out = await b.get('set sentinel', ['c', '3']);
+    expect(out).toMatch(/^\[err\] USER\.md is full/);
+  });
+
+  it('refuses keyword "set sentinel" if BlankFill misroutes it (defence-in-depth)', async () => {
+    // BlankFill's match logic guards against false positives, but if a
+    // user pack accidentally bound a different name to "set sentinel"
+    // and our keyword matcher fired weirdly, the blank should still
+    // refuse cleanly. (Keyword-bound trigger surface restriction.)
+    const io = makeIO(empty);
+    const b = new SentinelBlank(io);
+    const out = await b.get('settings change', ['voice', 'on']);
+    expect(out).toMatch(/^\[err\] unknown keyword/);
+  });
+});

--- a/packages/opencues-runtime/src/blanks/sentinel.ts
+++ b/packages/opencues-runtime/src/blanks/sentinel.ts
@@ -1,0 +1,164 @@
+// SentinelBlank — keyword-bound write surface for SENTINELS.md.
+//
+// Triggered by:
+//   set sentinel <key> <value> _        → add or update
+//   remove sentinel <key> _             → delete
+//
+// Every write goes through the single chokepoint `validateSentinelWrite`
+// in @opencues/core. The validator enforces:
+//   - KEY SHAPE      `[A-Za-z][A-Za-z0-9_-]*` (no path traversal,
+//                    no shell metacharacters, no Unicode tricks)
+//   - VALUE SHAPE    rejects NUL + C0/C1 control chars (defence-in-
+//                    depth against YAML/raw-mode prompt smuggling)
+//   - VALUE LENGTH   256-char cap (DEFAULT_SENTINEL_CAPS)
+//   - CAPACITY       64-field cap (refuses unbounded growth)
+//   - COLLISION      rejects keys that derive to a token already in
+//                    use under a different key name
+//
+// Errors are NEVER silent — the blank's return value is what gets
+// painted into the buffer, so a capacity-exceeded write produces a
+// visible `[err] USER.md is full — ...` pair the user can read and
+// react to.
+//
+// Security model — full review at docs/architecture/security-audit.md
+// row #24. Key invariants:
+//
+//   1. KEYWORD-BOUND ONLY. No LLM classification routes here (cf. the
+//      explicit refusal in fluid-config to extend ConfigIntent to
+//      SENTINELS.md writes). User must type the literal `set sentinel`
+//      / `remove sentinel` phrase before `_`.
+//   2. TRUST-GATE PROTECTED. The `_` keystroke is policed by the
+//      credit-based trust gate (security-audit row #13); a hostile
+//      page can't synthesize the trigger.
+//   3. NO AMBIENT CONTEXT. The blank ignores ambient field metadata
+//      (placeholder/aria/page title). Page text cannot influence the
+//      key or value.
+//   4. PACK-SHADOW DEFENDED. Built-in `sentinel` is registered in
+//      BUILTIN_BLANKS before any user pack; first-wins at
+//      user-blanks/registry.ts:145.
+//   5. VALIDATOR IS THE ONLY WRITE PATH. The shell-script fallback
+//      (defaults/blanks/sentinel/sentinel-blank.sh) routes back to
+//      the same validator via `opencues sentinels set`. Adding a
+//      second site that writes SENTINELS.md without going through
+//      validateSentinelWrite is an audit-row-worthy regression.
+
+import type { Blank } from './types';
+import {
+  parseSentinelsMd,
+  validateSentinelWrite,
+  DEFAULT_SENTINEL_CAPS,
+  deriveToken,
+  type SentinelCaps,
+  type SentinelField,
+} from '@opencues/core';
+
+export interface SentinelBlankOptions {
+  /** Read SENTINELS.md content. Returns null when missing. */
+  readonly readFile: () => Promise<string | null>;
+  /** Write SENTINELS.md (atomic replace). */
+  readonly writeFile: (content: string) => Promise<void>;
+  /** Override default caps (64 × 256). Used by tests + future per-host policy. */
+  readonly caps?: SentinelCaps;
+}
+
+export class SentinelBlank implements Blank {
+  readonly name = 'sentinel';
+  readonly readOnly = false;
+  private readonly _read: () => Promise<string | null>;
+  private readonly _write: (content: string) => Promise<void>;
+  private readonly _caps: SentinelCaps;
+
+  constructor(opts: SentinelBlankOptions) {
+    this._read = opts.readFile;
+    this._write = opts.writeFile;
+    this._caps = opts.caps ?? DEFAULT_SENTINEL_CAPS;
+  }
+
+  /**
+   * Dispatch — `keyword` is the matched phrase ("set sentinel" /
+   * "remove sentinel"), `context` is everything between the keyword
+   * and `_`.
+   *
+   * Return string is what the runtime substitutes for `_` in the
+   * buffer. Successful writes return the visible `key = value` pair
+   * (or `[removed key]`); failures return `[err] <detail>` so the
+   * user sees what went wrong without leaving the buffer.
+   */
+  async get(keyword?: string, context?: readonly string[]): Promise<string> {
+    const args = (context ?? []).filter(w => w.length > 0);
+    const isRemove = /^remove\s+sentinel$/i.test(keyword ?? '');
+    const isSet = /^set\s+sentinel$/i.test(keyword ?? '');
+    if (!isSet && !isRemove) {
+      return formatError(`unknown keyword "${keyword ?? ''}"`);
+    }
+
+    // Parse current state. Empty file is fine (validator handles []).
+    const text = (await this._read()) ?? '';
+    // Drop derived fields (token, description) — validator only needs
+    // {key, value}. Type-narrowing satisfies the SentinelField shape.
+    const currentFields: readonly SentinelField[] = parseSentinelsMd(text).fields
+      .map(f => ({ key: f.key, value: f.value }));
+
+    if (isRemove) {
+      const key = args[0];
+      if (!key) return formatError('remove sentinel: usage is `remove sentinel <key> _`');
+      const r = validateSentinelWrite(currentFields, { op: 'remove', key }, this._caps);
+      if (!r.ok) return formatError(r.detail);
+      await this._write(serialiseFrontmatter(r.fields, text));
+      return `[removed ${key}]`;
+    }
+
+    // SET path. context = [key, ...valueWords]. Value can be multi-word.
+    const key = args[0];
+    const value = args.slice(1).join(' ');
+    if (!key) return formatError('set sentinel: usage is `set sentinel <key> <value> _`');
+    if (!value) return formatError(`set sentinel: missing value for "${key}"`);
+    const r = validateSentinelWrite(currentFields, { op: 'set', key, value }, this._caps);
+    if (!r.ok) return formatError(r.detail);
+    if (r.action === 'noop') {
+      // Same key, same value — no write, but show confirmation.
+      return `${key} = ${value}`;
+    }
+    await this._write(serialiseFrontmatter(r.fields, text));
+    // Visual confirmation: derived token + value so the user sees what
+    // the LLM will substitute later.
+    const token = deriveToken(key);
+    return `${token} = ${value}`;
+  }
+}
+
+/**
+ * Re-emit the YAML frontmatter from the validated post-write fields
+ * while PRESERVING the body (notes/docstring) of the original file.
+ *
+ * We don't re-use the CLI's writer because the runtime can't pull a
+ * CJS helper from packages/opencues-cli. The shape stays identical:
+ * `<key>: <value>` lines, aligned colons for readability, quoted
+ * values when YAML-special starters / booleans appear.
+ */
+function serialiseFrontmatter(fields: readonly SentinelField[], existing: string): string {
+  const bodyMatch = existing.match(/^---\n[\s\S]*?\n---\n?([\s\S]*)$/);
+  const body = bodyMatch ? bodyMatch[1] : '';
+  const longestKey = fields.reduce((m, f) => Math.max(m, f.key.length), 0);
+  const lines = fields.map(f => {
+    const v = needsQuoting(f.value) ? `"${f.value.replace(/"/g, '\\"')}"` : f.value;
+    return `${f.key}:${' '.repeat(longestKey - f.key.length + 4)}${v}`;
+  });
+  const bodySep = body.length === 0 ? '' : (body.startsWith('\n') ? body : '\n' + body);
+  return `---\n${lines.join('\n')}\n---${bodySep}`;
+}
+
+function needsQuoting(value: string): boolean {
+  if (/^[#@&*!|>'"%-]/.test(value)) return true;
+  if (/^(yes|no|true|false|null|on|off)$/i.test(value)) return true;
+  if (/\s#/.test(value)) return true;
+  if (/^\s|\s$/.test(value)) return true;
+  return false;
+}
+
+function formatError(detail: string): string {
+  // `[err] ...` prefix is the marker BlankFill / cycling code uses to
+  // know not to register satellite-cycling state on the result. Keeps
+  // the error visible but inert.
+  return `[err] ${detail}`;
+}


### PR DESCRIPTION
## Summary

Lets users add or remove `SENTINELS.md` entries from inside any host's buffer:

```
set sentinel jobTitle Founder _              → adds [JOB TITLE]=Founder
set sentinel signOff Best from sunny London _ → adds [SIGN OFF]=…
remove sentinel jobTitle _                   → removes [JOB TITLE]
```

Every write routes through `validateSentinelWrite` in `@opencues/core` — the same chokepoint the `opencues sentinels` CLI uses. The native shell-script fallback (`defaults/blanks/sentinel/sentinel-blank.sh`) calls back through `opencues sentinels set`, so there are **no parallel write paths**.

> **Stacked on top of #32** (`feat/transform-blank-user-sentinels`) — depends on the validator + symbol renames that PR ships. Merge order: #32 first, then this rebases onto master cleanly.

## Security model

Audit row #24 in `docs/architecture/security-audit.md` codifies the threat model. Seven layered defences:

1. **Validator chokepoint** — key regex (refuses path traversal, shell metas), NUL/C0/C1 filter, 256-char value cap, 64-field capacity, token-collision detection. All enforced BEFORE `writeFile`.
2. **Keyword-bound only** — no LLM-classification path to USER.md writes (mirrors fluid-config's explicit FEATURES-only restriction).
3. **Trust-gate protected** — the `_` keystroke goes through the credit-based gate (row #13); page-synthesised events never fire the blank.
4. **No ambient context** — page placeholder/aria/title don't reach the writer.
5. **Pack-shadow defended** — built-in `sentinel` registers in `BUILTIN_BLANKS` before any user-pack walk; first-wins at `user-blanks/registry.ts:145`.
6. **Errors paint visibly** — `[err] <detail>` substitutes into the buffer; never silent, never throws.
7. **Local-only writes** — no network, no LLM, no exec, no clipboard.

## What's in the diff

| Path | Role |
|---|---|
| `packages/opencues-runtime/src/blanks/sentinel.ts` | `SentinelBlank` class — every host routes through this |
| `packages/opencues-runtime/src/blanks/sentinel.test.ts` | 21 tests pinning dispatch + validation + error surface + security |
| `defaults/blanks/sentinel/BLANK.md` | Keyword binding + `blankProximity: 16` (justification inline) |
| `defaults/blanks/sentinel/sentinel-blank.sh` | Native-host script fallback (routes through `opencues sentinels`) |
| `integrations/chrome/src/{blanks/index.ts,opencues-bootstrap.ts}` | Chrome bootstrap wires `sentinelsMdIO` |
| `integrations/opencode/patches/opencuesBootstrap.ts` | OC bootstrap wires `sentinelsMdIO` |
| `integrations/gemini-cli/patches/opencuesBootstrap.ts` | Gemini bootstrap wires `sentinelsMdIO` |
| `integrations/claude-code/patches/opencuesRuntime.ts` | CC bundle string wires `sentinelsMdIO` |
| `integrations/shell/src/bootstrap.ts` | Shell bootstrap wires `sentinelsMdIO` |
| `packages/opencues-runtime/src/blanks/index.ts` | Adds `SentinelBlank` to `BUILTIN_BLANKS` + new `sentinelsMdIO` field on `BuiltinBlankContext` |
| `packages/opencues-runtime/src/blanks/registry-drift.test.ts` | Extended to pin sentinel in the canonical floor |

## The proximity gotcha (worth highlighting)

End-to-end testing in OC caught a non-obvious wiring problem: without an explicit `blankProximity`, the default of `0` made `TransformBlank` (priority 93) claim every multi-word `set sentinel <k> <v> _` slot before the keyword matcher could fire. Symptom: the buffer rewrote `set sentinel tagline Built fast _` to just `Built fast` (a fluent TransformBlank rewrite), and SENTINELS.md never changed.

Fix: `blankProximity: 16` in BLANK.md. Covers any realistic sentinel value (~80 chars of prose) while keeping false-positive matches narrow. Users with longer values fall back to `opencues sentinels set` from the CLI.

This is the canonical "go-test reveals a defect at an install-boundary join" pattern — unit tests had passed, but the keyword binding only routed correctly under the full BlankFill+resolver flow with real config-loader-discovered blanks.

## Test plan

- [x] Core: 723 pass (validator + sentinels + transform-sentinels)
- [x] Runtime: 1260 pass (+21 new SentinelBlank tests + 1 new shadow scenario)
- [x] CLI: 105 pass
- [x] Agentic harness via OC headless:
  - `set sentinel tagline Built fast _` → `tagline Built fast [TAGLINE] = Built fast`, write persists
  - `set sentinel ../foo evil _` → `[err] key "../foo" must match …`, no write
  - `set sentinel foo;rm evil _` → `[err] key "foo;rm" …`, no write
  - `set sentinel first_name Bob _` (firstName exists) → `[err] key "first_name" derives to [FIRST NAME] …`, no write
  - `remove sentinel tagline _` → `[removed tagline]`
- [x] SENTINELS.md inspected after each rejection — zero leaks (no `../foo`, `passwd`, `evil`, `foo;rm` etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)