### PR TITLE
fix(cc-install): no-op-if-healthy gate now srcHash-aware — closes self-heal loop

### DIFF
--- a/integrations/claude-code/bin/install.cjs
+++ b/integrations/claude-code/bin/install.cjs
@@ -29,6 +29,30 @@ const PKG_DIR = path.resolve(__dirname, '..');
 const REPO_ROOT = path.resolve(PKG_DIR, '../..');
 const pkg = JSON.parse(fs.readFileSync(path.join(PKG_DIR, 'package.json'), 'utf8'));
 
+// Bundled-srcHash drift probe used by the no-op-if-healthy gate.
+// Delegates to the canonical version-markers.cjs in opencues-cli.
+// Returns { fresh: boolean, reason: string } — fresh: true when the
+// install marker's srcHash matches the current source's srcHash (no
+// rebuild needed); fresh: false when they differ (rebuild) or when
+// no marker exists yet (treat as fresh — first install just wrote
+// it). Errors swallowed silently and treated as fresh so a bad probe
+// can't trigger spurious rebuilds.
+function checkSrcHashDrift(markerDir) {
+  try {
+    const { checkDrift } = require(path.join(REPO_ROOT, 'packages/opencues-cli/src/lib/version-markers.cjs'));
+    const drift = checkDrift(markerDir, { pkg, REPO_ROOT });
+    if (drift.status === 'fresh' || drift.status === 'missing') {
+      return { fresh: true, reason: drift.reason };
+    }
+    return { fresh: false, reason: drift.reason };
+  } catch {
+    // Couldn't compute drift (clone-side install with missing files,
+    // post-publish path that has no source clone, etc.). Treat as
+    // fresh — drift detection is best-effort.
+    return { fresh: true, reason: 'probe-error' };
+  }
+}
+
 const HOME = os.homedir();
 const CLAUDE_DIR = path.join(HOME, '.claude');
 
