### PR TITLE
fix(blanks): log dispatch failures + tighten HTTP timeout to 15s

### DIFF
--- a/packages/opencues-core/node-http-adapter.js
+++ b/packages/opencues-core/node-http-adapter.js
@@ -28,6 +28,19 @@ exports.NodeHttpAdapter = void 0;
 /**
  * Node.js HTTP adapter with HTTPS keep-alive and optional provider config.
  */
+// Default timeout for a single LLM HTTP call. 30s was the original
+// default (June 2025); reduced to 15s in June 2026 after opencode-zen
+// free pool silent-hang regressions left users staring at `_` for
+// 30+ seconds with no log. 15s is still generous — every shipping
+// provider returns a real response well under 5s for typical
+// blank-sized prompts. Tighter values risked false-positive
+// timeouts on cold-start latency from slower providers; 15s leaves
+// 3x headroom over the slowest observed legitimate response.
+// Override via `new NodeHttpAdapter({ timeout: ms })` for batch /
+// long-running calls (none in the runtime today; benches set their
+// own).
+const DEFAULT_TIMEOUT_MS = 15000;
+
 class NodeHttpAdapter {
     constructor(config = {}) {
         this.config = config;
@@ -35,7 +48,7 @@ class NodeHttpAdapter {
         this.agent = new https.Agent({
             keepAlive: true,
             maxSockets: config.maxSockets || 2,
-            timeout: config.timeout || 30000,
+            timeout: config.timeout || DEFAULT_TIMEOUT_MS,
         });
         // Provider-specific overrides (e.g., Groq reasoning_effort)
         this.providerOverrides = config.providerOverrides || {};
@@ -86,7 +99,7 @@ class NodeHttpAdapter {
                     method: 'POST',
                     headers,
                     agent: this.agent,
-                    timeout: this.config.timeout || 30000,
+                    timeout: this.config.timeout || DEFAULT_TIMEOUT_MS,
                 }, (res) => {
                     let data = '';
                     res.on('data', (chunk) => { data += chunk; });

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/fluid-blank-source.ts
+++ b/packages/opencues-core/src/sources/fluid-blank-source.ts
@@ -844,6 +844,16 @@ export class FluidBlankSource implements CueSource {
       this.emit({ type: 'bailed', reason: 'llm-error', latencyMs: Date.now() - startTime });
       const err = error instanceof Error ? error : new Error(String(error));
       const reason = classifyHttpError(err);
+      // ALWAYS log dispatch failures at info level. Before June 2026 this
+      // catch silently stuffed the error into the result envelope and
+      // returned; the caller (resolver) ignored the `error` field, so the
+      // user saw "FluidBlank: starting" with no completion log forever.
+      // Silent hangs on opencode-zen/free were the trigger — symptom was
+      // typing `_` and getting nothing, no error, no clue why. Visible
+      // log gives the user (and us during debugging) a real signal.
+      this.logInfo(
+        `FluidBlank: failed (${Date.now() - startTime}ms, llm=${this.provider.id}/${this.model}) — ${err.message}`,
+      );
       // Only USER-ACTIONABLE failures get an in-buffer substitute.
       // Generic / transient LLM hiccups stay silent — retry on next change.
       const blankIdx = context.words.indexOf('_');

--- a/packages/opencues-core/src/sources/transform-blank-source.ts
+++ b/packages/opencues-core/src/sources/transform-blank-source.ts
@@ -1908,9 +1908,20 @@ export class TransformBlankSource implements CueSource {
 
       return { results: [result], timing: Date.now() - startTime, model: this.model };
     } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      // ALWAYS log dispatch failures at info level. Before June 2026 this
+      // catch silently stuffed the error into the result envelope and
+      // returned; the caller (resolver) ignored the `error` field, so the
+      // user saw "TransformBlank: starting" with no completion log forever.
+      // Silent hangs on opencode-zen/free were the trigger — symptom was
+      // typing a verb-prefixed `_` and getting nothing, no error, no clue.
+      // Visible log gives the user a real signal.
+      this.log(
+        `TransformBlank: failed (${Date.now() - startTime}ms, llm=${this.provider.id}/${this.model}) — ${msg}`,
+      );
       return {
         results: [],
-        error: error instanceof Error ? error.message : String(error),
+        error: msg,
         timing: Date.now() - startTime,
       };
     }

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",


### PR DESCRIPTION
## Why

Yesterday's session: opencode-zen/free started returning nothing for blank-sized prompts. The runtime kept firing TransformBlank + FluidBlank requests; every one of them hung for the 30s HTTP timeout then quietly failed. The user saw `TransformBlank: starting (...)` log lines piling up for 5+ minutes with **no completion log, no error log, no clue why blanks weren't resolving** — until we manually dug into the source and saw the catch swallowing the error.

This PR closes the visibility gap + makes the timeout interactive-friendly.

## Two fixes

**1. Log every dispatch failure at the source-class catch sites.**

`transform-blank-source.ts` and `fluid-blank-source.ts` both ended their pipeline in a `try { … } catch (err) { return { results: [], error: msg } }`. The resolver ignores the `error` field — only sees `results: []` and moves on. Source-class logs went silent. Now both emit:

```
TransformBlank: failed (15243ms, llm=opencode-zen/free) — timeout
FluidBlank: failed (15187ms, llm=opencode-zen/free) — timeout
```

at info level, on the same channel as the existing `: starting` line. The two log lines pair visibly in /tmp/opencues.log.

**2. Tighten HTTP timeout from 30s → 15s.**

30s was too long for interactive blanks (the user gives up around 5-8s). 15s is still 3x headroom over the slowest observed legit response from any shipping provider (cold-start cerebras ~3s, warm groq ~1.5s, gemini-2.0-flash ~5s). Centralised as `DEFAULT_TIMEOUT_MS` constant in `node-http-adapter.js` with the tuning history inline so it doesn't drift back to 30s next time someone adjusts it.

## Version bumps

- `@opencues/core` 0.1.5 → 0.1.6
- `@opencues/runtime` 0.1.6 → 0.1.7

Caught up to current source per the srcHash-driven self-heal contract — version bumps aren't load-bearing for drift detection anymore (srcHash fires on any source byte) but they remain best practice for changelog discoverability.

## Test plan

- [x] 1454 runtime tests pass
- [x] 117 core tests pass
- [ ] Reintroduce a hang (point blanks-llm-provider at a stalled endpoint) and verify the new `TransformBlank: failed` line fires within 15s

🤖 Generated with [Claude Code](https://claude.com/claude-code)