### PR TITLE
feat(nav): nav-keymap scalar (auto | ctrl-alt | ctrl-shift) + Terminal.app auto-detect

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -162,6 +162,22 @@ GNOME, KDE, and most tiling WMs bind Ctrl+Alt+arrow to workspace switching by de
 
 Test: in a fresh shell, press Ctrl+Alt+Right inside `claude-cues`. If your workspace switches, the OS still owns the binding.
 
+### macOS: Terminal.app doesn't forward Ctrl+Alt+arrow
+
+Apple's built-in **Terminal.app does not send the `Ctrl+Alt+arrow` (Control+Option+arrow) escape sequences** that OpenCues navigation relies on. Pressing Ctrl+Alt+Right inside `claude-cues` just moves the cursor one character — the modifiers are stripped before the runtime ever sees them, so word navigation appears dead even though cues still highlight correctly. This is a terminal-emulator limitation, not a Mission Control conflict: the keystroke never reaches the app at all (your workspace does *not* switch).
+
+OpenCues detects Terminal.app automatically (`TERM_PROGRAM=Apple_Terminal`) and switches to **Ctrl+Shift+arrow** as the navigation / cycling combo. The default `nav-keymap: auto` scalar in `~/.cues/OPENCUES.md` handles this without configuration. If you'd rather override:
+
+- `nav-keymap: ctrl-alt` — force the classic combo (use this on Ghostty / iTerm2, which forward Ctrl+Alt+arrow cleanly).
+- `nav-keymap: ctrl-shift` — force the Terminal.app fallback on every terminal host.
+
+The chrome extension ignores the scalar and always uses `Ctrl+Alt+arrow` — `Ctrl+Shift+arrow` extends browser text selection by word and OpenCues won't clobber it.
+
+If you'd prefer to keep your `Ctrl+Alt+arrow` muscle memory, install a forwarding terminal (no further config needed):
+
+- [Ghostty](https://ghostty.org) — `brew install --cask ghostty`
+- [iTerm2](https://iterm2.com) — `brew install --cask iterm2`
+
 ## Troubleshooting
 
 ### `claude-cues` is on PATH but typing produces no cues

--- a/packages/opencues-core/src/feature-registry.ts
+++ b/packages/opencues-core/src/feature-registry.ts
@@ -323,6 +323,17 @@ export const FEATURES: readonly FeatureSpec[] = [
     ],
   },
   {
+    scalar: 'nav-keymap',
+    camelCase: 'navKeymap',
+    description: 'Modifier combo for word navigation + alternative cycling. `auto` picks ctrl-shift on macOS Terminal.app, ctrl-alt everywhere else. Chrome ignores the scalar and always uses ctrl-alt (ctrl-shift+arrow extends browser text selection).',
+    menuTip: 'Modifier combo for word nav (Left/Right) + alt cycling (Up/Down). `auto` resolves per host: macOS Terminal.app → ctrl-shift; everything else → ctrl-alt.',
+    values: [
+      { id: 'auto',       description: 'Default — pick ctrl-shift on macOS Terminal.app, ctrl-alt everywhere else' },
+      { id: 'ctrl-alt',   description: 'Ctrl+Alt+Arrow (Ctrl+Option+Arrow on macOS). Requires Ghostty / iTerm2 on macOS — Terminal.app strips the modifiers' },
+      { id: 'ctrl-shift', description: 'Ctrl+Shift+Arrow — macOS Terminal.app fallback. Terminal hosts only; chrome always uses ctrl-alt to avoid clobbering browser text selection' },
+    ],
+  },
+  {
     scalar: 'debug-mode',
     camelCase: 'debugMode',
     description: 'Verbose runtime logging (every cue/blank decision)',

--- a/packages/opencues-runtime/src/modules/config-loader.test.ts
+++ b/packages/opencues-runtime/src/modules/config-loader.test.ts
@@ -135,6 +135,19 @@ some prose
     expect(parseOpenCuesMd('---\nsentinels-mode: enabled\n---').sentinelsMode).toBe('off');
   });
 