@@ -164,23 +188,43 @@ function doInstall() {
   // default) is now opt-in via --rebuild — explicit destructive
   // intent. validateFork checks every artefact (runtime + core +
   // statusline.sh + patched cli.js/native-extract with opencues
-  // markers). If it passes, we exit cleanly with a notice; if it
-  // FAILS for any reason, we auto-escalate to rebuild and log why so
-  // the user's "re-run install to fix things" instinct still works.
+  // markers). If it passes, we ALSO compare the install marker's
+  // srcHash to the current source hash — if they differ, the bundle
+  // is stale even though the files are intact, and we rebuild. If
+  // both checks pass, we exit cleanly with a notice; if EITHER
+  // fails, we escalate to rebuild and log why so the user's "re-run
+  // install to fix things" instinct works for both file-corruption
+  // and stale-bundle drift.
+  //
+  // Why the srcHash check was added in PR #48: PR #42's `opencues
+  // run` self-heal detected drift correctly and called install,
+  // but install short-circuited at "already healthy" without
+  // updating the marker — so the very next `opencues run` detected
+  // drift AGAIN and re-triggered install AGAIN, forever. Closed
+  // loop only when install knows what "healthy" means in the
+  // post-self-heal world.
   if (!args.rebuild && !args.dryRun) {
     const validation = validateFork(fork);
     if (validation.ok) {
-      console.log(`${'\x1b[32m✓\x1b[0m'} ${fork.root} is already installed + healthy. No work needed.`);
-      // Bold the hint — users (and prior versions of us) repeatedly
-      // miss --rebuild's role and assume "healthy" means "current
-      // runtime bundle." It doesn't; bundle drift is invisible to
-      // this short-circuit. Make the actionable flag stand out.
-      console.log(`  ${'\x1b[2m'}Pass${'\x1b[0m'} ${'\x1b[1m--rebuild\x1b[0m'} ${'\x1b[2m'}to force a nuke-and-reinstall from scratch.${'\x1b[0m'}`);
-      return;
+      // File-level healthy. Now check srcHash drift.
+      const installRoot = fork.installRoot || path.join(fork.root, '.cues');
+      const drift = checkSrcHashDrift(installRoot);
+      if (drift.fresh) {
+        console.log(`${'\x1b[32m✓\x1b[0m'} ${fork.root} is already installed + healthy. No work needed.`);
+        // Bold the hint — users (and prior versions of us) repeatedly
+        // miss --rebuild's role and assume "healthy" means "current
+        // runtime bundle." Now the srcHash check rebuilds automatically
+        // on drift; --rebuild is still useful for force-from-scratch.
+        console.log(`  ${'\x1b[2m'}Pass${'\x1b[0m'} ${'\x1b[1m--rebuild\x1b[0m'} ${'\x1b[2m'}to force a nuke-and-reinstall from scratch.${'\x1b[0m'}`);
+        return;
+      }
+      console.log(`${'\x1b[33m▸\x1b[0m'} bundle stale (${drift.reason}). Rebuilding...`);
+      console.log('');
+    } else {
+      console.log(`${'\x1b[33m▸\x1b[0m'} install state needs repair: ${validation.reason}`);
+      console.log(`  ${'\x1b[2m'}Running full reinstall...${'\x1b[0m'}`);
+      console.log('');
     }
-    console.log(`${'\x1b[33m▸\x1b[0m'} install state needs repair: ${validation.reason}`);
-    console.log(`  ${'\x1b[2m'}Running full reinstall...${'\x1b[0m'}`);
-    console.log('');
   }
 
   checkCompat(fork.target);

--- a/integrations/claude-code/package.json
+++ b/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/claude-code",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "OpenCues for Claude Code \u2014 patches Claude Code's CLI via tweakcc to add real-time word alternatives, blanks, and cue-controls.",
   "compatibility": {


### PR DESCRIPTION
## The bug you hit

Every \`opencues run cc\` printed:

\`\`\`
▸ claude-code bundle is stale (source files changed since last install). Rebuilding before launch — pass --no-rebuild-check to skip.
[install runs]
✓ /home/wilfred/claude-code-cues is already installed + healthy. No work needed.
🗸 claude-code
\`\`\`

…on **every single launch**, forever. Drift always detected, "rebuild" always short-circuits at "already healthy", marker never updates, drift always detected again. Closed loop.

## Why

PR #42's \`ensureFreshBundle\` did the right thing — detected srcHash drift, called \`opencues install claude-code --no-prompts --yes\`.

But CC's \`bin/install.cjs\` early-exit:

\`\`\`js
if (validation.ok) {
  console.log(\`✓ ${fork.root} is already installed + healthy. No work needed.\`);
  return;   // ← never reaches writeMarker
}
\`\`\`

\`validateFork\` only checks file presence + OpenCues markers in cli.js. The files WERE intact (the last rebuild finished cleanly). So early return → no rebuild → no marker update → marker.srcHash stays at the pre-PR-42 value forever.

Comment at install.cjs:174-178 already documented this exact trap:

> "Users (and prior versions of us) repeatedly miss --rebuild's role and assume 'healthy' means 'current runtime bundle.' It doesn't; bundle drift is invisible to this short-circuit."

PR #42 stepped into it.

## Fix

The "healthy" gate now probes srcHash drift too:

\`\`\`js
if (validation.ok) {
  const drift = checkSrcHashDrift(installRoot);
  if (drift.fresh) {
    // truly healthy — exit
  } else {
    console.log(\`▸ bundle stale (${drift.reason}). Rebuilding...\`);
    // fall through to the rebuild path
  }
}
\`\`\`

After the rebuild, the existing \`writeMarker\` call updates marker.srcHash to current. Next launch reads matching hashes → fresh → no spurious rebuild.

## Verified end-to-end

\`\`\`
Pre-fix marker srcHash:  2b7ee207df24b316
Current source srcHash:  b241189491a75ae3   ← drift

Running install with the fix:
  ▸ bundle stale (srcHash). Rebuilding...
  ▸ [setup.sh ran full pipeline]
  ✓ installed + validated

Post-fix marker srcHash: b241189491a75ae3   ← matches
checkDrift status:       fresh
\`\`\`

Next \`opencues run cc\` will no-op on the drift check.

## Scope

CC-only. \`grep\` confirms no other host's \`bin/install.cjs\` has the no-op-if-healthy short-circuit; OC / gemini / shell all run the full setup.sh every time (no idempotent skip), so their markers update naturally.

## Versions

\`@opencues/claude-code\` 0.1.2 → 0.1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)