### PR TITLE
fix(ci): hermeticity gate watches ~/.cues/ too — was only watching empty ~/.opencues/

### DIFF
--- a/scripts/check-test-hermeticity.sh
+++ b/scripts/check-test-hermeticity.sh
@@ -1,41 +1,63 @@
 #!/usr/bin/env bash
 # check-test-hermeticity.sh — run `pnpm -r test` (and the CLI's own
 # test target) under a sandboxed $HOME, then assert nothing in the
-# REAL ~/.opencues/ was touched. Catches the PR #41 failure mode where
-# vendor-pins.test.cjs was wiping the user's vendored tmux directory
-# on every test run.
+# REAL ~/.opencues/ OR ~/.cues/ was touched.
+#
+# Coverage:
+#   - ~/.opencues/  — vendored deps (tmux), update lock, internal state.
+#                     PR #41 (June 2026) caught vendor-pins.test.cjs
+#                     wiping the user's tmux dir here on every test run.
+#   - ~/.cues/      — user's live config: OPENCUES.md, CUES.md, SENTINELS.md,
+#                     cues/<topic>/CUE.md, blanks/<name>/BLANK.md. A test
+#                     that bypasses the HOME sandbox via a hardcoded path
+#                     or reads $USER instead of $HOME could write here.
+#                     Added after the user reported their OPENCUES.md
+#                     scalars drifting unexpectedly between test runs.
 #
 # Strategy:
-#   1. Snapshot the real ~/.opencues/ mtime tree before tests run.
+#   1. Snapshot the real ~/.opencues/ AND ~/.cues/ mtime trees before tests.
 #   2. Point HOME at a fresh tempdir; run `pnpm -r test`.
-#   3. After tests finish, walk the real ~/.opencues/ again and
-#      compare mtimes. Any change → fail loudly with the path that
-#      moved.
+#   3. After tests finish, walk both real dirs again and compare mtimes.
+#      Any change → fail loudly with the path that moved.
 #
-# Skips the snapshot when ~/.opencues/ doesn't exist (CI runners
-# don't have one) — the HOME override is still applied, so a test
-# that tries to create ~/.opencues/ would create it under the
-# sandbox tempdir, not the real home.
+# Skips the snapshot for any dir that doesn't exist (CI runners don't have
+# either) — the HOME override is still applied, so a test that tries to
+# create one would create it under the sandbox tempdir, not the real home.
 
 set -eo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-REAL_OPENCUES="$HOME/.opencues"
-HAVE_BASELINE=0
-BASELINE_FILE=""
+# Watched dirs: name → real path. Used to fail with both the missing-
+# guard name and the actual file that was touched.
+declare -a WATCH_DIRS=("$HOME/.opencues" "$HOME/.cues")
 
-# Snapshot real ~/.opencues if present. We compare the SORTED list
+# Parallel arrays to track baseline state per dir.
+declare -a HAVE_BASELINE=()
+declare -a BASELINE_FILES=()
+
+snapshot_dir() {
+  local dir="$1" out="$2"
+  find "$dir" -printf '%P:%T@\n' 2>/dev/null \
+    | sort > "$out" 2>/dev/null \
+    || find "$dir" -exec stat -f '%N:%m' {} \; 2>/dev/null \
+       | sort > "$out"
+}
+
+# Snapshot every watched dir that exists. We compare the SORTED list
 # of `<path>:<mtime>` entries pre/post — quick diff via diff -u.
-if [ -d "$REAL_OPENCUES" ]; then
-  BASELINE_FILE="$(mktemp -t opencues-test-baseline.XXXXXX)"
-  find "$REAL_OPENCUES" -printf '%P:%T@\n' 2>/dev/null \
-    | sort > "$BASELINE_FILE" 2>/dev/null \
-    || find "$REAL_OPENCUES" -exec stat -f '%N:%m' {} \; 2>/dev/null \
-       | sort > "$BASELINE_FILE"
-  HAVE_BASELINE=1
-fi
+for dir in "${WATCH_DIRS[@]}"; do
+  if [ -d "$dir" ]; then
+    file="$(mktemp -t opencues-test-baseline.XXXXXX)"
+    snapshot_dir "$dir" "$file"
+    HAVE_BASELINE+=("1")
+    BASELINE_FILES+=("$file")
+  else
+    HAVE_BASELINE+=("0")
+    BASELINE_FILES+=("")
+  fi
+done
 
 # Sandboxed HOME for the test run. Tests that respect $HOME (via
 # os.homedir() / os.userInfo() etc.) silently follow the override.
@@ -59,32 +81,35 @@ HOME="$SANDBOX_HOME" bash -c '
 ' || TEST_EXIT=$?
 
 echo ""
