### PR TITLE
fix(cli): sandbox vendor-pins test $HOME so it stops deleting real ~/.opencues/vendor/

### DIFF
--- a/packages/opencues-cli/src/lib/vendor-pins.test.cjs
+++ b/packages/opencues-cli/src/lib/vendor-pins.test.cjs
@@ -1,6 +1,6 @@
 'use strict';
 
-const { test, describe } = require('node:test');
+const { test, describe, before, after, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
@@ -8,7 +8,50 @@ const os = require('node:os');
 
 const { writeVendorMarker, readVendorMarker, checkVendorDrift, markerPath, vendorDir } = require('./vendor-pins.cjs');
 
+// HERMETICITY ─────────────────────────────────────────────────────────
+// Every helper in vendor-pins.cjs resolves paths via `os.homedir()`,
+// which reads `process.env.HOME`. The tests below mutate
+// `~/.opencues/vendor/<tool>/` — if they ran against the real $HOME
+// they would (and historically DID) silently delete the user's
+// vendored tmux / bun directories on every `pnpm test` run.
+//
+// Symptom that pinned this: running `pnpm test` in opencues-cli would
+// `rm -rf ~/.opencues/vendor/tmux/` six times, then a later
+// `opencues run shell` would fall through to /usr/bin/tmux 3.0 and
+// fail the >= 3.2 version check. The vendor binary was being
+// destroyed by the test that's supposed to verify the marker code
+// works.
+//
+// Fix: redirect `$HOME` to a per-test-file tempdir for the whole
+// suite. `os.homedir()` reads HOME on every call (it's not cached),
+// so this works even though vendor-pins.cjs was required before the
+// override. The original HOME is restored at the end.
+const ORIGINAL_HOME = process.env.HOME;
+let SANDBOX_HOME = '';
+
+before(() => {
+  SANDBOX_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'opencues-vendor-pins-test-'));
+  process.env.HOME = SANDBOX_HOME;
+});
+
+after(() => {
+  process.env.HOME = ORIGINAL_HOME;
+  try { fs.rmSync(SANDBOX_HOME, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// Per-test cleanup — drop ~/<sandbox>/.opencues so each test starts
+// from an empty slate. Safe now because `~` is the sandboxed tempdir,
+// not the real user's home.
+beforeEach(() => {
+  try {
+    fs.rmSync(path.join(SANDBOX_HOME, '.opencues'), { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
 function clean(tool) {
+  // Belt-and-braces: this still resolves to the sandboxed HOME because
+  // os.homedir() reads $HOME on every call. Kept inline so the tests'
+  // intent ("start from a clean per-tool slate") stays readable.
   try { fs.rmSync(vendorDir(tool), { recursive: true, force: true }); } catch {}
 }
 
@@ -70,14 +113,15 @@ test("checkVendorDrift: bun with wildcard '*' pin treats any version as fresh", 
 });
 
 test('writeVendorMarker: silent failure on unwritable target', () => {
-  // Force a write to a path that can't exist. Returns null, no throw.
-  const origHome = process.env.HOME;
+  // Override the sandboxed HOME to an un-writable path for the
+  // duration of this one test. Restored before the next test runs.
+  const sandboxHome = process.env.HOME;
   process.env.HOME = '/dev/null/nope';
   try {
     const data = writeVendorMarker('tmux', '3.4');
     assert.strictEqual(data, null);
   } finally {
-    process.env.HOME = origHome;
+    process.env.HOME = sandboxHome;
   }
 });
 


### PR DESCRIPTION
## The bug

`packages/opencues-cli/src/lib/vendor-pins.test.cjs` called `clean('tmux')` / `clean('bun')` across six tests; each one ran `fs.rmSync(vendorDir(tool), { recursive: true, force: true })` against the **real user's home** (`vendorDir` is `path.join(os.homedir(), '.opencues', 'vendor', tool)`). So every `pnpm test` run in `opencues-cli` silently wiped `~/.opencues/vendor/tmux/`. Subsequent `opencues run shell` would then fall through to `/usr/bin/tmux` (whatever the system ships) and fail the `>= 3.2` version check — telling the user to `rm -rf ~/.opencues/vendor/tmux && oc-install-tmux`, i.e. delete a directory we'd just deleted.

I caught this only after spending half a session debugging it on a real machine.

## The fix

Redirect `process.env.HOME` to a per-suite `fs.mkdtempSync` tempdir in a `before` hook, restore in `after`. `os.homedir()` reads `HOME` on every call (not cached), so `vendor-pins.cjs`'s helpers silently follow the override. `beforeEach` wipes the sandbox `.opencues/` between tests so each starts clean. The existing "writeVendorMarker: silent failure on unwritable target" test keeps its own targeted `HOME` override.

## Verified

- BEFORE: `~/.opencues/vendor/tmux/` disappears after `pnpm test`.
- AFTER: it survives. All 8 vendor-pins tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)