### PR TITLE
fix(chrome): mark node:fs / node:path external so esbuild stops failing the bundle

### DIFF
--- a/integrations/chrome/esbuild.config.mjs
+++ b/integrations/chrome/esbuild.config.mjs
@@ -81,6 +81,16 @@ const common = {
   alias: {
     '@opencues/core/node-http-adapter': new URL('./src/stubs/node-http-adapter-stub.ts', import.meta.url).pathname,
   },
+  // boot-common's checkRuntimeDrift (PR #47) dynamically imports
+  // node:fs + node:path for the direct-launch advisory. Those
+  // modules don't exist in the browser, but the function's own
+  // try/catch catches the failed import and silent-skips. Marking
+  // them external tells esbuild "emit the dynamic import as-is,
+  // don't try to bundle" — the import then throws at runtime in
+  // chrome and the silent-skip path fires. Without this, the
+  // chrome build hard-fails at "node:path wasn't found on the
+  // file system but is built into node."
+  external: ['node:fs', 'node:path'],
 };
 
 // Content script — IIFE (injected into page context)

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {


### PR DESCRIPTION
## What broke

PR #47's \`checkRuntimeDrift\` in \`boot-common.ts\` uses:

\`\`\`ts
const fs = (await import('node:fs')).default;
const path = (await import('node:path')).default;
\`\`\`

The function's own try/catch catches the failed import at runtime in chrome (browser → no node modules) and silent-skips. But esbuild analyses dynamic imports STATICALLY during the chrome build and refuses to bundle:

\`\`\`
✘ [ERROR] Could not resolve "node:path"
  The package "node:path" wasn't found on the file system but is built into node.
  Are you trying to bundle for node? You can use "platform: 'node'" to do that,
  which will remove this error.
\`\`\`

Caught during end-to-end install verification — every \`opencues run chrome\` triggered a rebuild attempt, every rebuild then failed at the esbuild step. Closed loop of "stale → can't rebuild" forever.

## Fix

Mark \`node:fs\` + \`node:path\` as external in chrome's esbuild config. esbuild emits the dynamic imports as-is; at runtime in chrome they throw, the existing try/catch fires, silent-skip. Same pattern as the existing \`@opencues/core/node-http-adapter\` alias-stub just above.

## Verified

- \`npm run build\` in \`integrations/chrome/\` — passes
- \`opencues install chrome --no-prompts --yes\` — installs cleanly
- Chrome drift status post-install: \`fresh\`
- All 5 hosts (CC / OC / gemini-cli / shell / chrome) now \`fresh\`

## Versions

\`@opencues/chrome\` 0.1.3 → 0.1.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)