+  it('nav-keymap defaults to auto and only accepts ctrl-alt / ctrl-shift', () => {
+    expect(parseOpenCuesMd('---\n---').navKeymap).toBe('auto');
+    expect(parseOpenCuesMd('---\nnav-keymap: auto\n---').navKeymap).toBe('auto');
+    expect(parseOpenCuesMd('---\nnav-keymap: ctrl-alt\n---').navKeymap).toBe('ctrl-alt');
+    expect(parseOpenCuesMd('---\nnav-keymap: ctrl-shift\n---').navKeymap).toBe('ctrl-shift');
+    // Case-insensitive.
+    expect(parseOpenCuesMd('---\nnav-keymap: Ctrl-Shift\n---').navKeymap).toBe('ctrl-shift');
+    // Anything else stays auto — typos / unexpected values fall back
+    // to the host-aware default rather than disabling navigation.
+    expect(parseOpenCuesMd('---\nnav-keymap: meta-arrow\n---').navKeymap).toBe('auto');
+    expect(parseOpenCuesMd('---\nnav-keymap: shift\n---').navKeymap).toBe('auto');
+  });
+
   it('clamps unknown values to safe defaults', () => {
     const md = `---
 voice-mode: muted

--- a/packages/opencues-runtime/src/modules/config-loader.ts
+++ b/packages/opencues-runtime/src/modules/config-loader.ts
@@ -138,6 +138,24 @@ export interface OpenCuesState {
    */
   readonly blankTriggerMode: 'immediate' | 'spaced';
   /**
+   * Modifier combo used for word navigation (Left/Right) and
+   * alternative cycling (Up/Down).
+   *
+   * - `auto` (default): pick `ctrl-shift` on macOS Terminal.app
+   *   (TERM_PROGRAM=Apple_Terminal — strips Ctrl+Alt+arrow before the
+   *   app sees it), `ctrl-alt` everywhere else.
+   * - `ctrl-alt`: classic Ctrl+Alt+arrow / Ctrl+Option+arrow. Default
+   *   on every host except Apple_Terminal.
+   * - `ctrl-shift`: Ctrl+Shift+arrow. Used as the Terminal.app
+   *   fallback. Terminal hosts only — chrome hard-pins to ctrl-alt
+   *   regardless of the scalar (ctrl-shift+arrow extends browser
+   *   text selection — hijacking it would steal a primary shortcut).
+   *
+   * Hot-reloads. The handlers gate per-keystroke on the resolved
+   * combo so no restart is needed after editing OPENCUES.md.
+   */
+  readonly navKeymap: 'auto' | 'ctrl-alt' | 'ctrl-shift';
+  /**
    * Per-bucket LLM provider overrides — the three-bucket simplification.
    * Each bucket carves the LLM surface into one of three trust classes:
    *
@@ -190,6 +208,7 @@ export const DEFAULT_OPENCUES_STATE: OpenCuesState = {
   ambientContextMode: 'off',
   sentinelsMode: 'off',
   blankTriggerMode: 'immediate',
+  navKeymap: 'auto',
   cuesLlmProvider: 'inherit',
   auditorsLlmProvider: 'inherit',
   blanksLlmProvider: 'inherit',
@@ -256,6 +275,11 @@ export function parseOpenCuesMd(content: string): OpenCuesState {
     : 'off';
   const blankTriggerMode: 'immediate' | 'spaced' =
     get('blank-trigger-mode', 'immediate').toLowerCase() === 'spaced' ? 'spaced' : 'immediate';
+  const navKeymapRaw = get('nav-keymap', 'auto').toLowerCase();
+  const navKeymap: 'auto' | 'ctrl-alt' | 'ctrl-shift' =
+    navKeymapRaw === 'ctrl-alt' ? 'ctrl-alt'
+    : navKeymapRaw === 'ctrl-shift' ? 'ctrl-shift'
+    : 'auto';
   // Bucket scalars — `inherit` (default) or any concrete provider id.
   // Unknown values fall back to `inherit` rather than silently picking
   // an invalid provider — protects users from typos that would
@@ -287,7 +311,7 @@ export function parseOpenCuesMd(content: string): OpenCuesState {
   // Tests keep shipping mock `settings:` blocks; they get the
   // file-driven definitions, identical to the pre-refactor behaviour.
   const definitions = mergeDefinitions(getMenuDefinitions(), parseSettingsBlock(lines));
-  return { voiceMode, debugMode, tipsMode, cursorNavigate, ambientContextMode, sentinelsMode, blankTriggerMode, cuesLlmProvider, auditorsLlmProvider, blanksLlmProvider, settings, definitions };
+  return { voiceMode, debugMode, tipsMode, cursorNavigate, ambientContextMode, sentinelsMode, blankTriggerMode, navKeymap, cuesLlmProvider, auditorsLlmProvider, blanksLlmProvider, settings, definitions };
 }
 
 /**
@@ -569,6 +593,10 @@ export class ConfigLoader {
         return v === 'safe' ? 'safe' : v === 'raw' ? 'raw' : 'off';
       })(),
       blankTriggerMode: (get('blank-trigger-mode', 'immediate').toLowerCase() === 'spaced' ? 'spaced' : 'immediate') as 'immediate' | 'spaced',
+      navKeymap: ((): 'auto' | 'ctrl-alt' | 'ctrl-shift' => {
+        const v = get('nav-keymap', 'auto').toLowerCase();
+        return v === 'ctrl-alt' ? 'ctrl-alt' : v === 'ctrl-shift' ? 'ctrl-shift' : 'auto';
+      })(),
       cuesLlmProvider: bucketProvider(get('cues-llm-provider', 'inherit').toLowerCase()),
       auditorsLlmProvider: bucketProvider(get('auditors-llm-provider', 'inherit').toLowerCase()),
       blanksLlmProvider: bucketProvider(

--- a/packages/opencues-runtime/src/modules/cycling.test.ts
+++ b/packages/opencues-runtime/src/modules/cycling.test.ts
@@ -41,7 +41,7 @@ async function setup(text: string) {
   await loader.load();
   const cycling = new Cycling(adapter, hlState, dynDefs, loader);
   cycling.subscribe();
-  const nav = new Navigation(adapter, hlState, dynDefs);
+  const nav = new Navigation(adapter, hlState, dynDefs, loader);
   nav.subscribe();
   return { adapter, hlState, dynDefs, loader, cycling, nav };
 }
@@ -116,6 +116,45 @@ describe('Cycling', () => {
     expect(hlState.wordIndex).toBe(1);
     adapter.fireKey('up', { ctrl: true, alt: true });
     expect(adapter.setTextCalls.at(-1)).toBe('big quick');
+  });
+
+  describe('nav-keymap scalar — ctrl-shift fallback', () => {
+    // Pins the macOS-Terminal.app fallback. The same scenario as the
+    // canonical Ctrl+Alt cycle test, but with `nav-keymap: ctrl-shift`
+    // active. Verifies that (a) ctrl-shift+arrow now drives nav +
+    // cycling, and (b) ctrl-alt+arrow goes inert (the unmatched
+    // handler returns false so the host's own default takes over).
+    async function setupCtrlShift(text: string) {
+      const ctx = await setup(text);
+      // applyOpenCuesScalar is the canonical in-memory mutation
+      // path — the same one selector-satellite cycling uses when the
+      // user flips a setting at runtime. Tests get hot-reload semantics
+      // for free.
+      ctx.loader.applyOpenCuesScalar('nav-keymap', 'ctrl-shift');
+      return ctx;
+    }
+
+    it('Ctrl+Shift+Up drives cycling when nav-keymap: ctrl-shift', async () => {
+      const { adapter, hlState } = await setupCtrlShift('fast slow');
+      hlState.activate(0, 'fast slow');
+      expect(adapter.fireKey('up', { ctrl: true, shift: true })).toBe(true);
+      expect(adapter.setTextCalls.at(-1)).toBe('quick slow');
+    });
+
+    it('Ctrl+Alt+Up is inert when nav-keymap: ctrl-shift', async () => {
+      const { adapter, hlState } = await setupCtrlShift('fast slow');
+      hlState.activate(0, 'fast slow');
+      expect(adapter.fireKey('up', { ctrl: true, alt: true })).toBe(false);
+      expect(adapter.setTextCalls).toEqual([]);
+    });
+
+    it('Ctrl+Shift+Left/Right drives navigation when nav-keymap: ctrl-shift', async () => {
+      const { adapter, hlState } = await setupCtrlShift('big fast');
+      expect(adapter.fireKey('left', { ctrl: true, shift: true })).toBe(true);
+      expect(hlState.wordIndex).toBe(1); // rightmost: fast
+      expect(adapter.fireKey('up', { ctrl: true, shift: true })).toBe(true);
+      expect(adapter.setTextCalls.at(-1)).toBe('big quick');
+    });
   });
 });
 

--- a/packages/opencues-runtime/src/modules/cycling.ts
+++ b/packages/opencues-runtime/src/modules/cycling.ts
@@ -15,6 +15,7 @@ import type { HighlightState } from '../state/highlight-state';
 import { DynDefs, type WordDef } from '../state/dyn-defs';
 import type { ConfigLoader, BlankEntry } from './config-loader';
 import { splitWords } from './navigation';
+import { resolveNavKeymap } from './nav-keymap';
 import type { SpanFillState } from '../state/span-fill';
 import type { DismissedBlanks } from '../state/dismissed-blanks';
 import type { SelectorSatelliteState } from '../state/selector-satellite';
@@ -22,6 +23,8 @@ import type { SelectorSatelliteState } from '../state/selector-satellite';
 export class Cycling {
   private _unsubUp: Unsubscribe | null = null;
   private _unsubDown: Unsubscribe | null = null;
+  private _unsubUpShift: Unsubscribe | null = null;
+  private _unsubDownShift: Unsubscribe | null = null;
 
   constructor(
     private adapter: HostAdapter,
@@ -65,19 +68,40 @@ export class Cycling {
   }
 
   subscribe(): void {
+    // See navigation.ts for the design rationale — both combos are
+    // subscribed so the OPENCUES.md `nav-keymap` scalar hot-reloads;
+    // chrome skips ctrl-shift because the browser owns "extend
+    // selection by word" on that combo.
     this._unsubUp = this.adapter.onKey(
       { requireModifiers: ['ctrl', 'alt'], keys: ['up'] },
-      e => this.step(e, +1),
+      e => this.matchesKeymap('ctrl-alt') ? this.step(e, +1) : false,
     );
     this._unsubDown = this.adapter.onKey(
       { requireModifiers: ['ctrl', 'alt'], keys: ['down'] },
-      e => this.step(e, -1),
+      e => this.matchesKeymap('ctrl-alt') ? this.step(e, -1) : false,
     );
+    if (this.adapter.hostName !== 'chrome') {
+      this._unsubUpShift = this.adapter.onKey(
+        { requireModifiers: ['ctrl', 'shift'], keys: ['up'] },
+        e => this.matchesKeymap('ctrl-shift') ? this.step(e, +1) : false,
+      );
+      this._unsubDownShift = this.adapter.onKey(
+        { requireModifiers: ['ctrl', 'shift'], keys: ['down'] },
+        e => this.matchesKeymap('ctrl-shift') ? this.step(e, -1) : false,
+      );
+    }
   }
 
   unsubscribe(): void {
     if (this._unsubUp) { this._unsubUp(); this._unsubUp = null; }
     if (this._unsubDown) { this._unsubDown(); this._unsubDown = null; }
+    if (this._unsubUpShift) { this._unsubUpShift(); this._unsubUpShift = null; }
+    if (this._unsubDownShift) { this._unsubDownShift(); this._unsubDownShift = null; }
+  }
+
+  private matchesKeymap(combo: 'ctrl-alt' | 'ctrl-shift'): boolean {
+    const configured = this.configLoader.opencuesState.navKeymap ?? 'auto';
+    return resolveNavKeymap(configured, this.adapter.hostName) === combo;
   }
 
   /** Exposed for unit testing — direction is +1 (up, forward) / -1 (down, back). */

--- a/packages/opencues-runtime/src/modules/nav-keymap.test.ts
+++ b/packages/opencues-runtime/src/modules/nav-keymap.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { resolveNavKeymap } from './nav-keymap';
+
+const ORIGINAL_TERM_PROGRAM = process.env.TERM_PROGRAM;
+
+afterEach(() => {
+  if (ORIGINAL_TERM_PROGRAM === undefined) delete process.env.TERM_PROGRAM;
+  else process.env.TERM_PROGRAM = ORIGINAL_TERM_PROGRAM;
+});
+
+describe('resolveNavKeymap', () => {
+  it('explicit ctrl-alt is honoured on every host', () => {
+    process.env.TERM_PROGRAM = 'Apple_Terminal';
+    expect(resolveNavKeymap('ctrl-alt', 'mock')).toBe('ctrl-alt');
+    expect(resolveNavKeymap('ctrl-alt', 'chrome')).toBe('ctrl-alt');
+    expect(resolveNavKeymap('ctrl-alt', 'claude-code')).toBe('ctrl-alt');
+  });
+
+  it('explicit ctrl-shift is honoured on terminal hosts, even when running in Apple_Terminal', () => {
+    process.env.TERM_PROGRAM = 'Apple_Terminal';
+    expect(resolveNavKeymap('ctrl-shift', 'claude-code')).toBe('ctrl-shift');
+    delete process.env.TERM_PROGRAM;
+    expect(resolveNavKeymap('ctrl-shift', 'opencode')).toBe('ctrl-shift');
+  });
+
+  it('chrome ignores explicit ctrl-shift and pins to ctrl-alt — browser owns ctrl-shift+arrow', () => {
+    // The chrome adapter band doesn't subscribe ctrl-shift at all
+    // (see navigation.ts / cycling.ts), so this branch is belt-and-
+    // braces — if someone wires the runtime up differently, the
+    // resolver still keeps chrome on the safe combo.
+    expect(resolveNavKeymap('ctrl-shift', 'chrome')).toBe('ctrl-alt');
+  });
+
+  it('auto resolves to ctrl-shift on macOS Terminal.app', () => {
+    process.env.TERM_PROGRAM = 'Apple_Terminal';
+    expect(resolveNavKeymap('auto', 'claude-code')).toBe('ctrl-shift');
+    expect(resolveNavKeymap('auto', 'opencode')).toBe('ctrl-shift');
+  });
+
+  it('auto resolves to ctrl-alt on Ghostty / iTerm2 / no TERM_PROGRAM', () => {
+    process.env.TERM_PROGRAM = 'ghostty';
+    expect(resolveNavKeymap('auto', 'claude-code')).toBe('ctrl-alt');
+    process.env.TERM_PROGRAM = 'iTerm.app';
+    expect(resolveNavKeymap('auto', 'claude-code')).toBe('ctrl-alt');
+    delete process.env.TERM_PROGRAM;
+    expect(resolveNavKeymap('auto', 'claude-code')).toBe('ctrl-alt');
+  });
+
+  it('auto resolves to ctrl-alt for chrome — TERM_PROGRAM is irrelevant in a browser', () => {
+    process.env.TERM_PROGRAM = 'Apple_Terminal';
+    expect(resolveNavKeymap('auto', 'chrome')).toBe('ctrl-alt');
+  });
+});

--- a/packages/opencues-runtime/src/modules/nav-keymap.ts
+++ b/packages/opencues-runtime/src/modules/nav-keymap.ts
@@ -1,0 +1,39 @@
+// nav-keymap resolver — resolves the `nav-keymap` OPENCUES.md scalar
+// (auto / ctrl-alt / ctrl-shift) into the concrete modifier combo a
+// host's navigation + cycling handlers should match against.
+//
+// `auto` resolution:
+//   - chrome (hostName === 'chrome'): always 'ctrl-alt'.
+//     ctrl-shift+arrow is the canonical "extend text selection by word"
+//     shortcut in every browser textarea / contenteditable. Stealing
+//     it would clobber user muscle memory for a primary action — not
+//     worth the gain on a single misbehaving terminal.
+//   - macOS Terminal.app (TERM_PROGRAM === 'Apple_Terminal'):
+//     'ctrl-shift'. Apple's Terminal.app strips Ctrl+Alt+arrow before
+//     the running app ever sees it, so ctrl-alt is a dead default
+//     there. Ghostty / iTerm2 both forward Ctrl+Alt+arrow cleanly,
+//     so they stay on the ctrl-alt default.
+//   - Everything else: 'ctrl-alt'.
+//
+// Explicit `ctrl-alt` / `ctrl-shift` always wins over `auto`. The
+// menu still lets users override the auto pick from the cycling UI.
+
+export type NavKeymapScalar = 'auto' | 'ctrl-alt' | 'ctrl-shift';
+export type ResolvedNavKeymap = 'ctrl-alt' | 'ctrl-shift';
+
+export function resolveNavKeymap(
+  configured: NavKeymapScalar,
+  hostName: string,
+): ResolvedNavKeymap {
+  // Chrome ALWAYS gets ctrl-alt — ctrl-shift+arrow is the canonical
+  // "extend selection by word" shortcut in every browser textarea /
+  // contenteditable. The chrome adapter band also skips the ctrl-shift
+  // subscription entirely (see navigation.ts / cycling.ts); this is the
+  // belt-and-braces second check in the resolver itself.
+  if (hostName === 'chrome') return 'ctrl-alt';
+  if (configured === 'ctrl-alt' || configured === 'ctrl-shift') return configured;
+  const termProgram = typeof process !== 'undefined' && process.env
+    ? process.env.TERM_PROGRAM
+    : undefined;
+  return termProgram === 'Apple_Terminal' ? 'ctrl-shift' : 'ctrl-alt';
+}

--- a/packages/opencues-runtime/src/modules/navigation.ts
+++ b/packages/opencues-runtime/src/modules/navigation.ts
@@ -11,6 +11,7 @@ import type { DynDefs } from '../state/dyn-defs';
 import type { ConfigLoader } from './config-loader';
 import type { SpanFillState } from '../state/span-fill';
 import type { SelectorSatelliteState } from '../state/selector-satellite';
+import { resolveNavKeymap } from './nav-keymap';
 
 export interface WordSpan {
   readonly start: number;
@@ -22,6 +23,8 @@ export interface WordSpan {
 export class Navigation {
   private _unsubLeft: Unsubscribe | null = null;
   private _unsubRight: Unsubscribe | null = null;
+  private _unsubLeftShift: Unsubscribe | null = null;
+  private _unsubRightShift: Unsubscribe | null = null;
   private _unsubEscape: Unsubscribe | null = null;
   private _unsubText: Unsubscribe | null = null;
   private _unsubCursor: Unsubscribe | null = null;
@@ -51,14 +54,31 @@ export class Navigation {
   ) {}
 
   subscribe(): void {
+    // Subscribe to both modifier combos so flipping `nav-keymap` in
+    // OPENCUES.md hot-reloads without re-subscribing. Each handler
+    // gates on the resolved keymap per-keystroke; the unmatched combo
+    // returns false so the host's own behaviour (or nothing) takes
+    // over. Chrome is exempt — ctrl-shift+arrow is the canonical
+    // browser "extend selection by word" shortcut, so we don't even
+    // subscribe to avoid any chance of a stray preventDefault.
     this._unsubLeft = this.adapter.onKey(
       { requireModifiers: ['ctrl', 'alt'], keys: ['left'] },
-      e => this.onArrowLeft(e),
+      e => this.matchesKeymap('ctrl-alt') ? this.onArrowLeft(e) : false,
     );
     this._unsubRight = this.adapter.onKey(
       { requireModifiers: ['ctrl', 'alt'], keys: ['right'] },
-      e => this.onArrowRight(e),
+      e => this.matchesKeymap('ctrl-alt') ? this.onArrowRight(e) : false,
     );
+    if (this.adapter.hostName !== 'chrome') {
+      this._unsubLeftShift = this.adapter.onKey(
+        { requireModifiers: ['ctrl', 'shift'], keys: ['left'] },
+        e => this.matchesKeymap('ctrl-shift') ? this.onArrowLeft(e) : false,
+      );
+      this._unsubRightShift = this.adapter.onKey(
+        { requireModifiers: ['ctrl', 'shift'], keys: ['right'] },
+        e => this.matchesKeymap('ctrl-shift') ? this.onArrowRight(e) : false,
+      );
+    }
     // Escape deactivates the highlight without changing text.
     // No required modifier — bare Escape; forbidModifiers prevents
     // accidental capture during a Ctrl+Esc / Alt+Esc shortcut chord.
@@ -83,9 +103,16 @@ export class Navigation {
   unsubscribe(): void {
     if (this._unsubLeft) { this._unsubLeft(); this._unsubLeft = null; }
     if (this._unsubRight) { this._unsubRight(); this._unsubRight = null; }
+    if (this._unsubLeftShift) { this._unsubLeftShift(); this._unsubLeftShift = null; }
+    if (this._unsubRightShift) { this._unsubRightShift(); this._unsubRightShift = null; }
     if (this._unsubEscape) { this._unsubEscape(); this._unsubEscape = null; }
     if (this._unsubText) { this._unsubText(); this._unsubText = null; }
     if (this._unsubCursor) { this._unsubCursor(); this._unsubCursor = null; }
+  }
+
+  private matchesKeymap(combo: 'ctrl-alt' | 'ctrl-shift'): boolean {
+    const configured = this.configLoader?.opencuesState.navKeymap ?? 'auto';
+    return resolveNavKeymap(configured, this.adapter.hostName) === combo;
   }
 
   /**


### PR DESCRIPTION
## Summary

- New `nav-keymap` OPENCUES.md scalar (`auto` | `ctrl-alt` | `ctrl-shift`) so macOS Terminal.app users — whose terminal strips `Ctrl+Alt+arrow` before the running app ever sees it — get working word nav + cycling on `Ctrl+Shift+arrow` instead of having to install Ghostty / iTerm2.
- `auto` is the default and resolves per host: chrome → ctrl-alt always (ctrl-shift+arrow is the canonical browser "extend selection by word" shortcut); macOS Terminal.app (`TERM_PROGRAM=Apple_Terminal`) → ctrl-shift; everything else → ctrl-alt (no behaviour change for existing users).
- Hot-reloads — `Navigation` and `Cycling` subscribe both modifier combos at boot and gate per-keystroke against `resolveNavKeymap(state.navKeymap, hostName)`. Flipping the scalar in OPENCUES.md takes effect on the next key event; no restart.
- Chrome adapter band skips the ctrl-shift subscription entirely (belt-and-braces against stray preventDefault); the resolver also hard-pins chrome to ctrl-alt regardless of the configured value.
- `docs/install.md` gains a "macOS: Terminal.app doesn't forward Ctrl+Alt+arrow" subsection under the existing Linux/Wayland workspace-conflict section.

## Files

- `packages/opencues-core/src/feature-registry.ts` — new `nav-keymap` FeatureSpec
- `packages/opencues-runtime/src/modules/config-loader.ts` — `navKeymap` field on `OpenCuesState`; parse case in `parseOpenCuesMd` + `applyOpenCuesScalar`
- `packages/opencues-runtime/src/modules/nav-keymap.ts` — `resolveNavKeymap(configured, hostName)` resolver
- `packages/opencues-runtime/src/modules/{navigation,cycling}.ts` — subscribe ctrl-alt unconditionally, ctrl-shift only on non-chrome hosts; gate per-keystroke
- `docs/install.md` — Terminal.app section
- Tests: `nav-keymap.test.ts` (6 tests), `config-loader.test.ts` (parse coverage), `cycling.test.ts` (3 scenario tests under `nav-keymap: ctrl-shift`)

No package version bumps (small additive feature; following the existing skip-bump pattern used for sentence-cues / ambient-context). Existing 1454 runtime tests + 156 chrome tests + CLI + core suites all pass.

## Upgrade path

Per the project rule of naming the upgrade path before "go test":

1. **Pull master** after merge — source change only, no migration.
2. **Rebuild every fork** (because the change is in `@opencues/{core,runtime}`):
   - CC fork(s): `integrations/claude-code/patches/setup.sh` (default `~/claude-code-cues/`); for the 150 fork pass `OPENCUES_CC_TARGET=~/claude-code-cues-150/...` or `--target`.
   - OC fork: re-run the OC install path.
   - Chrome bake bundle: rebuild + copy to the Windows-side extension dir.
   - Shell `oc-edit` if installed.
3. **Default behaviour change is zero for everyone except macOS Terminal.app users** — their first launch after rebuild will pick `ctrl-shift` via the auto resolver.
4. To override explicitly, edit `~/.cues/OPENCUES.md`:
   ```
   nav-keymap: ctrl-alt    # force classic combo
   nav-keymap: ctrl-shift  # force Terminal.app fallback
   ```

## Test plan

- [x] `pnpm -r test` — full monorepo green (1454 runtime + 156 chrome + core + CLI suites)
- [ ] On macOS Terminal.app: launch claude-cues, type `the attorney filed today`, press `Ctrl+Shift+Right` — highlight should land on rightmost cued word
- [ ] On Ghostty/iTerm2: same buffer, `Ctrl+Alt+Right` still works (no regression)
- [ ] In Chrome on a contenteditable: `Ctrl+Shift+Right` still extends browser text selection (we never subscribe it)
- [ ] Flip `nav-keymap: ctrl-shift` in OPENCUES.md while the host is running, press a key, observe the keymap takes effect without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)