### PR TITLE
fix(cc-setup): set -o pipefail + tsc check so silent npm failures abort

### DIFF
--- a/integrations/claude-code/patches/setup.sh
+++ b/integrations/claude-code/patches/setup.sh
@@ -35,7 +35,16 @@
 #   OPENCUES_CC_TARGET=<path>    cli.js to patch (default: auto-detect under fork)
 #
 
-set -e
+# pipefail is load-bearing here: every install step is piped through
+# `tail -N` to keep the user-visible output short. Without pipefail,
+# a failing `npm install ... | tail -3` returns tail's exit (0) and
+# set -e doesn't fire — the script silently marches on with no
+# node_modules/, then fails late at the dist-verification step with
+# a misleading "tweakcc dist contains no opencues v2 code" message.
+# Caught June 2026 after a transient npm error left tweakcc deps
+# missing on a real user install. See `assert_dir_nonempty` below
+# for the belt-and-braces post-install check.
+set -eo pipefail
 
 # BSD sed (macOS) requires an explicit extension arg after -i (even empty '');
 # GNU sed (Linux/WSL) does not accept it as a separate argument.
@@ -228,6 +237,18 @@ if $KEEP_STATE && [ -d "$TWEAKCC_DIR/.git" ]; then
 else
   git clone https://github.com/Piebald-AI/tweakcc "$TWEAKCC_DIR"
   (cd "$TWEAKCC_DIR" && npm install --legacy-peer-deps --no-audit --no-fund 2>&1 | tail -3)
+  # Belt-and-braces — pipefail (top of file) already aborts on a
+  # failing `npm install`, but a flake of "exited 0 + node_modules
+  # incomplete" would still slip through. This check looks for the
+  # specific binary the next build step needs (tsc); missing means
+  # the build will fail with a misleading "tsc: not found" error
+  # downstream. Better to fail here with the real cause.
+  if [ ! -x "$TWEAKCC_DIR/node_modules/.bin/tsc" ]; then
+    echo "FATAL: tweakcc deps incomplete — $TWEAKCC_DIR/node_modules/.bin/tsc missing after npm install." >&4
+    echo "  Likely cause: npm install hit a transient error (network, registry, peer dep)." >&4
+    echo "  Recover: rm -rf $TWEAKCC_DIR && re-run this script." >&4
+    exit 1
+  fi
 fi
 end_step
 


### PR DESCRIPTION
## The bug you hit

\`opencues install claude-code --rebuild\` finished every step with ✓ then failed at the end with:

\`\`\`
FATAL: tweakcc dist contains no opencues v2 code.
  Searched: /home/wilfred/claude-code-cues/.cues/tweakcc/dist/*.mjs
  Expected: writeOpenCuesRuntimeV2, @opencues/runtime
  Likely cause: section 4b (orchestrator wiring) didn't run cleanly.
\`\`\`

The "likely cause" was wrong. Section 4b had run cleanly (\`index.ts\` had \`writeOpenCuesRuntimeV2\` correctly imported + invoked). The actual cause was \`~/claude-code-cues/.cues/tweakcc/node_modules/\` didn't exist — \`npm install\` had silently failed three steps earlier.

## Why setup.sh swallowed the npm failure

\`integrations/claude-code/patches/setup.sh\` used \`set -e\` but **NOT** \`set -o pipefail\`. The clone+install step:

\`\`\`bash
(cd "\$TWEAKCC_DIR" && npm install --legacy-peer-deps --no-audit --no-fund 2>&1 | tail -3)
\`\`\`

Without pipefail, when npm install fails:
- npm exits non-zero
- \`tail -3\` exits 0 (it succeeded — it tailed something)
- the pipe returns tail's status (0)
- subshell returns 0
- \`set -e\` doesn't fire
- setup.sh marches on with no node_modules

Then section 7 calls \`npm run build\` → \`tsc --noEmit && tsdown ...\` → \`tsc: not found\` → no dist → verification at line 390 trips the misleading FATAL.

## Fix

- \`set -eo pipefail\` so the first failure in any pipeline aborts the script.
- Belt-and-braces post-install check: if \`\$TWEAKCC_DIR/node_modules/.bin/tsc\` is missing after \`npm install\`, abort with the real cause + a recovery hint (\`rm -rf \$TWEAKCC_DIR && re-run\`) instead of letting it surface 200 lines later as the dist error.

Audited all five \`| tail -N\` patterns in setup.sh — they're noise reduction on successful commands; pipefail is the correct behaviour for every one.

## Verified

Re-ran \`opencues install claude-code --rebuild --no-prompts\` against the broken state. Now completes end-to-end:

\`\`\`
▸ /home/wilfred/claude-code-cues (native)
  ▸ Nuking prior install state ✓
  ▸ Installing pinned @anthropic-ai/claude-code ✓
  ▸ Cloning tweakcc ✓
  ▸ Patching tweakcc source ✓
  ▸ Building + installing @opencues/{core,runtime} ✓
  ▸ Installing CC support files (statusline) ✓
  ▸ Building tweakcc ✓
  ▸ Applying patches to native-binary ✓

Done. Restart Claude Code to activate.
✓ /home/wilfred/claude-code-cues (native) installed + validated.
\`\`\`

## Test plan

- [x] Manual install with the fix succeeds end-to-end on a real machine
- [x] \`bash -n integrations/claude-code/patches/setup.sh\` syntax-clean
- [ ] Test a synthetic npm-install failure (drop network mid-install) and verify the script aborts at the right step with the right error

🤖 Generated with [Claude Code](https://claude.com/claude-code)