### PR TITLE
fix(update): wait for handler-ready marker in SIGINT race test (CI stability)

### DIFF
--- a/packages/opencues-cli/src/commands/update.cjs
+++ b/packages/opencues-cli/src/commands/update.cjs
@@ -160,6 +160,11 @@ async function doUpdate(host, { skipPull, dryRun }, ctx) {
   // acquireLock to deterministically exercise the race window. Without
   // this hook, the race only fires on slow CI runners (microsecond
   // window). Production never sets either env var.
+  if (process.env.OPENCUES_UPDATE_TEST_HANDLER_MARKER) {
+    // Stderr marker so the integration test can wait for handler-
+    // registration completion instead of guessing a startup delay.
+    process.stderr.write('ready-for-signal\n');
+  }
   const preLockHangMs = parseInt(process.env.OPENCUES_UPDATE_TEST_PRE_LOCK_HANG_MS || '0', 10);
   if (preLockHangMs > 0) await new Promise(r => setTimeout(r, preLockHangMs));
 

--- a/packages/opencues-cli/src/commands/update.integration.test.cjs
+++ b/packages/opencues-cli/src/commands/update.integration.test.cjs
@@ -176,16 +176,35 @@ test('SIGINT arriving in the handler-register window releases the lock — regre
       ...process.env,
       HOME: home,
       OPENCUES_NO_UPDATE_CHECK: '1',
-      // 200ms gap between handler registration and acquireLock — the
-      // window in which signals must already be handled.
-      OPENCUES_UPDATE_TEST_PRE_LOCK_HANG_MS: '200',
+      // 1000ms gap between handler registration and acquireLock —
+      // generous so cold CI runners have time to spawn node + load
+      // modules + reach the handler-registration site before we
+      // SIGINT into the window.
+      OPENCUES_UPDATE_TEST_PRE_LOCK_HANG_MS: '1000',
+      // Tell update.cjs to print "ready-for-signal" on stderr once
+      // handlers are wired. The test waits for this marker rather
+      // than guessing a startup delay — earlier versions used a
+      // 50ms wait that was too tight for cold CI runners (node
+      // startup itself exceeded the wait, so SIGINT killed the
+      // process before any JS handler attached).
+      OPENCUES_UPDATE_TEST_HANDLER_MARKER: '1',
     },
     stdio: 'pipe',
   });
 
-  // 50ms is solidly inside the 200ms gap. Long enough for child to
-  // start the JS + register handlers (~10ms), well before acquireLock.
-  await new Promise(r => setTimeout(r, 50));
+  // Wait for the handler-ready marker on stderr. Cap at 5s.
+  await new Promise((resolve) => {
+    let buf = '';
+    const onData = (chunk) => {
+      buf += chunk.toString();
+      if (buf.includes('ready-for-signal')) {
+        child.stderr.off('data', onData);
+        resolve();
+      }
+    };
+    child.stderr.on('data', onData);
+    setTimeout(resolve, 5000);
+  });
   child.kill('SIGINT');
   await new Promise(r => child.once('exit', r));
 


### PR DESCRIPTION
## Summary

The regression test added in #33 fails reliably on cold CI runners. The test sends SIGINT 50ms after spawn, assuming the child has reached the signal-handler-registration site — which holds on a warm dev laptop but not on a cold runner where node startup alone exceeds 50ms.

Symptom on PR #32 CI ([run 26722351120](https://github.com/opencues/opencues/actions/runs/26722351120)): \`exitCode=null, signal=SIGINT\` — process terminated by signal because no JS handler was attached yet. That's exactly the failure mode the test was supposed to catch on the OLD (buggy) code, not the FIXED code. False positive.

## The fix

Switch from "guess a startup delay" to "wait for a handler-ready marker":

- \`update.cjs\` writes \`ready-for-signal\\n\` to stderr immediately after handler registration, gated on \`OPENCUES_UPDATE_TEST_HANDLER_MARKER\` (production never sets it).
- The integration test reads stderr, waits for the marker, then SIGINTs.
- Pre-lock hang stretches to 1000ms so cold CI runners have ample time even after the marker fires.

The test is now deterministic regardless of runner speed.

## Test plan

- [x] \`node --test packages/opencues-cli/src/commands/update.integration.test.cjs\` — 6/6 pass in ~5s locally
- [x] Verified the original fix from #33 is still present in master and the regression test still proves it (test fails when the fix is reverted — same way #33 demonstrated)

This is a CI-flake fix; the actual behaviour fix shipped in #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)