### PR TITLE
fix(chrome): tag provider-audit warning with [chrome] + clarify recovery path

### DIFF
--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -1883,13 +1883,24 @@ async function auditProvidersAgainstKeys(keys: Record<string, string>): Promise<
     }
   }
   if (problems.length === 0) return;
+  // Prefix the warning with [chrome] so it's unambiguous WHICH host is
+  // complaining when /tmp/opencues.log is shared with CC/OC/gemini-cli
+  // — those hosts read process.env directly so they see different
+  // keys-available state than chrome (which reads chrome.storage).
+  // Before June 2026 this warning landed in the shared log as a
+  // generic "[opencues]" line; users on CC with the env var SET saw
+  // "needs CEREBRAS_API_KEY" and assumed their CC install was broken.
+  // The host tag pins the warning to the actual misconfigured host.
   log.warn(
-    `[opencues] CUES.md provider audit found ${problems.length} ` +
-    `misconfigured ${problems.length === 1 ? 'directive' : 'directives'}:\n` +
+    `[opencues][chrome] CUES.md provider audit found ${problems.length} ` +
+    `misconfigured ${problems.length === 1 ? 'directive' : 'directives'} ` +
+    `(chrome reads keys from chrome.storage — env vars do NOT propagate):\n` +
     problems.join('\n') + '\n' +
-    `Set the missing env keys (CC/OC/gemini-cli read process.env + ~/.cues/.env), ` +
-    `or save them in the OpenCues popup (chrome). Cues/blanks routed to these ` +
-    `providers will silently no-op until fixed.`,
+    `Fix: save the missing keys in the OpenCues popup. (Native hosts ` +
+    `CC/OC/gemini-cli read process.env / ~/.cues/.env independently; ` +
+    `if a key is set in your shell, those hosts already have it — ` +
+    `only chrome needs the popup save.) Cues/blanks routed to these ` +
+    `providers will silently no-op on chrome until fixed.`,
   );
 }
 


### PR DESCRIPTION
## The bug

Chrome's provider audit at boot warns when CUES.md declares a provider whose API key isn't in chrome.storage. The warning landed in /tmp/opencues.log as:

\`\`\`
[opencues] CUES.md provider audit found 4 misconfigured directives:
  - "llm-provider: cerebras" — needs CEREBRAS_API_KEY
  - "word-cues-provider: cerebras" — needs CEREBRAS_API_KEY
  ...
\`\`\`

No \`[chrome]\` prefix. Users running CC alongside chrome saw this in their shared logfile and assumed CC was misconfigured — because their shell env HAS \`CEREBRAS_API_KEY\` set. The warning was actually about chrome.storage's view, not env's view, but the message didn't say so.

## Fix

- Prefix with \`[opencues][chrome]\` so the host owner is unambiguous.
- Rewrite the warning header to call out the chrome ≠ env split explicitly: "chrome reads keys from chrome.storage — env vars do NOT propagate".
- Rewrite the recovery hint to say "save the missing keys in the OpenCues popup" as the primary path, with a parenthetical clarifying that native hosts (CC/OC/gemini-cli) read env independently and don't need the popup save.

New warning shape:

\`\`\`
[opencues][chrome] CUES.md provider audit found 4 misconfigured directives (chrome reads keys from chrome.storage — env vars do NOT propagate):
  - "llm-provider: cerebras" — needs CEREBRAS_API_KEY
  ...
Fix: save the missing keys in the OpenCues popup. (Native hosts CC/OC/gemini-cli read process.env / ~/.cues/.env independently; if a key is set in your shell, those hosts already have it — only chrome needs the popup save.) Cues/blanks routed to these providers will silently no-op on chrome until fixed.
\`\`\`

## Versions

\`@opencues/chrome\` 0.1.2 → 0.1.3

## Test plan

- [x] 156 chrome tests pass
- [ ] Manual: trigger the audit by setting an unsaved provider in OPENCUES.md, observe the new \`[opencues][chrome]\` line in the shared log

🤖 Generated with [Claude Code](https://claude.com/claude-code)