### PR TITLE
fix(runtime): blanks fire only on explicit `_` keystroke (cursor-split bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Changed — Blanks fire only on explicit `_` keystroke (cursor-split bug)
+
+Explicit-`_` gate for blank activation (`packages/opencues-runtime/src/modules/{resolver,blank-fill}.ts`). FluidBlank / TransformBlank / ConfigIntent and script-backed blanks (volume, brightness, …) now fire ONLY when the `_` in the buffer was placed by an explicit user keystroke. A `_` exposed via cursor-relocation (typing `monologue_` and then splitting it to `monologue _`), paste, or programmatic `setText` is suppressed. Resolver and BlankFill each arm a one-shot flag on a plain `_` keypress, but only when the simulated insertion would produce a standalone `_` — so typing `_` adjacent to an existing word never arms. The flag is cleared at the end of the next `onTextChange` (exception: spaced-mode unconfirmed `_` keeps it through one extra dispatch so the confirming space still dispatches). `MockAdapter.pushText` auto-fires the `_` keystroke when the new text introduces additional `_` chars; the new `pushTextNoKeystroke` is the explicit opt-out for paste/programmatic-insertion simulations. Three scenario tests pin the user journey.
+
+A follow-up commit on the same branch adds an event-bridge synth on `text:` injection that grows the underscore count — keeps the gate honest when text arrives through programmatic paths that bypass `onKey`.
+
+Version bumped: `@opencues/runtime` 0.1.12 → 0.1.13.
+
+
 ### Fixed — Terminal.app Ctrl+Option+arrow: stdin byte-rewrite (completes the #51 synth)
 
 Real-device testing of the [#51](https://github.com/opencues/opencues/pull/51) synth on a **default** Terminal.app profile (claude-cues 2.1.158, Ink) showed it still did nothing. A runtime probe of the raw event proved why: Ink **splits** the `\x1b\x1b[A` chord into two events *before any consumer sees it* — a standalone `escape` (seq `\x1b`) + a plain arrow (seq `\x1b[A`), same millisecond. After the split the arrow no longer carries the double-ESC prefix, so the event-level `shouldSynthesizeMacDoubleEscCtrl` gate can never fire (`synthFired:false` on every arrow; zero `ctrl:true` in the dispatch log).

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/event-bridge.ts
+++ b/packages/opencues-runtime/src/event-bridge.ts
@@ -446,6 +446,23 @@ class CommandRunner {
         // sequences which we decode here. \\\\ → \\ keeps backslashes
         // injectable.
         const decoded = arg.replace(/\\n/g, '\n').replace(/\\\\/g, '\\');
+        // Explicit-`_` gate compatibility: when `text:` introduces new
+        // `_` characters relative to the prior buffer, synthesise a `_`
+        // keystroke BEFORE the text update so subscribers that gate on
+        // explicit keystroke origin (Resolver / BlankFill's explicit-`_`
+        // gate) see the keystroke→change pair a real user would produce.
+        // Without this, every blank-firing scenario that uses `text:foo _`
+        // would silently no-op. `text-keep-hl` skips this because the
+        // 'runtime' source flag already signals "not user-typed".
+        const prevText = adapter.getText();
+        if (cmd === 'text' && countUnderscores(decoded) > countUnderscores(prevText)) {
+          this.bindings.dispatchKey({
+            key: '_',
+            modifiers: { ctrl: false, alt: false, shift: false, meta: false },
+            text: prevText,
+            cursorOffset: adapter.getCursorOffset(),
+          });
+        }
         // Two-step write: (1) buffer set; (2) synthetic textChange so
         // the resolver / statusline see the change. OpenTUI's
         // replaceText skips onContentChange for programmatic writes —
@@ -562,6 +579,12 @@ function parseLine(line: string): { cmd: string; arg: string } {
  * dispatch time so the synthesised event matches what a real keystroke
  * would carry.
  */
+function countUnderscores(text: string): number {
+  let n = 0;
+  for (let i = 0; i < text.length; i += 1) if (text[i] === '_') n += 1;
+  return n;
+}
+
 function parseKeyArg(arg: string, adapter: HostAdapter): KeyEvent {
   const colon = arg.indexOf(':');
   const name = (colon >= 0 ? arg.slice(0, colon) : arg).trim().toLowerCase();

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -223,6 +223,7 @@ export class BlankFill {
       // resolver's gate so the runtime is consistent across both blank
       // dispatch paths. See `_underscoreKeyArmed`.
       if (filteredSlots.length > 0 && !this.explicitUnderscoreRecent()) {
+        this.adapter.log('debug', `BlankFill: explicit-_ gate BLOCKED ${filteredSlots.length} slot(s) (no recent _ keystroke)`);
         filteredSlots = [];
       }
       this.maybeRunScripts(e.text, filteredSlots);

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -35,6 +35,13 @@ export class BlankFill {
   private _slots: readonly BlankSlot[] = [];
   private _unsubText: Unsubscribe | null = null;
   private _unsubKey: Unsubscribe | null = null;
+  /** One-shot flag: armed on a plain `_` keystroke, cleared at the end
+   *  of the next `onTextChange`. Mirrors the resolver's gate — script-
+   *  backed blanks (volume, brightness, etc.) only dispatch when the `_`
+   *  in the buffer was placed by an explicit user keystroke. A `_`
+   *  exposed via cursor-relocation (`volume_` → split to `volume _`),
+   *  paste, or programmatic setText MUST NOT fire the script. */
+  private _underscoreKeyArmed = false;
   /** Dedup key (text + slot index) → in-flight script promise. */
   private _pendingScripts = new Set<string>();
   private _warnedSandboxBlanks = new Set<string>();
@@ -108,6 +115,10 @@ export class BlankFill {
   /** Currently-detected slots (latest scan). */
   get slots(): readonly BlankSlot[] { return this._slots; }
 
+  private explicitUnderscoreRecent(): boolean {
+    return this._underscoreKeyArmed;
+  }
+
   /** Pure scanner — exposed for unit tests. */
   scan(text: string): readonly BlankSlot[] {
     const cleanText = text.replace(/[\u200B\u200C]/g, '');
@@ -123,6 +134,21 @@ export class BlankFill {
   }
 
   private onTextChange(e: TextChangeEvent): void {
+    let keepArmed = false;
+    try {
+      keepArmed = this._onTextChangeImpl(e);
+    } finally {
+      // One-shot: clear the keystroke flag at the END of this dispatch so
+      // the NEXT text-change (one not paired with a `_` keystroke) sees
+      // `explicitUnderscoreRecent()` = false. Exception: spaced-mode
+      // unconfirmed `_` — the user explicitly typed `_` and is waiting
+      // for the confirming space; we MUST keep the flag through one
+      // extra dispatch (mirrors the same exception in Resolver.onTextChange).
+      if (!keepArmed) this._underscoreKeyArmed = false;
+    }
+  }
+
+  private _onTextChangeImpl(e: TextChangeEvent): boolean {
     // Span-fill invalidation: if the span fill is live and the
     // current text doesn't match what we last filled (cycle or initial),
     // try to preserve the span (user edited OUTSIDE it — just re-anchor
@@ -190,8 +216,27 @@ export class BlankFill {
         const hasTrailingWs = /\s$/.test(cleanText);
         filteredSlots = slots.filter(s => s.index < lastWordIdx || hasTrailingWs);
       }
+      // Explicit-`_` gate: only dispatch scripts when the `_` was placed
+      // by an explicit user keystroke. A `_` exposed via cursor-relocation
+      // (`volume_` → split to `volume _`), paste, or programmatic setText
+      // MUST NOT fire the volume / brightness / etc. scripts. Mirrors the
+      // resolver's gate so the runtime is consistent across both blank
+      // dispatch paths. See `_underscoreKeyArmed`.
+      if (filteredSlots.length > 0 && !this.explicitUnderscoreRecent()) {
+        filteredSlots = [];
+      }
       this.maybeRunScripts(e.text, filteredSlots);
+
+      // Spaced-mode unconfirmed `_` (text ends with `_` without trailing
+      // whitespace): keep the armed flag so the next text-change (the
+      // confirming space) can still dispatch. Without this, spaced-mode
+      // legitimate usage would permanently fail the explicit-`_` gate.
+      if (this.configLoader?.opencuesState.blankTriggerMode === 'spaced') {
+        const cleanText = e.text.replace(/[\u200B\u200C]/g, '');
+        if (cleanText.endsWith('_')) return true;
+      }
     }
+    return false;
   }
 
   /**
@@ -838,6 +883,19 @@ export class BlankFill {
     // Only intercept plain '_' presses (no nav modifiers etc.).
     const m = event.modifiers;
     if (m.ctrl || m.alt || m.meta) return false;
+    // Simulate the insertion FIRST, then arm the one-shot flag only when
+    // the resulting `_` would be a standalone word. A `_` typed adjacent
+    // to existing letters (`volume` + `_` → `volume_`, or inside a word
+    // like `vol_ume`) is structurally NOT a blank trigger; arming on
+    // those would re-open the cursor-split bug for script-backed blanks.
+    const insertedText =
+      event.text.slice(0, event.cursorOffset) +
+      '_' +
+      event.text.slice(event.cursorOffset);
+    const insertedWord = findUnderscoreAtChar(insertedText, event.cursorOffset);
+    if (insertedWord) {
+      this._underscoreKeyArmed = true;
+    }
 
     // `blank-trigger-mode: spaced` defers blank firing until a space
     // follows the `_`. Letting the keypress fall through to the host's
@@ -848,14 +906,8 @@ export class BlankFill {
       return false;
     }
 
-    const insertedText =
-      event.text.slice(0, event.cursorOffset) +
-      '_' +
-      event.text.slice(event.cursorOffset);
-
     // Find the word index of our just-inserted '_' in the simulated text.
     // Only count it as a blank when it's surrounded by whitespace (or BOL/EOL).
-    const insertedWord = findUnderscoreAtChar(insertedText, event.cursorOffset);
     if (!insertedWord) return false;
 
     const slots = this.scan(insertedText);
@@ -1227,7 +1279,7 @@ export function computeCleanupRange(
  * character is the lone '_' word at its position. Returns null if the '_'
  * is part of a larger word (e.g. `affirm_xyz`).
  */
-function findUnderscoreAtChar(text: string, charOffset: number): { index: number; start: number; end: number } | null {
+export function findUnderscoreAtChar(text: string, charOffset: number): { index: number; start: number; end: number } | null {
   const words = splitWords(text);
   for (const w of words) {
     if (w.start <= charOffset && charOffset < w.end && w.word === '_') {

--- a/packages/opencues-runtime/src/modules/resolver.test.ts
+++ b/packages/opencues-runtime/src/modules/resolver.test.ts
@@ -462,15 +462,16 @@ describe('Resolver — same-text dedupe (regression: double LLM call on `_` trig
     const spy = vi.spyOn(resolver, 'resolveAndApply');
     resolver.subscribe();
 
+    // Two distinct text changes, separated by enough time for the first
+    // debounced schedule to fire (10ms debounce in setupResolver). The
+    // point: dedupe is text-equality only — different text MUST trigger a
+    // second resolve, regardless of which path (bypass vs scheduled) each
+    // change takes.
     adapter.pushText('hello _');
+    await new Promise(r => setTimeout(r, 30));
     adapter.pushText('hello world _');  // different text
+    await new Promise(r => setTimeout(r, 30));
 
-    await new Promise(r => setTimeout(r, 50));
-
-    // Both fast-paths fire — first because `_` was just typed against
-    // empty `prev`, second because `_` is at the trailing edge against
-    // a `prev` that didn't end in `_` after we strip the trailing space.
-    // The point is: dedupe MUST NOT swallow a real text change.
     expect(spy).toHaveBeenCalledTimes(2);
   });
 });
@@ -913,6 +914,90 @@ describe('Resolver blank-trigger-mode gate', () => {
     adapter.pushText('this is _italic_');    // closing `_`
     await new Promise(r => setTimeout(r, 50));
     expect(callCount()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Explicit-`_` gate: blanks (FluidBlank / TransformBlank / ConfigIntent)
+// fire ONLY when the `_` in the buffer was placed by an explicit user
+// keystroke. A `_` exposed via cursor-relocation (`monologue_` → split to
+// `monologue _`), paste, or programmatic setText must NOT fire.
+//
+// Bug observed June 2026: typing `monologue_` then splitting to
+// `monologue _` triggered FluidBlank substitution (log evidence:
+// `FluidBlank: substituting "Monologue #2 _" → "Monologue #2"`). The
+// blank's origin was not a "direct placement" — it was an attached `_`
+// that became standalone after a separate edit. Fix: gate blank
+// activation on the most-recent explicit `_` keystroke; the falls-through
+// scheduleResolve path captures freshness at change time so the debounce
+// can't open a hole.
+// ---------------------------------------------------------------------------
+
+describe('Resolver explicit-`_` gate', () => {
+  function setupGateScenario() {
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: { '/mock/CUES.md': TIPS, '/proj/CUES.md': CUES_MD },
+    });
+    adapter.pushText('');
+    const hlState = new HighlightState();
+    const dynDefs = new DynDefs();
+    const loader = new ConfigLoader(adapter, { settingsFile: '/proj/CUES.md' });
+    const resolver = new Resolver(adapter, hlState, dynDefs, loader, {
+      endpoint: 'http://test', apiKey: 'x', defaultModel: 'm',
+      debounceMs: 20,
+      httpAdapter: {},
+    });
+    const seenWordsPerCall: string[][] = [];
+    (resolver as unknown as { _resolver: { resolve(ctx: { words: string[] }): Promise<{ results: unknown[] }> } })._resolver = {
+      resolve: async ctx => { seenWordsPerCall.push([...ctx.words]); return { results: [] }; },
+    };
+    resolver.subscribe();
+    return { adapter, resolver, seenWordsPerCall };
+  }
+
+  it('cursor-split scenario: `monologue_` → split to `monologue _` does NOT route `_` to blank sources', async () => {
+    const { adapter, seenWordsPerCall } = setupGateScenario();
+    // Step 1: user types `monologue_` (single explicit `_` keystroke
+    // attached to the word — NOT a standalone slot).
+    adapter.pushText('monologue_');
+    await new Promise(r => setTimeout(r, 80));
+    // The bypass on `monologue_` is a no-op for blank dispatch (no
+    // standalone `_`); the debounced resolve fires once with the `_`
+    // still attached — no isolated `_` word in the cleanWords list.
+    for (const words of seenWordsPerCall) {
+      expect(words).not.toContain('_');
+    }
+    const callsAfterStep1 = seenWordsPerCall.length;
+
+    // Step 2: user moves cursor and inserts a space, exposing a
+    // standalone `_`. This is the buggy path — no fresh keystroke fired
+    // (pushText auto-fires only when underscore COUNT grows, and here it
+    // doesn't). The cleanWords filter must mask the now-standalone `_`.
+    adapter.pushTextNoKeystroke('monologue _');
+    await new Promise(r => setTimeout(r, 80));
+    expect(seenWordsPerCall.length).toBeGreaterThan(callsAfterStep1);
+    for (const words of seenWordsPerCall) {
+      expect(words).not.toContain('_');
+    }
+  });
+
+  it('direct path: typing `country _` with the `_` keystroke DOES route `_` to blank sources', async () => {
+    const { adapter, seenWordsPerCall } = setupGateScenario();
+    // pushText auto-fires `_` keystroke because text gained a `_`.
+    adapter.pushText('country _');
+    await new Promise(r => setTimeout(r, 80));
+    const sawStandaloneUnderscore = seenWordsPerCall.some(words => words.includes('_'));
+    expect(sawStandaloneUnderscore).toBe(true);
+  });
+
+  it('paste scenario: programmatic `pushTextNoKeystroke` with a standalone `_` does NOT route to blank sources', async () => {
+    const { adapter, seenWordsPerCall } = setupGateScenario();
+    adapter.pushTextNoKeystroke('weather _');
+    await new Promise(r => setTimeout(r, 80));
+    for (const words of seenWordsPerCall) {
+      expect(words).not.toContain('_');
+    }
   });
 });
 

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -13,7 +13,7 @@
 // User mid-cycle protection: if a DynDef entry has currentIndex > 0
 // (user has cycled past the original), the resolver leaves it alone.
 
-import type { HostAdapter, TextChangeEvent, Unsubscribe } from '../adapter';
+import type { HostAdapter, KeyEvent, TextChangeEvent, Unsubscribe } from '../adapter';
 import type { ConfigLoader } from './config-loader';
 import type { DynDefs, WordDef } from '../state/dyn-defs';
 import { reconstructAsTyped, reconstructAsTypedWithMap } from '../state/dyn-defs';
@@ -23,6 +23,7 @@ import type { AgentTaskState } from '../state/agent-task';
 import type { SelectorSatelliteState as SelectorSatelliteStateRef } from '../state/selector-satellite';
 import { splitWords } from './navigation';
 import type { BlankLoadingAnimator } from './blank-loading';
+import { findUnderscoreAtChar } from './blank-fill';
 import { applyMarkdownAwareSplice, applyMarkdownAwareSubstitution } from './markdown-substitute';
 import { threeWayMerge } from './word-diff';
 
@@ -171,6 +172,23 @@ export class Resolver {
   private _sources: unknown[] = [];
   private _httpAdapter: unknown = null;
   private _unsubText: Unsubscribe | null = null;
+  private _unsubKey: Unsubscribe | null = null;
+  /** One-shot flag: set TRUE when a plain `_` keystroke arrives, cleared
+   *  at the END of the next `onTextChange`. Gates blank activation on
+   *  EXPLICIT user intent — a `_` that appears in the buffer without a
+   *  corresponding keystroke (paste, programmatic setText, cursor-
+   *  relocation exposing an attached `_`, e.g. typing `monologue_` then
+   *  splitting to `monologue _`) MUST NOT fire FluidBlank /
+   *  TransformBlank / ConfigIntent.
+   *
+   *  Why one-shot (not a time window): a 1500ms timestamp window leaves a
+   *  hole for fast cursor-splits — type `monologue_`, move cursor and
+   *  press space in <1500ms, and the gate still reads "fresh". One-shot
+   *  ties freshness to the SPECIFIC onTextChange that paired with the
+   *  keystroke; the cursor-split's onTextChange happens AFTER the flag
+   *  has been consumed and cleared. The falls-through `scheduleResolve`
+   *  captures the flag at change time, so the debounce can't open a hole. */
+  private _underscoreKeyArmed = false;
   private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private _generation = 0;
   /** Last user-typed text — used to detect when `_` was just added so we
@@ -238,6 +256,35 @@ export class Resolver {
   subscribe(): void {
     this.rebuildResolver();
     this._unsubText = this.adapter.onTextChange(e => this.onTextChange(e));
+    this._unsubKey = this.adapter.onKey({ keys: ['_'] }, e => this.onUnderscoreKey(e));
+  }
+
+  /** Arm the one-shot keystroke flag on plain `_` presses (no
+   *  ctrl/alt/meta) — but ONLY when the simulated insertion would
+   *  produce a standalone `_` word. A `_` typed adjacent to existing
+   *  letters (`monologue` + `_` → `monologue_`, or inside a word like
+   *  `monolog_ue`) is structurally NOT a blank trigger; arming on those
+   *  would re-open the cursor-split bug (the keystroke happens BEFORE
+   *  the split, so a time-window approach can't distinguish them).
+   *  Mirrors the same standalone check BlankFill's `onUnderscoreKey`
+   *  uses (line ~880). Returns false unconditionally — host inserts
+   *  the `_` normally. The flag is cleared at the end of the next
+   *  onTextChange dispatch (or kept across a spaced-mode unconfirmed
+   *  `_` so the confirming-space's text-change can still see it). */
+  private onUnderscoreKey(event: KeyEvent): boolean {
+    const m = event.modifiers;
+    if (m.ctrl || m.alt || m.meta) return false;
+    const insertedText =
+      event.text.slice(0, event.cursorOffset) +
+      '_' +
+      event.text.slice(event.cursorOffset);
+    if (!findUnderscoreAtChar(insertedText, event.cursorOffset)) return false;
+    this._underscoreKeyArmed = true;
+    return false;
+  }
+
+  private explicitUnderscoreRecent(): boolean {
+    return this._underscoreKeyArmed;
   }
 
   /**
@@ -374,6 +421,7 @@ export class Resolver {
 
   unsubscribe(): void {
     if (this._unsubText) { this._unsubText(); this._unsubText = null; }
+    if (this._unsubKey) { this._unsubKey(); this._unsubKey = null; }
     if (this._debounceTimer) { clearTimeout(this._debounceTimer); this._debounceTimer = null; }
   }
 
@@ -719,36 +767,74 @@ export class Resolver {
     } else {
       blankJustTyped = text.trimEnd().endsWith('_') && !prev.trimEnd().endsWith('_');
     }
-    if (blankJustTyped) {
-      if (this._debounceTimer) { clearTimeout(this._debounceTimer); this._debounceTimer = null; }
-      this.adapter.log('debug', `Resolver: _ trigger — bypassing debounce (mode=${triggerMode})`);
-      void this.resolveAndApply(text);
-      return;
+    // Explicit-`_` gate: the trailing `_` only counts as a blank trigger
+    // when it was placed by an explicit `_` keystroke. A `_` that appeared
+    // via paste, programmatic setText, or cursor-relocation exposing an
+    // attached `_` (`monologue_` → cursor inside → space → `monologue _`)
+    // must NOT fire. The keystroke handler (`onUnderscoreKey`) arms the
+    // one-shot flag; this gate reads it BEFORE the flag is cleared in the
+    // finally block below.
+    if (blankJustTyped && !this.explicitUnderscoreRecent()) {
+      blankJustTyped = false;
     }
+    let keepArmed = false;
+    try {
+      if (blankJustTyped) {
+        if (this._debounceTimer) { clearTimeout(this._debounceTimer); this._debounceTimer = null; }
+        this.adapter.log('debug', `Resolver: _ trigger — bypassing debounce (mode=${triggerMode})`);
+        void this.resolveAndApply(text, { allowBlanks: true });
+        return;
+      }
 
-    // In spaced mode, an unconfirmed lone `_` at end of buffer should
-    // never fire blanks — not via bypass (handled above) AND not via
-    // the debounced fall-through (handled here). Skip scheduling so a
-    // user pausing after `_` doesn't end up substituted. The next
-    // text-change (typing more or the confirming space) re-evaluates.
-    if (triggerMode === 'spaced' && text.trimEnd().endsWith('_') && !/_\s+$/.test(text)) {
-      if (this._debounceTimer) { clearTimeout(this._debounceTimer); this._debounceTimer = null; }
-      return;
+      // In spaced mode, an unconfirmed lone `_` at end of buffer should
+      // never fire blanks — not via bypass (handled above) AND not via
+      // the debounced fall-through (handled here). Skip scheduling so a
+      // user pausing after `_` doesn't end up substituted. The next
+      // text-change (typing more or the confirming space) re-evaluates.
+      // KEEP the armed flag across this dispatch so the next text-change
+      // (the confirming space) can still see the user's earlier explicit
+      // `_` keystroke. Without this, spaced-mode legit usage would
+      // permanently fail the explicit-`_` gate.
+      if (triggerMode === 'spaced' && text.trimEnd().endsWith('_') && !/_\s+$/.test(text)) {
+        if (this._debounceTimer) { clearTimeout(this._debounceTimer); this._debounceTimer = null; }
+        keepArmed = true;
+        return;
+      }
+
+      this.scheduleResolve(text);
+    } finally {
+      // One-shot: clear armed flag at the END of this onTextChange so the
+      // NEXT text-change (one not paired with a `_` keystroke) doesn't
+      // inherit the freshness. Exception: spaced-mode unconfirmed `_`
+      // (see `keepArmed`) — the user explicitly typed `_` and is waiting
+      // for the confirming space; we MUST keep the flag through one extra
+      // dispatch. `scheduleResolve` above captures the flag INTO its
+      // closure BEFORE this clear runs, so the debounced fire still sees
+      // allowBlanks=true when the keystroke was genuine.
+      if (!keepArmed) this._underscoreKeyArmed = false;
     }
-
-    this.scheduleResolve(text);
   }
 
   private scheduleResolve(text: string): void {
     if (this._debounceTimer) clearTimeout(this._debounceTimer);
     const delay = this.options.debounceMs ?? 500;
+    // Capture the freshness now so the gate reflects when the change
+    // happened — not when the debounce fires `delay` ms later (by which
+    // time the keystroke window may have lapsed even though the user
+    // genuinely just typed `_`).
+    const allowBlanks = this.explicitUnderscoreRecent();
     this._debounceTimer = setTimeout(() => {
-      void this.resolveAndApply(text);
+      void this.resolveAndApply(text, { allowBlanks });
     }, delay);
   }
 
-  /** Exposed for tests. */
-  async resolveAndApply(text: string): Promise<void> {
+  /** Exposed for tests.
+   *  @param opts.allowBlanks Default true. When false, `_` slots in the
+   *    buffer are masked from blank sources (FluidBlank / TransformBlank /
+   *    ConfigIntent). Production callers in `onTextChange` set this based
+   *    on `explicitUnderscoreRecent()` — see the explicit-`_` gate above. */
+  async resolveAndApply(text: string, opts: { allowBlanks?: boolean } = {}): Promise<void> {
+    const allowBlanks = opts.allowBlanks ?? true;
     if (!this._resolver) return;
     const generation = ++this._generation;
     const t0 = Date.now();
@@ -791,6 +877,20 @@ export class Resolver {
       // pruneStale, after which the `_` falls through to a real resolve.
       if (cleaned === '_') {
         if (this.dynDefs.findSpanContaining(i)) return '';
+        // Explicit-`_` gate (mirrors the bypass gate in onTextChange): a
+        // `_` slot in the buffer only routes to blank sources when the
+        // caller declares this resolve pass came from an explicit `_`
+        // keystroke. Without this, a falls-through scheduleResolve fires
+        // FluidBlank / TransformBlank on `_`s that were never explicitly
+        // typed (paste, programmatic setText, cursor-relocation exposing
+        // `monologue _` from `monologue_`). The flag is wired from
+        // onTextChange (which reads `explicitUnderscoreRecent()`); direct
+        // unit-test calls to resolveAndApply default to allowBlanks=true
+        // so the existing test suite — which exercises the resolver in
+        // isolation, with no keystroke surface — keeps working. Word-cues
+        // / sentence-cues continue to run on the other words; only the
+        // `_` slot is masked.
+        if (!allowBlanks) return '';
         return cleaned;
       }
       if (span && i >= span.index && i < span.index + span.spanLength) return '';

--- a/packages/opencues-runtime/testing/mock-adapter.ts
+++ b/packages/opencues-runtime/testing/mock-adapter.ts
@@ -285,8 +285,27 @@ export class MockAdapter implements HostAdapter {
     return false;
   }
 
-  /** Simulate a user edit: updates buffer AND fires onTextChange with source 'user'. */
+  /** Simulate a user edit: updates buffer AND fires onTextChange with source 'user'.
+   *  If the new text introduces additional `_` characters relative to the
+   *  previous buffer, ALSO fires a plain `_` keystroke first so subscribers
+   *  that gate on explicit keystroke origin (Resolver / BlankFill's
+   *  explicit-`_` gate) see the keystroke→change pair a real user would
+   *  produce. Tests that want to simulate paste / programmatic insertion
+   *  of `_` without a keystroke should use `pushTextNoKeystroke` instead. */
   pushText(text: string, cursorOffset?: number): void {
+    if (countUnderscores(text) > countUnderscores(this._text)) {
+      // Synthesise the `_` keypress before the change. We fire with the
+      // PRE-change text so a handler that reads `event.text` (cursor-aware
+      // logic in BlankFill.onUnderscoreKey, for instance) sees the same
+      // pre-state a real keypress would deliver.
+      this.fireKey('_');
+    }
+    this.pushTextNoKeystroke(text, cursorOffset);
+  }
+
+  /** Like `pushText` but without the auto-fired `_` keystroke. Use this when
+   *  the test specifically wants to simulate paste / programmatic insertion. */
+  pushTextNoKeystroke(text: string, cursorOffset?: number): void {
     const prev = this._text;
     this._text = text;
     if (cursorOffset !== undefined) this._offset = Math.max(0, Math.min(cursorOffset, text.length));
@@ -335,6 +354,12 @@ export class MockAdapter implements HostAdapter {
       }
     }
   }
+}
+
+function countUnderscores(text: string): number {
+  let n = 0;
+  for (let i = 0; i < text.length; i += 1) if (text[i] === '_') n += 1;
+  return n;
 }
 
 function keyMatchesFilter(event: KeyEvent, filter: KeyFilter | null): boolean {


### PR DESCRIPTION
## Summary

- FluidBlank / TransformBlank / ConfigIntent and script-backed blanks (volume, brightness, …) now fire ONLY when the `_` in the buffer was placed by an explicit user `_` keystroke.
- Suppresses three previously-buggy paths: cursor-relocation (`monologue_` split to `monologue _`), paste, and programmatic `setText` of strings containing standalone `_`.
- One-shot keystroke flag, armed only when the simulated insertion at keystroke time would produce a standalone `_`; cleared at end of next `onTextChange` (with spaced-mode unconfirmed `_` keeping it through one extra dispatch).

## Why

Bug observed in `/tmp/opencues.log`: typing `Monologue #2 _` (with any path reaching that buffer shape) triggered `FluidBlank: substituting "Monologue #2 _" → "Monologue #2"`. The blank's `_` wasn't a "direct placement" — it was exposed by a separate edit. Pre-fix, both `Resolver.onTextChange` (bypass + falls-through `scheduleResolve`) and `BlankFill.onTextChange` script dispatch were purely buffer-state based with no origin discipline.

## Approach

- Resolver subscribes `onKey({ keys: ['_'] })`, arming `_underscoreKeyArmed` on plain `_` press, gated on `findUnderscoreAtChar` standalone check at the keystroke's cursor offset (so typing `_` adjacent to a word never arms).
- `resolveAndApply` accepts an optional `{ allowBlanks }` param; `onTextChange` wires it from the gate. Inside `cleanWords`, `_` slots are masked from blank sources when `allowBlanks=false`. Word-cues / sentence-cues continue to run on the other words.
- `scheduleResolve` captures `allowBlanks` into its closure at change-time (not at the debounced fire time), so the 500ms debounce can't open a hole.
- BlankFill mirrors the gate at the script-dispatch path.
- Spaced-mode unconfirmed `_` (text ends in `_` without trailing whitespace): both gates keep the flag through one extra `onTextChange` so the confirming space's text-change still dispatches.

## Implications (other paths that change)

- **Paste of `"foo _"`**: blocked. No `_` keystroke means no arm.
- **Programmatic `setText` containing `_`**: blocked. Same reason.
- **IME-composed `_`**: blocked unless the host fires `onKey` for the composed character. Chrome / CC do; some hosts may not — those would need investigation if reported.
- **Markdown `_italic_`**: still works in spaced mode (the first `_` arms, spaced-unconfirmed branch keeps it through the in-progress typing, the second `_` ultimately resolves through the existing markdown path).
- **`MockAdapter.pushText`**: now auto-fires the `_` keystroke when the new text introduces additional `_` chars (matches real-user behavior). The new `pushTextNoKeystroke` is the explicit opt-out for paste / programmatic-insertion simulations.

## Test plan

- [x] `npx vitest run src/modules/resolver.test.ts src/modules/blank-fill.test.ts` — 141/141.
- [x] Full runtime suite — 1461/1462 (1 pre-existing failure in `seed-configs.test.ts` HEAL phase, unrelated; verified by stashing changes and re-running).
- [x] Three new scenario tests in `resolver.test.ts > Resolver explicit-\`_\` gate`:
  - cursor-split scenario blocks blank routing.
  - direct `country _` typing fires.
  - `pushTextNoKeystroke('weather _')` does NOT fire.
- [x] `npx tsc --noEmit` clean.
- [x] Manual sanity in production hosts after install:
  - `monologue_` then split to `monologue _` → no FluidBlank substitution (was the bug).
  - `country _` typed normally → substitutes as before.
  - `_italic_` markdown in spaced mode → no premature substitution.
  - `volume _` (typed) → volume script still dispatches.
  - `volume_` (typed) then split → volume script does NOT dispatch.

## Upgrade path

1. `pnpm install`.
2. Run `pnpm --filter @opencues/runtime build` then `opencues install <host>` per fork (or just `opencues run <host>` — srcHash drift detection will auto-rebuild).
3. No config flag, no migration. Behavior change is enabled by default per user request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)