### PR TITLE
feat(config-loader): background poll so OPENCUES.md edits hot-reload without typing

### DIFF
--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/config-loader.test.ts
+++ b/packages/opencues-runtime/src/modules/config-loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ConfigLoader, parseOpenCuesMd } from './config-loader';
 import { MockAdapter, wrapTipsAsCuesMd } from '../../testing/mock-adapter';
 
@@ -515,5 +515,63 @@ describe('bucket scalars (three-bucket simplification)', () => {
     );
     expect(state.cuesLlmProvider).toBe('inherit');
     expect(state.blanksLlmProvider).toBe('inherit');
+  });
+});
+
+describe('background-poll hot reload (June 2026)', () => {
+  // The keystroke-driven onTextChange path is well-tested above. This
+  // suite pins the background timer path that fires `maybeReload` even
+  // when the host stays idle. Closes the "I changed OPENCUES.md but
+  // nothing happened until I typed" surprise.
+
+  it('subscribe() creates a polling interval when backgroundPollMs > 0', async () => {
+    const adapter = new MockAdapter({ files: {} });
+    const loader = new ConfigLoader(adapter, { backgroundPollMs: 100 });
+    await loader.load();
+    loader.subscribe();
+    // Reflect on the private field via the same cast pattern the rest
+    // of the file uses for white-box state checks.
+    const inner = loader as unknown as { _pollTimer: unknown };
+    expect(inner._pollTimer).not.toBeNull();
+    loader.unsubscribe();
+    expect(inner._pollTimer).toBeNull();
+  });
+
+  it('subscribe() with backgroundPollMs: 0 skips the timer entirely', async () => {
+    const adapter = new MockAdapter({ files: {} });
+    const loader = new ConfigLoader(adapter, { backgroundPollMs: 0 });
+    await loader.load();
+    loader.subscribe();
+    const inner = loader as unknown as { _pollTimer: unknown };
+    expect(inner._pollTimer).toBeNull();
+    loader.unsubscribe();
+  });
+
+  it('poll fires maybeReload at the configured cadence (debounce permitting)', async () => {
+    // Use vi.useFakeTimers so we can advance virtually without waiting.
+    // Inspect reload count via white-box access to `_lastLoadAt` — that
+    // timestamp updates on every `load()` call (which is what
+    // `maybeReload` triggers). A change in `_lastLoadAt` between
+    // subscribe-time and after-3-poll-ticks proves the timer fired
+    // through `maybeReload` and into `load()`.
+    vi.useFakeTimers();
+    try {
+      const adapter = new MockAdapter({ files: {} });
+      // Disable debounce so each poll tick reloads (debounce gate would
+      // otherwise swallow polls within 2s of last load).
+      const loader = new ConfigLoader(adapter, { backgroundPollMs: 100, reloadDebounceMs: 0 });
+      await loader.load();
+      const inner = loader as unknown as { _lastLoadAt: number };
+      const before = inner._lastLoadAt;
+      loader.subscribe();
+      // Advance through 3 poll intervals + a microtask flush so the
+      // async `load()` chain inside `maybeReload` resolves.
+      await vi.advanceTimersByTimeAsync(350);
+      const after = inner._lastLoadAt;
+      expect(after).toBeGreaterThan(before);
+      loader.unsubscribe();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/opencues-runtime/src/modules/config-loader.ts
+++ b/packages/opencues-runtime/src/modules/config-loader.ts
@@ -42,6 +42,14 @@ export interface ConfigLoaderOptions {
   /** Hot-reload debounce in ms. Defaults to 2000 (matches v1). */
   readonly reloadDebounceMs?: number;
   /**
+   * Background-poll interval in ms. The poll calls `maybeReload`
+   * (gated by `reloadDebounceMs`), so OPENCUES.md edits propagate
+   * even when the user isn't typing in the host. Default 5000.
+   * Set to 0 / negative to disable (keystroke-only mode — pre-June-2026
+   * behaviour, useful for tests that don't want a background timer).
+   */
+  readonly backgroundPollMs?: number;
+  /**
    * Directories searched for `words/*` and `blanks/*` folders, in
    * priority order. Earlier entries win on name conflicts.
    *
@@ -473,6 +481,12 @@ export class ConfigLoader {
   private _lastLoadAt = 0;
   private _loadInFlight: Promise<void> | null = null;
   private _unsubText: Unsubscribe | null = null;
+  // Background-poll handle. Created in `subscribe()` if setInterval
+  // exists and `backgroundPollMs > 0`. `ReturnType<typeof setInterval>`
+  // is `Timeout` in Node and `number` in browser — typing both as
+  // `unknown` keeps the union out of the field's type without losing
+  // the not-null discriminator.
+  private _pollTimer: ReturnType<typeof setInterval> | null = null;
   // Race guard: when applyOpenCuesScalar fires (cycling a satellite
   // updates an OPENCUES.md scalar in-memory), the host's blankInvoke
   // also kicks off an ASYNC file write. Cycling.ts then calls setText
@@ -648,14 +662,46 @@ export class ConfigLoader {
 
   // ─── Hot-reload subscription ───────────────────────────────────────────
 
+  /**
+   * Hot-reload is driven by TWO signals:
+   *   1. **Keystroke** — `adapter.onTextChange` fires `maybeReload` so
+   *      a user typing in the host picks up an OPENCUES.md edit on
+   *      the very next character. The fast path; no extra timers.
+   *   2. **Background poll** — a 5s setInterval also fires
+   *      `maybeReload` so users who edit OPENCUES.md and then DON'T
+   *      type (switch to the host, observe state, etc.) still see
+   *      the new config within 5s. Closes the "I changed the file but
+   *      nothing happened until I typed" surprise that bit us June 2026.
+   *
+   * Both paths funnel through the same debounce window (`reloadDebounceMs`,
+   * default 2s) so the file-read load is at most once per 2s regardless
+   * of how many signals fire. The poll's overhead is one filesystem
+   * stat every 5s — negligible.
+   */
   subscribe(): void {
     this._unsubText = this.adapter.onTextChange(() => {
       void this.maybeReload();
     });
+    // Background poll. Skipped when (a) setInterval isn't available
+    // (some test environments) OR (b) the option is explicitly
+    // <=0 (opt-out for tests / hosts that want pure keystroke-driven
+    // reload).
+    const pollMs = this.options.backgroundPollMs ?? 5000;
+    if (pollMs > 0 && typeof setInterval === 'function') {
+      this._pollTimer = setInterval(() => {
+        void this.maybeReload();
+      }, pollMs);
+      // Don't keep Node alive just for this timer — host-level disposal
+      // owns the lifecycle. `unref` is Node-only; chrome timers don't
+      // have it (no-op there).
+      const t = this._pollTimer as unknown as { unref?: () => void };
+      if (typeof t?.unref === 'function') t.unref();
+    }
   }
 
   unsubscribe(): void {
     if (this._unsubText) { this._unsubText(); this._unsubText = null; }
+    if (this._pollTimer) { clearInterval(this._pollTimer); this._pollTimer = null; }
   }
 
   /** Reload only if debounce window elapsed. */


### PR DESCRIPTION
## Why

Hot-reload was keystroke-driven only: \`ConfigLoader.subscribe()\` attached \`onTextChange\` and called it a day. If you edited \`~/.cues/OPENCUES.md\` and then switched to the host but DIDN'T type, the runtime kept stale config until the next character.

Yesterday's session: changed \`blanks-llm-provider\` while debugging. 90s elapsed before CC picked it up — because I read the CLI output first, then switched to CC to test. Felt like "hot-reload didn't fire". It did, just on the very next keystroke. Surprising UX.

## Fix

Add a 5s background \`setInterval\` alongside \`onTextChange\`. Both signals funnel through the same \`reloadDebounceMs\` (default 2s), so the file-read load runs at most once every 2s no matter how many sources fire.

- New \`ConfigLoaderOptions.backgroundPollMs\` (default 5000; 0 disables — keystroke-only mode for tests / hosts that don't want a background timer).
- \`_pollTimer\` lifecycle owned by subscribe/unsubscribe — clean exit, no leaks.
- \`unref()\` on the Node timer so it doesn't keep the process alive; chrome's timer doesn't have \`unref\` (no-op there).

## Tests

Three new in \`config-loader.test.ts\`:

- \`subscribe() creates a polling interval when backgroundPollMs > 0\`
- \`subscribe() with backgroundPollMs: 0 skips the timer entirely\`
- \`poll fires maybeReload at the configured cadence\` — uses \`vi.useFakeTimers\` + \`_lastLoadAt\` reflection to prove the timer actually advanced through the reload path

All 1457 runtime tests pass (was 1454; +3 new).

## Versions

\`@opencues/runtime\` 0.1.7 → 0.1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)