-echo "▸ Comparing real $REAL_OPENCUES before/after test run"
-
 HERMETICITY_FAIL=0
-if [ "$HAVE_BASELINE" = "1" ]; then
-  POST_FILE="$(mktemp -t opencues-test-post.XXXXXX)"
-  find "$REAL_OPENCUES" -printf '%P:%T@\n' 2>/dev/null \
-    | sort > "$POST_FILE" 2>/dev/null \
-    || find "$REAL_OPENCUES" -exec stat -f '%N:%m' {} \; 2>/dev/null \
-       | sort > "$POST_FILE"
-  if ! diff -u "$BASELINE_FILE" "$POST_FILE" > /tmp/opencues-hermeticity.diff; then
-    echo "✗ HERMETICITY VIOLATION — real $REAL_OPENCUES was modified during tests:"
-    head -20 /tmp/opencues-hermeticity.diff | sed 's/^/    /'
-    echo ""
-    echo "    Symptom of a test that wrote to os.homedir() / process.env.HOME"
-    echo "    without sandboxing. See PR #41 (June 2026) for the fix pattern:"
-    echo "    use a before/after hook that mkdtempSync + sets process.env.HOME."
-    HERMETICITY_FAIL=1
+
+for i in "${!WATCH_DIRS[@]}"; do
+  dir="${WATCH_DIRS[$i]}"
+  echo "▸ Comparing real $dir before/after test run"
+  if [ "${HAVE_BASELINE[$i]}" = "1" ]; then
+    POST_FILE="$(mktemp -t opencues-test-post.XXXXXX)"
+    snapshot_dir "$dir" "$POST_FILE"
+    DIFF_FILE="/tmp/opencues-hermeticity-$(basename "$dir").diff"
+    if ! diff -u "${BASELINE_FILES[$i]}" "$POST_FILE" > "$DIFF_FILE"; then
+      echo "✗ HERMETICITY VIOLATION — real $dir was modified during tests:"
+      head -20 "$DIFF_FILE" | sed 's/^/    /'
+      echo ""
+      echo "    Symptom of a test that wrote to os.homedir() / process.env.HOME"
+      echo "    without sandboxing. See PR #41 (June 2026) for the fix pattern:"
+      echo "    use a before/after hook that mkdtempSync + sets process.env.HOME."
+      HERMETICITY_FAIL=1
+    fi
+    rm -f "$POST_FILE"
+  else
+    echo "  (no baseline — real $dir didn't exist before tests)"
   fi
-  rm -f "$POST_FILE"
-else
-  echo "  (no baseline — real ~/.opencues didn't exist before tests)"
-fi
+done
 
 # Clean up the sandbox.
 rm -rf "$SANDBOX_HOME"
-[ -n "$BASELINE_FILE" ] && rm -f "$BASELINE_FILE"
+for f in "${BASELINE_FILES[@]}"; do
+  [ -n "$f" ] && rm -f "$f"
+done
 
 if [ "$TEST_EXIT" -ne 0 ]; then
   echo ""
@@ -94,4 +119,4 @@ fi
 if [ "$HERMETICITY_FAIL" -ne 0 ]; then
   exit 1
 fi
-echo "✓ Tests pass + real ~/.opencues unchanged."
+echo "✓ Tests pass + real ~/.opencues and ~/.cues unchanged."


### PR DESCRIPTION
## Summary

User reported their `~/.cues/OPENCUES.md` scalars drifting between test runs but the hermeticity gate stayed green. Root cause: the gate snapshotted `~/.opencues/` (empty on their machine) and ignored `~/.cues/` where the actual config lives — `OPENCUES.md`, `CUES.md`, `BLANKS.md`, `SENTINELS.md`, plus the `cues/<topic>/CUE.md` and `blanks/<name>/BLANK.md` folder trees.

A test that bypassed the HOME sandbox via hardcoded paths or `$USER`/`os.userInfo()` could write to `~/.cues/` and slip past CI invisibly. Now both directories get snapshotted and diffed.

## Verified

- `bash scripts/check-test-hermeticity.sh` on master: full sweep + extended gate runs clean. Current suite **IS** hermetic against both dirs; the fix is structural / forward-looking.
- `~/.cues/OPENCUES.md` byte-identical pre/post test run.
- `bash scripts/lint-shell-portability.sh` clean — bash 3.2 + BSD coreutils compat preserved.

## Implementation notes

Refactored to parallel arrays + a `snapshot_dir` helper. Adding a third watched dir (if we ever introduce a `~/.something-else/`) is a one-line append to `WATCH_DIRS`. The existing `find -printf` with `stat -f` fallback convention is preserved.

## Test plan

- [x] Local hermeticity gate runs green
- [x] Shell portability lint clean
- [x] User's `~/.cues/OPENCUES.md` verified byte-identical pre/post test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)