### PR TITLE
fix(shell): consolidate tmux mentions during `opencues install shell`

### DIFF
--- a/integrations/shell/bin/install.cjs
+++ b/integrations/shell/bin/install.cjs
@@ -67,20 +67,11 @@ function doInstall() {
     }
   }
 
-  const vendoredTmux = path.join(require('os').homedir(), '.opencues', 'vendor', 'tmux', 'bin', 'tmux');
-  const hasTmux =
-    fs.existsSync(vendoredTmux) ||
-    spawnSync('which', ['tmux'], { stdio: ['ignore', 'pipe', 'ignore'] }).status === 0;
-  if (!hasTmux) {
-    console.error('\nNOTE: tmux is not installed. oc-shell requires tmux >= 3.2.');
-    console.error('  macOS:         brew install tmux');
-    console.error('  Debian/Ubuntu: sudo apt install tmux');
-    console.error('  Fedora:        sudo dnf install tmux');
-    console.error('  Arch:          sudo pacman -S tmux');
-    console.error('After installing, run oc-install-tmux to build a private copy for oc-shell,');
-    console.error('or set OPENCUES_TMUX=/path/to/tmux to use your system tmux directly.');
-    console.error('');
-  }
+  // tmux warning lives in the top-level `opencues install` preflight
+  // (packages/opencues-cli/src/commands/install.cjs) — duplicating it
+  // here was the second of four tmux mentions per install. Removed.
+  // The post-setup.sh `hasUsableTmux` check still runs oc-install-tmux
+  // if needed, with a clearer "why" message at the call site.
 
   if (args.dryRun) {
     console.log('\n[dry-run] Would build @opencues/{core,runtime}.');
@@ -133,12 +124,29 @@ function doInstall() {
   //      path first, falls through to source build if 404. Source build
   //      may fail if the C-toolchain isn't installed — at that point
   //      oc-install-tmux prints platform-specific apt/brew commands.
+  let tmuxOk = true;
   if (!hasUsableTmux()) {
+    // State at this point: no vendored tmux exists AND system tmux is
+    // either missing or < 3.2. Show WHY we're vendoring so the user
+    // isn't surprised by a 30-second build step appearing after a
+    // smooth install. The installer tries a prebuilt tarball first
+    // (zero compile-deps) and only falls through to source build if
+    // that 404s.
+    const sysVer = (() => {
+      try {
+        const out = require('child_process').execSync('tmux -V 2>/dev/null', { encoding: 'utf8' });
+        const m = out.match(/tmux (\d+)\.(\d+)/);
+        return m ? `${m[1]}.${m[2]}` : null;
+      } catch { return null; }
+    })();
     console.log('');
-    console.log('▸ Setting up tmux for oc-shell (one-time)…');
+    console.log(sysVer
+      ? `▸ System tmux is ${sysVer} (oc-shell needs ≥ 3.2). Vendoring tmux 3.4 to ~/.opencues/vendor/tmux/ — your system tmux is untouched.`
+      : '▸ No tmux on PATH. Vendoring tmux 3.4 to ~/.opencues/vendor/tmux/ (one-time, ~30s).');
     const tmuxInstaller = path.join(PKG_DIR, 'bin', 'oc-install-tmux');
     const tmuxResult = spawnSync('bash', [tmuxInstaller], { stdio: 'inherit' });
     if (tmuxResult.status !== 0) {
+      tmuxOk = false;
       console.log('');
       console.log('  oc-install-tmux didn\'t complete. oc-shell needs tmux 3.2+ to launch.');
       console.log('  Options: (a) install via your package manager (apt/brew install tmux), then re-run');
@@ -147,6 +155,25 @@ function doInstall() {
       // Non-fatal — the rest of the install succeeded; tmux is per-launch.
     }
   }
+  // Launch / how-to summary — final lines of the install so they
+  // don't get buried by a 30-second tmux vendor build that prints
+  // ABOVE this block. Skipped if tmux didn't land — that path
+  // already printed actionable next-steps.
+  if (tmuxOk) printShellLaunchSummary();
+}
+
+function printShellLaunchSummary() {
+  // tput is the portable way to emit dim/reset; falls back to empty
+  // strings when stdout isn't a TTY (CI / piped runs).
+  const dim = process.stdout.isTTY ? '\x1b[2m' : '';
+  const reset = process.stdout.isTTY ? '\x1b[22m' : '';
+  console.log('');
+  console.log(`Launch:        ${'opencues run shell'.padEnd(20)} ${dim}# wraps your $SHELL in a private tmux session${reset}`);
+  console.log(`Open input:    ${'Alt+Shift+↑'.padEnd(20)} ${dim}# inside oc-shell, opens the OpenCues input pane${reset}`);
+  console.log('');
+  console.log('Optional one-time setup — capture the current shell line on Alt+Shift+↑:');
+  console.log(`  ${path.join(PKG_DIR, 'bin', 'oc-install-shell-integration')}`);
+  console.log('  (adds a source line to .bashrc/.zshrc/fish config; uninstall later cleans it up)');
 }
 
 // Probe for a usable tmux. Returns true if either:

--- a/integrations/shell/patches/setup.sh
+++ b/integrations/shell/patches/setup.sh
@@ -89,15 +89,9 @@ if [[ -n "$LINK_DIR" ]]; then
   done
 fi
 
-echo "✓ Terminal integration ready."
-echo
-echo "Try it:"
-echo "  $TERM_DIR/bin/oc-shell                    # shell wrapped with Alt+Shift+↑ input box"
-echo
-echo "Before first launch, build the vendored tmux 3.4 (one-time, ~30s):"
-echo "  $TERM_DIR/bin/oc-install-tmux          # builds to ~/.opencues/vendor/tmux/"
-echo "  (system tmux is never touched; user PATH is never changed)"
-echo
-echo "Optional — capture-current-line shell integration:"
-echo "  $TERM_DIR/bin/oc-install-shell-integration"
-echo "  (adds a one-time source line to your .bashrc/.zshrc/.fishrc)"
+echo "✓ Shell build done."
+# Launch / how-to summary is printed by integrations/shell/bin/install.cjs
+# AFTER the tmux vendoring step so the user reads "ready to launch"
+# as the last line, not before a 30-second source-build kicks off.
+# Devs invoking setup.sh directly get just the build confirmation —
+# next-steps live in CLAUDE.md / README.md.

--- a/packages/opencues-cli/src/commands/install.cjs
+++ b/packages/opencues-cli/src/commands/install.cjs
@@ -216,38 +216,57 @@ function preflightChecks(folders) {
   }
 
   // ── tmux 3.2+ (shell integration only) ────────────────────────────
+  // Skip entirely if `~/.opencues/vendor/tmux/bin/tmux` is already
+  // present and >= 3.2 — oc-shell prefers the vendored binary, and
+  // dragging the user through an apt/brew tmux install on top of that
+  // is pure noise (and was the second of FOUR tmux mentions in one
+  // `opencues install shell` run pre-2026-06). Mirrors doctor.cjs's
+  // vendored-first check at the same precedence.
   if (folders.includes('shell')) {
-    let tmuxInstall = platform === 'darwin' ? 'brew install tmux'
-      : 'apt install tmux  (or `dnf install tmux` / `pacman -S tmux`)';
-    const tmuxAuto = { apt: 'tmux', dnf: 'tmux', pacman: 'tmux', brew: 'tmux' };
-    try {
-      const out = execSync('tmux -V 2>/dev/null', { encoding: 'utf8' });
-      const m = out.match(/tmux (\d+)\.(\d+)/);
-      if (m) {
+    const vendoredTmux = path.join(os.homedir(), '.opencues', 'vendor', 'tmux', 'bin', 'tmux');
+    const vendoredUsable = (() => {
+      if (!fs.existsSync(vendoredTmux)) return false;
+      try {
+        const out = execSync(`${JSON.stringify(vendoredTmux)} -V 2>/dev/null`, { encoding: 'utf8' });
+        const m = out.match(/tmux (\d+)\.(\d+)/);
+        if (!m) return false;
         const maj = parseInt(m[1], 10), min = parseInt(m[2], 10);
-        if (maj < 3 || (maj === 3 && min < 2)) {
+        return maj > 3 || (maj === 3 && min >= 2);
+      } catch { return false; }
+    })();
+    if (!vendoredUsable) {
+      let tmuxInstall = platform === 'darwin' ? 'brew install tmux'
+        : 'apt install tmux  (or `dnf install tmux` / `pacman -S tmux`)';
+      const tmuxAuto = { apt: 'tmux', dnf: 'tmux', pacman: 'tmux', brew: 'tmux' };
+      try {
+        const out = execSync('tmux -V 2>/dev/null', { encoding: 'utf8' });
+        const m = out.match(/tmux (\d+)\.(\d+)/);
+        if (m) {
+          const maj = parseInt(m[1], 10), min = parseInt(m[2], 10);
+          if (maj < 3 || (maj === 3 && min < 2)) {
+            warnings.push({
+              item: `tmux ${maj}.${min}`,
+              impact: 'oc-shell needs tmux 3.2+ for display-popup',
+              fix: tmuxInstall,
+              autoInstall: tmuxAuto,
+            });
+          }
+        } else {
           warnings.push({
-            item: `tmux ${maj}.${min}`,
-            impact: 'oc-shell needs tmux 3.2+ for display-popup',
+            item: 'tmux not found on PATH',
+            impact: 'oc-shell needs tmux 3.2+ (will be vendored to ~/.opencues/vendor/tmux/ if you skip)',
             fix: tmuxInstall,
             autoInstall: tmuxAuto,
           });
         }
-      } else {
+      } catch {
         warnings.push({
           item: 'tmux not found on PATH',
-          impact: 'oc-shell needs tmux 3.2+',
+          impact: 'oc-shell needs tmux 3.2+ (will be vendored to ~/.opencues/vendor/tmux/ if you skip)',
           fix: tmuxInstall,
           autoInstall: tmuxAuto,
         });
       }
-    } catch {
-      warnings.push({
-        item: 'tmux not found on PATH',
-        impact: 'oc-shell needs tmux 3.2+',
-        fix: tmuxInstall,
-        autoInstall: tmuxAuto,
-      });
     }
   }
 


### PR DESCRIPTION
## Summary

`opencues install shell` mentioned tmux in **four** distinct places per install (preflight warning, shell-installer duplicate warning, silent auto-vendor build, and a misleading "before first launch, build the vendored tmux" tail line that contradicted the silent build that just ran). This PR consolidates everything to **at most two** mentions on a fresh install — the preflight warning + the auto-vendor "vendoring tmux 3.4 because …" line — and **zero** on re-installs with a vendored tmux already in place.

## Changes

- **`packages/opencues-cli/src/commands/install.cjs`** (preflight): skip the tmux warning entirely when `~/.opencues/vendor/tmux/bin/tmux ≥ 3.2` is already present. Mirrors `doctor.cjs`'s vendored-first check. Re-installs are silent.
- **`integrations/shell/bin/install.cjs`**:
  - Delete the duplicate "NOTE: tmux is not installed" block. Umbrella preflight is the single source of truth.
  - Improve the auto-vendor message: `▸ System tmux is 3.0 (oc-shell needs ≥ 3.2). Vendoring tmux 3.4 to ~/.opencues/vendor/tmux/ — your system tmux is untouched.`
  - Move the Launch / Open input / Optional-shell-integration summary OUT of `setup.sh`'s tail and into `install.cjs`, so it prints AFTER the tmux vendor step instead of before it.
- **`integrations/shell/patches/setup.sh`**: tail is now just `✓ Shell build done.` — devs invoking `setup.sh` directly get the build confirmation; user-facing launch summary lives in `install.cjs`.

## Verified end-to-end

System tmux 3.0a installed, no vendored:

```
First install:
• Linux preflight — runtime notes for this install:
  • tmux 3.0
    impact: oc-shell needs tmux 3.2+ for display-popup
    fix:    apt install tmux  (...)
  (install will continue — ...)

[install runs]
✓ Shell build done.

▸ System tmux is 3.0 (oc-shell needs ≥ 3.2). Vendoring tmux 3.4 to ~/.opencues/vendor/tmux/ — your system tmux is untouched.
[builds tmux 3.4 from source]
✓ tmux 3.4 installed at /home/wilfred/.opencues/vendor/tmux/bin/tmux

Launch:        opencues run shell   # wraps your $SHELL in a private tmux session
Open input:    Alt+Shift+↑          # inside oc-shell, opens the OpenCues input pane

Optional one-time setup — capture the current shell line on Alt+Shift+↑:
  /.../integrations/shell/bin/oc-install-shell-integration

🗸 shell


Second install (vendored present):
[no tmux mentions at all]
[install runs]
✓ Shell build done.

Launch:        opencues run shell   # ...
Open input:    Alt+Shift+↑          # ...
...

🗸 shell
```

## Test plan

- [x] Real install with system tmux 3.0a, no vendored — succeeded; one preflight mention + one vendoring notice; summary at the end
- [x] Real install with vendored tmux 3.4 already present — zero tmux mentions
- [x] CLI tests (`pnpm test` in opencues-cli) pass
- [ ] macOS test (no system tmux, brew available) — `opencues install shell` should offer `brew install tmux` once via preflight, accept Y, then either skip vendoring or vendor 3.4 depending on brew's tmux version

🤖 Generated with [Claude Code](https://claude.com/claude-code)