### PR TITLE
fix(providers): all LLM combinations now actually work — Anthropic temperature, Groq reasoning_effort, refreshed Gemini + Cerebras catalogues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Changed — Provider rename `claude-cli` → `claude-code-cli`, llama-3.3 removed from Groq catalogue, CLI providers added to smoke
+
+Follow-up on the LLM-provider fix below. Renamed the Anthropic CLI-transport provider id from `claude-cli` to `claude-code-cli` to match the official product name and remove ambiguity ("claude-cli" reads as a generic Claude CLI; the canonical user-facing brand for the binary is "Claude Code"). `canonicalizeProviderId()` keeps legacy user configs (`globalProvider: claude-cli`) silently working — old id resolves to canonical at every user-input boundary (resolveLLM + validateEndpoint + getProvider). Drop after 2027-01-01.
+
+`llama-3.3-70b-versatile` removed from Groq's `knownModels` — it's not a reasoning model, so the adapter's default `reasoning_effort: low` 400s on it. The `modelRejectsReasoningEffort` predicate keeps it usable via direct OPENCUES.md edit; the classifier just doesn't surface it.
+
+Smoke runner now also covers the two CLI-transport providers (`claude-code-cli`, `openai-subscription`) — `probe()` branches on `transport === 'cli'` and dispatches via `invokeCli()` instead of `fetch()`. Verified live 2026-06-02: 20 of 21 combos pass; the one failure was the user's expired `codex login` (actionable, not a bug — the runner correctly surfaced the API's auth-expired message).
+
+Version bumped: `@opencues/core` 0.1.7 → 0.1.8 (single bump covers both fixes).
+
 ### Fixed — LLM providers: temperature/reasoning-effort deprecations + stale model catalogues
 
 User reported `draft email _` producing no output in claude-cues despite doctor reporting healthy. Log trace caught the actual failure: `anthropic error: \`temperature\` is deprecated for this model.` — every blank routing through `blanks-llm-provider: anthropic` (Claude 4.x) was silently dying in the LLM call. A live smoke runner ([`tests/integration/llm-providers-smoke.cjs`](tests/integration/llm-providers-smoke.cjs)) verifying all 19 shipped (provider, model) combinations against real keys caught three more latent failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fixed — LLM providers: temperature/reasoning-effort deprecations + stale model catalogues
+
+User reported `draft email _` producing no output in claude-cues despite doctor reporting healthy. Log trace caught the actual failure: `anthropic error: \`temperature\` is deprecated for this model.` — every blank routing through `blanks-llm-provider: anthropic` (Claude 4.x) was silently dying in the LLM call. A live smoke runner ([`tests/integration/llm-providers-smoke.cjs`](tests/integration/llm-providers-smoke.cjs)) verifying all 19 shipped (provider, model) combinations against real keys caught three more latent failures:
+
+- **anthropic + claude-{opus,sonnet,haiku}-4-*** rejected `temperature`. Anthropic deprecated the field on the entire Claude 4.x family in June 2026. Now omitted at request build (`modelRejectsTemperature` registry). OpenRouter passthrough to `anthropic/claude-*` also covered.
+- **groq + llama-3.3-70b-versatile** rejected `reasoning_effort` with HTTP 400. Groq's adapter previously claimed "non-reasoning models silently ignore it" — they don't on llama. Now gated by `modelRejectsReasoningEffort` registry; gpt-oss companions (which REQUIRE the field) keep getting it.
+- **cerebras** catalogue listed `qwen-3-235b-a22b-instruct-2507` which Cerebras's `/v1/models` endpoint no longer returns. Removed from `knownModels`.
+- **gemini** catalogue listed `gemini-3.1-flash` / `gemini-3.1-pro` which 404 on the live API. Google switched to the `gemini-flash-latest` / `gemini-pro-latest` rolling aliases. Updated.
+
+Capability matrix lives in two registry consts in `llm-provider.ts` (`TEMPERATURE_REJECTING_MODELS`, `REASONING_EFFORT_REJECTING_MODELS`). Adding a future deprecation is a one-line append. 24 unit-test pins in `llm-provider.temperature.test.ts` cover the predicates + the buildRequest forwarding (Anthropic inline body + buildOpenAIBody-driven Groq/OpenRouter/Cerebras/OpenAI shared body). Live smoke runner (opt-in, requires API keys) verifies every catalogue entry actually accepts a minimal request — re-run on any model-catalogue or provider-adapter edit:
+
+```bash
+node tests/integration/llm-providers-smoke.cjs           # smoke every combo
+node tests/integration/llm-providers-smoke.cjs --models  # list known combos
+```
+
+Verified live: 19/19 combos pass after the fix. Version bumped: `@opencues/core` 0.1.7 → 0.1.8.
+
 ### Changed — Blanks fire only on explicit `_` keystroke (cursor-split bug)
 
 Explicit-`_` gate for blank activation (`packages/opencues-runtime/src/modules/{resolver,blank-fill}.ts`). FluidBlank / TransformBlank / ConfigIntent and script-backed blanks (volume, brightness, …) now fire ONLY when the `_` in the buffer was placed by an explicit user keystroke. A `_` exposed via cursor-relocation (typing `monologue_` and then splitting it to `monologue _`), paste, or programmatic `setText` is suppressed. Resolver and BlankFill each arm a one-shot flag on a plain `_` keypress, but only when the simulated insertion would produce a standalone `_` — so typing `_` adjacent to an existing word never arms. The flag is cleared at the end of the next `onTextChange` (exception: spaced-mode unconfirmed `_` keeps it through one extra dispatch so the confirming space still dispatches). `MockAdapter.pushText` auto-fires the `_` keystroke when the new text introduces additional `_` chars; the new `pushTextNoKeystroke` is the explicit opt-out for paste/programmatic-insertion simulations. Three scenario tests pin the user journey.

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -897,7 +897,7 @@ module.exports = async function doctor(argv, ctx) {
         // path). Default to the id for any future CLI provider whose
         // binary matches its id.
         const BIN_BY_ID = {
-          'claude-cli': 'claude',
+          'claude-code-cli': 'claude',
           'openai-subscription': 'codex',
         };
         const bin = BIN_BY_ID[adapter.id] || adapter.id;
@@ -906,7 +906,7 @@ module.exports = async function doctor(argv, ctx) {
         s.ok(`${adapter.displayName} (${bin} on PATH)`, installed);
         if (!installed) {
           const FIX_BY_ID = {
-            'claude-cli': `install Claude Code from https://claude.com/code, run \`claude auth\`, then \`claude -p hi\` to confirm`,
+            'claude-code-cli': `install Claude Code from https://claude.com/code, run \`claude auth\`, then \`claude -p hi\` to confirm`,
             'openai-subscription': `install OpenAI Codex via \`npm i -g @openai/codex\`, then run \`codex login\` to sign in with your ChatGPT plan (writes ~/.codex/auth.json which the runtime reads on every call — the codex binary is not on the request hot path)`,
           };
           findings.push({

--- a/packages/opencues-cli/src/commands/help.cjs
+++ b/packages/opencues-cli/src/commands/help.cjs
@@ -258,7 +258,7 @@ function displayProvider(id, core) {
 const PROVIDER_DISPLAY = {
   groq: 'Groq', cerebras: 'Cerebras', openai: 'OpenAI',
   anthropic: 'Claude', openrouter: 'OpenRouter', gemini: 'Gemini',
-  'claude-cli': 'Claude (CLI, subscription)',
+  'claude-code-cli': 'Claude Code (CLI, subscription)',
   'openai-subscription': 'OpenAI (ChatGPT subscription)',
   'opencode-zen': 'OpenCode Zen',
 };
@@ -272,7 +272,7 @@ const PROVIDER_DEFAULT_MODEL = {
   anthropic:  'claude-haiku-4-5-20251001',
   openrouter: 'openai/gpt-oss-120b:free',
   gemini:     'gemini-3.1-flash-lite',
-  'claude-cli': 'haiku',
+  'claude-code-cli': 'haiku',
   'openai-subscription': 'gpt-5.4-mini',
   'opencode-zen': 'big-pickle',
 };

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "find dist -name '*.test.js' ! -name 'feature-registry*.test.js' ! -name 'llm-provider.drift.test.js' ! -name 'conformance.test.js' | xargs node --test && vitest run",
+    "test": "find dist -name '*.test.js' ! -name 'feature-registry*.test.js' ! -name 'llm-provider.drift.test.js' ! -name 'llm-provider.temperature.test.js' ! -name 'conformance.test.js' | xargs node --test && vitest run",
     "prepublishOnly": "node ../../scripts/prepublish-guard.cjs",
     "smoke:providers": "tsc --skipLibCheck --rootDir . --outDir dist-smoke scripts/smoke-providers.ts && node dist-smoke/scripts/smoke-providers.js",
     "bench:providers": "tsc --skipLibCheck --rootDir . --outDir dist-smoke scripts/bench-providers.ts && node dist-smoke/scripts/bench-providers.js",

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/feature-registry.ts
+++ b/packages/opencues-core/src/feature-registry.ts
@@ -371,7 +371,7 @@ export const FEATURES: readonly FeatureSpec[] = [
       { id: 'anthropic', description: 'Anthropic — pricier, parity accuracy' },
       { id: 'openai',    description: 'OpenAI — gpt-5.4-mini default' },
       { id: 'openrouter', description: 'OpenRouter (multi-model router)', exposeInMenu: false },
-      { id: 'claude-cli', description: 'claude-cli (subprocess)',          exposeInMenu: false },
+      { id: 'claude-code-cli', description: 'claude-code-cli (subprocess)', exposeInMenu: false },
     ],
   },
   {
@@ -387,7 +387,7 @@ export const FEATURES: readonly FeatureSpec[] = [
       { id: 'anthropic', description: 'Anthropic — pricier, parity accuracy' },
       { id: 'openai',    description: 'OpenAI — gpt-5.4-mini default' },
       { id: 'openrouter', description: 'OpenRouter (multi-model router)', exposeInMenu: false },
-      { id: 'claude-cli', description: 'claude-cli (subprocess)',          exposeInMenu: false },
+      { id: 'claude-code-cli', description: 'claude-code-cli (subprocess)', exposeInMenu: false },
     ],
   },
   {
@@ -404,7 +404,7 @@ export const FEATURES: readonly FeatureSpec[] = [
       { id: 'anthropic',    description: 'Anthropic — pricier, parity accuracy' },
       { id: 'openai',       description: 'OpenAI — gpt-5.4-mini default' },
       { id: 'openrouter',   description: 'OpenRouter (multi-model router)', exposeInMenu: false },
-      { id: 'claude-cli',   description: 'claude-cli (subprocess)',          exposeInMenu: false },
+      { id: 'claude-code-cli', description: 'claude-code-cli (subprocess)', exposeInMenu: false },
     ],
   },
 

--- a/packages/opencues-core/src/llm-provider.temperature.test.ts
+++ b/packages/opencues-core/src/llm-provider.temperature.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import { modelRejectsTemperature, modelRejectsReasoningEffort, getProvider, type ChatRequest } from './llm-provider';
+
+// Anthropic deprecated `temperature` on every Claude 4.x model in June 2026
+// (verified live against the user's claude-opus-4-7 key on 2026-06-02:
+// "anthropic error: `temperature` is deprecated for this model").
+// `modelRejectsTemperature` is the single source of truth. Both the Anthropic
+// adapter and `buildOpenAIBody` (used by Groq/OpenAI/OpenRouter/Cerebras)
+// consult it. These pins guarantee both call sites stay in agreement and that
+// a future provider/model entry covers every wire-shape variant the runtime
+// emits.
+
+describe('modelRejectsTemperature — capability matrix', () => {
+  describe('rejects (must skip the field)', () => {
+    it('anthropic + claude-opus-4-7', () => {
+      expect(modelRejectsTemperature('anthropic', 'claude-opus-4-7')).toBe(true);
+    });
+    it('anthropic + claude-sonnet-4-6', () => {
+      expect(modelRejectsTemperature('anthropic', 'claude-sonnet-4-6')).toBe(true);
+    });
+    it('anthropic + claude-haiku-4-5-20251001 (dated suffix)', () => {
+      expect(modelRejectsTemperature('anthropic', 'claude-haiku-4-5-20251001')).toBe(true);
+    });
+    it('openrouter + anthropic/claude-opus-4-7 (passthrough)', () => {
+      expect(modelRejectsTemperature('openrouter', 'anthropic/claude-opus-4-7')).toBe(true);
+    });
+    it('openrouter + anthropic/claude-haiku-4-5 (passthrough)', () => {
+      expect(modelRejectsTemperature('openrouter', 'anthropic/claude-haiku-4-5')).toBe(true);
+    });
+  });
+
+  describe('accepts (must include the field)', () => {
+    it('groq + gpt-oss-120b', () => {
+      expect(modelRejectsTemperature('groq', 'openai/gpt-oss-120b')).toBe(false);
+    });
+    it('cerebras + gpt-oss-120b', () => {
+      expect(modelRejectsTemperature('cerebras', 'gpt-oss-120b')).toBe(false);
+    });
+    it('gemini + gemini-3.1-flash-lite', () => {
+      expect(modelRejectsTemperature('gemini', 'gemini-3.1-flash-lite')).toBe(false);
+    });
+    it('openrouter + openai/gpt-oss-120b:free (NON-anthropic passthrough)', () => {
+      expect(modelRejectsTemperature('openrouter', 'openai/gpt-oss-120b:free')).toBe(false);
+    });
+    it('anthropic + claude-3-opus (legacy 3.x family, pre-deprecation)', () => {
+      // Hypothetical regression guard: if a user pins a 3.x model from
+      // before June 2026, temperature still works. The pattern is anchored
+      // to `4` so 3.x doesn't match.
+      expect(modelRejectsTemperature('anthropic', 'claude-3-opus-20240229')).toBe(false);
+    });
+  });
+});
+
+describe('Anthropic buildRequest — temperature omission', () => {
+  // The Anthropic adapter rebuilds the body inline (not via buildOpenAIBody).
+  // Pin BOTH directions: temperature is included for legacy models, omitted
+  // for Claude 4.x. A 400 from the API would silently kill every blank that
+  // routes to anthropic; this test catches it before deployment.
+  const anthropic = getProvider('anthropic')!;
+
+  function buildAndParse(model: string, temperature: number | undefined): Record<string, unknown> {
+    const req: ChatRequest = {
+      model,
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature,
+    };
+    const built = anthropic.buildRequest(req, { apiKey: 'sk-test', endpoint: undefined });
+    return JSON.parse(built.body);
+  }
+
+  it('omits temperature for claude-opus-4-7 even when caller passes 0', () => {
+    const body = buildAndParse('claude-opus-4-7', 0);
+    expect('temperature' in body).toBe(false);
+  });
+
+  it('omits temperature for claude-haiku-4-5-20251001', () => {
+    const body = buildAndParse('claude-haiku-4-5-20251001', 0.5);
+    expect('temperature' in body).toBe(false);
+  });
+
+  it('includes temperature for legacy claude-3-opus (regression guard)', () => {
+    const body = buildAndParse('claude-3-opus-20240229', 0.3);
+    expect(body.temperature).toBe(0.3);
+  });
+
+  it('omits temperature when caller passes undefined regardless of model', () => {
+    expect('temperature' in buildAndParse('claude-opus-4-7', undefined)).toBe(false);
+    expect('temperature' in buildAndParse('claude-3-opus-20240229', undefined)).toBe(false);
+  });
+});
+
+describe('modelRejectsReasoningEffort — capability matrix', () => {
+  describe('rejects (must skip the field)', () => {
+    it('groq + llama-3.3-70b-versatile', () => {
+      // Live-verified 2026-06-02: Groq returned HTTP 400
+      // "`reasoning_effort` is not supported with this model".
+      expect(modelRejectsReasoningEffort('groq', 'llama-3.3-70b-versatile')).toBe(true);
+    });
+    it('groq + llama-3.1-8b-instant (regression guard — other llamas too)', () => {
+      expect(modelRejectsReasoningEffort('groq', 'llama-3.1-8b-instant')).toBe(true);
+    });
+  });
+
+  describe('accepts (must include the field)', () => {
+    it('groq + openai/gpt-oss-120b', () => {
+      // gpt-oss models REQUIRE reasoning_effort on Groq.
+      expect(modelRejectsReasoningEffort('groq', 'openai/gpt-oss-120b')).toBe(false);
+    });
+    it('cerebras + gpt-oss-120b', () => {
+      expect(modelRejectsReasoningEffort('cerebras', 'gpt-oss-120b')).toBe(false);
+    });
+    it('openai + gpt-5.4-mini', () => {
+      expect(modelRejectsReasoningEffort('openai', 'gpt-5.4-mini')).toBe(false);
+    });
+  });
+});
+
+describe('Groq buildRequest — llama models omit reasoning_effort', () => {
+  const groq = getProvider('groq')!;
+
+  function buildAndParse(model: string): Record<string, unknown> {
+    const req: ChatRequest = {
+      model,
+      messages: [{ role: 'user', content: 'hi' }],
+      reasoningEffort: 'low',
+    };
+    const built = groq.buildRequest(req, { apiKey: 'sk-test', endpoint: undefined });
+    return JSON.parse(built.body);
+  }
+
+  it('omits reasoning_effort for llama-3.3-70b-versatile', () => {
+    const body = buildAndParse('llama-3.3-70b-versatile');
+    expect('reasoning_effort' in body).toBe(false);
+  });
+
+  it('includes reasoning_effort for openai/gpt-oss-120b', () => {
+    const body = buildAndParse('openai/gpt-oss-120b');
+    expect(body.reasoning_effort).toBe('low');
+  });
+
+  it('includes reasoning_effort for openai/gpt-oss-20b', () => {
+    const body = buildAndParse('openai/gpt-oss-20b');
+    expect(body.reasoning_effort).toBe('low');
+  });
+});
+
+describe('OpenRouter buildRequest — Anthropic passthrough temperature omission', () => {
+  const openrouter = getProvider('openrouter')!;
+
+  function buildAndParse(model: string, temperature: number | undefined): Record<string, unknown> {
+    const req: ChatRequest = {
+      model,
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature,
+    };
+    const built = openrouter.buildRequest(req, { apiKey: 'sk-test', endpoint: undefined });
+    return JSON.parse(built.body);
+  }
+
+  it('omits temperature for anthropic/claude-opus-4-7 via OpenRouter', () => {
+    const body = buildAndParse('anthropic/claude-opus-4-7', 0);
+    expect('temperature' in body).toBe(false);
+  });
+
+  it('includes temperature for openai/gpt-oss-120b:free via OpenRouter (non-Anthropic)', () => {
+    const body = buildAndParse('openai/gpt-oss-120b:free', 0.7);
+    expect(body.temperature).toBe(0.7);
+  });
+});

--- a/packages/opencues-core/src/llm-provider.test.ts
+++ b/packages/opencues-core/src/llm-provider.test.ts
@@ -1062,18 +1062,18 @@ describe('resolveLLM — misconfiguration warnings (silent-no-op regressors)', (
   });
 });
 
-describe('resolveLLM — claude-cli (CLI-transport, no API key)', () => {
-  it('resolves to claude-cli with no apiKey + no fallback (auth is external)', () => {
+describe('resolveLLM — claude-code-cli (CLI-transport, no API key)', () => {
+  it('resolves to claude-code-cli with no apiKey + no fallback (auth is external)', () => {
     _resetWarnDedupForTesting();
     const { warnings, restore } = captureWarn();
     try {
       const result = resolveLLM({
-        globalProvider: 'claude-cli',
+        globalProvider: 'claude-code-cli',
         globalModel: 'haiku',
         apiKeys: {}, // intentionally empty — CLI transport doesn't use apiKeys
       });
       assert.notStrictEqual(result, null);
-      assert.strictEqual(result!.provider.id, 'claude-cli');
+      assert.strictEqual(result!.provider.id, 'claude-code-cli');
       assert.strictEqual(result!.provider.transport, 'cli');
       assert.strictEqual(result!.model, 'haiku');
       assert.strictEqual(result!.apiKey, '', 'CLI providers carry an empty apiKey');
@@ -1082,25 +1082,37 @@ describe('resolveLLM — claude-cli (CLI-transport, no API key)', () => {
     } finally { restore(); }
   });
 
-  it('per-feature claude-cli override resolves without env keys', () => {
+  it('per-feature claude-code-cli override resolves without env keys', () => {
     _resetWarnDedupForTesting();
     const result = resolveLLM({
-      featureProvider: 'claude-cli',
+      featureProvider: 'claude-code-cli',
       featureModel: 'sonnet',
       apiKeys: { GROQ_API_KEY: 'unused-here' },
     });
-    assert.strictEqual(result?.provider.id, 'claude-cli');
+    assert.strictEqual(result?.provider.id, 'claude-code-cli');
     assert.strictEqual(result?.model, 'sonnet');
   });
 
-  it('claude-cli is NOT auto-picked when only env keys for other providers are set', () => {
-    // claude-cli is opt-in only — not in PROVIDER_AUTO_ORDER. pickAutoProvider
-    // should never return it just because the user has a `claude` install.
+  it('legacy `claude-cli` id silently resolves to canonical `claude-code-cli`', () => {
+    // User configs created before the rename (2026-06-02) keep working.
+    _resetWarnDedupForTesting();
+    const result = resolveLLM({
+      globalProvider: 'claude-cli',  // legacy
+      globalModel: 'haiku',
+      apiKeys: {},
+    });
+    assert.strictEqual(result?.provider.id, 'claude-code-cli');
+  });
+
+  it('claude-code-cli is NOT auto-picked when only env keys for other providers are set', () => {
+    // claude-code-cli is opt-in only — not in PROVIDER_AUTO_ORDER.
+    // pickAutoProvider should never return it just because the user has a
+    // `claude` install.
     _resetWarnDedupForTesting();
     const result = resolveLLM({
       apiKeys: { CEREBRAS_API_KEY: 'k' }, // cerebras IS in auto-order
     });
-    assert.strictEqual(result?.provider.id, 'cerebras', 'auto-route must pick cerebras, not claude-cli');
+    assert.strictEqual(result?.provider.id, 'cerebras', 'auto-route must pick cerebras, not claude-code-cli');
   });
 });
 

--- a/packages/opencues-core/src/llm-provider.ts
+++ b/packages/opencues-core/src/llm-provider.ts
@@ -227,7 +227,7 @@ export interface ProviderAdapter {
  * pass `includeReasoningEffort: true`; others omit the field unless
  * the model name suggests it's a reasoning model.
  */
-function buildOpenAIBody(req: ChatRequest, opts?: { includeReasoningEffort?: boolean; useCompletionTokensName?: boolean; defaultReasoningEffort?: 'none' | 'low' | 'medium' | 'high' }): string {
+function buildOpenAIBody(req: ChatRequest, opts?: { includeReasoningEffort?: boolean; useCompletionTokensName?: boolean; defaultReasoningEffort?: 'none' | 'low' | 'medium' | 'high'; provider?: ProviderId }): string {
   const body: Record<string, unknown> = {
     model: req.model,
     messages: req.messages.map((m) => ({ role: m.role, content: m.content })),
@@ -264,16 +264,29 @@ function buildOpenAIBody(req: ChatRequest, opts?: { includeReasoningEffort?: boo
     // wants based on its own routing.
     body[opts?.useCompletionTokensName ? 'max_completion_tokens' : 'max_tokens'] = effectiveMax;
   }
-  // gpt-5 / o-series lock temperature to 1 — passing any other value
-  // (including 0) returns HTTP 400 "Only the default (1) value is
-  // supported." `useCompletionTokensName` correlates 1:1 with this
-  // restriction, so re-use the flag rather than threading a second.
-  if (req.temperature !== undefined && !opts?.useCompletionTokensName) body.temperature = req.temperature;
+  // Two gates on `temperature`:
+  //   1. OpenAI gpt-5 / o-series lock temperature to 1 — passing any
+  //      other value (including 0) returns HTTP 400. `useCompletionTokensName`
+  //      correlates 1:1 with this restriction, so we re-use the flag.
+  //   2. Provider/model-level rejection — Anthropic Claude 4.x (direct or
+  //      via OpenRouter pass-through) and any future model added to the
+  //      `TEMPERATURE_REJECTING_MODELS` matrix.
+  const providerRejectsTemp = opts?.provider !== undefined
+    && modelRejectsTemperature(opts.provider, req.model);
+  if (req.temperature !== undefined && !opts?.useCompletionTokensName && !providerRejectsTemp) {
+    body.temperature = req.temperature;
+  }
   if (req.seed !== undefined) body.seed = req.seed;
   // Pass reasoning_effort only when the provider opts in OR the model
   // name suggests it's an OpenAI reasoning model (o1/o3/o4/gpt-5).
   // Leaves gpt-4o-mini-class models alone, where the field 400s.
-  if (reasoning !== undefined) {
+  // Provider/model-level explicit rejection wins regardless of opt-in
+  // (e.g. Groq llama-* rejects the field even though the adapter
+  //  opts in for its gpt-oss companions — see
+  //  `modelRejectsReasoningEffort`).
+  const providerRejectsReasoning = opts?.provider !== undefined
+    && modelRejectsReasoningEffort(opts.provider, req.model);
+  if (reasoning !== undefined && !providerRejectsReasoning) {
     body.reasoning_effort = reasoning;
   }
   // Structured outputs. Groq's gpt-oss-{20b,120b} support `strict: true`
@@ -320,6 +333,81 @@ function parseOpenAIResponse(rawJson: string): string {
 }
 
 // ---------------------------------------------------------------------
+// Model capability matrix
+// ---------------------------------------------------------------------
+
+/**
+ * (provider, model) pairs that 400 on the `temperature` parameter.
+ *
+ * - OpenAI's gpt-5 / o-series: temperature is locked to `1`; the adapter
+ *   already filters these via `useCompletionTokensName` (see buildOpenAIBody)
+ *   so they're NOT enumerated here.
+ * - Anthropic Claude 4.x: Anthropic's June 2026 API change deprecated
+ *   `temperature` on every Claude 4.x model — claude-opus-4-7 raises
+ *   "`temperature` is deprecated for this model" on every call that includes
+ *   the field, regardless of `reasoning_effort` state. Verified live against
+ *   the user's anthropic key on 2026-06-02. The same applies to
+ *   sonnet-4-6 and haiku-4-5 per Anthropic's docs / change notes.
+ * - OpenRouter pass-through: requests to `anthropic/claude-*` via OpenRouter
+ *   hit Anthropic's gate too, so the same rule applies when the model name
+ *   carries the `anthropic/` prefix.
+ *
+ * Match is a regex against the model name; the caller passes the resolved
+ * (provider, model) pair. When a future provider adds more reasoning-class
+ * models, append a row here — no buildRequest edits needed.
+ */
+const TEMPERATURE_REJECTING_MODELS: ReadonlyArray<{
+  provider: ProviderId;
+  pattern: RegExp;
+  reason: string;
+}> = [
+  { provider: 'anthropic',  pattern: /^claude-(opus|sonnet|haiku)-4/,             reason: 'Anthropic Claude 4.x deprecated `temperature` (June 2026 API change).' },
+  { provider: 'openrouter', pattern: /^anthropic\/claude-(opus|sonnet|haiku)-4/, reason: 'OpenRouter passthrough to Anthropic Claude 4.x — same deprecation.' },
+];
+
+/**
+ * Returns true when the (provider, model) pair is known to reject the
+ * `temperature` parameter at the API boundary. Callers should omit the
+ * field from the request body when this returns true.
+ */
+export function modelRejectsTemperature(provider: ProviderId, model: string): boolean {
+  return TEMPERATURE_REJECTING_MODELS.some(
+    (entry) => entry.provider === provider && entry.pattern.test(model),
+  );
+}
+
+/**
+ * (provider, model) pairs that 400 on the `reasoning_effort` parameter.
+ *
+ * - Groq's llama-3.3-70b-versatile (and other non-gpt-oss llama models) reject
+ *   `reasoning_effort` with HTTP 400 "`reasoning_effort` is not supported with
+ *   this model". Groq's adapter previously set `includeReasoningEffort: true`
+ *   adapter-wide on the assumption that non-reasoning models would silently
+ *   ignore it — they don't. Verified live 2026-06-02.
+ *
+ * The match shape mirrors `TEMPERATURE_REJECTING_MODELS` so adding a new
+ * entry is one line and never requires editing an adapter.
+ */
+const REASONING_EFFORT_REJECTING_MODELS: ReadonlyArray<{
+  provider: ProviderId;
+  pattern: RegExp;
+  reason: string;
+}> = [
+  { provider: 'groq', pattern: /^llama-/, reason: 'Groq llama-* family rejects `reasoning_effort` (HTTP 400).' },
+];
+
+/**
+ * Returns true when the (provider, model) pair is known to reject the
+ * `reasoning_effort` parameter. Callers should omit the field from the
+ * request body when this returns true.
+ */
+export function modelRejectsReasoningEffort(provider: ProviderId, model: string): boolean {
+  return REASONING_EFFORT_REJECTING_MODELS.some(
+    (entry) => entry.provider === provider && entry.pattern.test(model),
+  );
+}
+
+// ---------------------------------------------------------------------
 // Built-in providers
 // ---------------------------------------------------------------------
 
@@ -349,7 +437,7 @@ const GROQ: ProviderAdapter = {
     // non-reasoning models silently ignore it. Always-on is safe.
     return {
       url: ctx.endpoint ?? this.defaultEndpoint,
-      body: buildOpenAIBody(req, { includeReasoningEffort: true, defaultReasoningEffort: this.defaultReasoningEffort }),
+      body: buildOpenAIBody(req, { includeReasoningEffort: true, defaultReasoningEffort: this.defaultReasoningEffort, provider: this.id }),
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${ctx.apiKey}` },
     };
   },
@@ -386,7 +474,7 @@ const OPENROUTER: ProviderAdapter = {
   buildRequest(req, ctx) {
     return {
       url: ctx.endpoint ?? this.defaultEndpoint,
-      body: buildOpenAIBody(req, { defaultReasoningEffort: this.defaultReasoningEffort }),
+      body: buildOpenAIBody(req, { defaultReasoningEffort: this.defaultReasoningEffort, provider: this.id }),
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${ctx.apiKey}`,
@@ -456,7 +544,7 @@ const OPENAI: ProviderAdapter = {
 
     return {
       url: ctx.endpoint ?? this.defaultEndpoint,
-      body: buildOpenAIBody(reqForBody, { useCompletionTokensName, defaultReasoningEffort: this.defaultReasoningEffort }),
+      body: buildOpenAIBody(reqForBody, { useCompletionTokensName, defaultReasoningEffort: this.defaultReasoningEffort, provider: this.id }),
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${ctx.apiKey}` },
     };
   },
@@ -572,9 +660,13 @@ const GEMINI: ProviderAdapter = {
   // family stays reachable via direct file edit.
   knownModels: [
     'gemini-3.1-flash-lite',
-    'gemini-3.1-flash',
-    'gemini-3.1-pro',
+    'gemini-flash-latest',
+    'gemini-pro-latest',
   ],
+  // 2026-06: Google retired the `gemini-3.1-flash` / `gemini-3.1-pro` model
+  // names. The new public aliases are `gemini-flash-latest` / `gemini-pro-latest`
+  // (always point at the current Gemini 3.x family). flash-lite kept its
+  // own name. Smoke runner verifies against live API on each release.
   envKeyName: 'GEMINI_API_KEY',
   buildRequest(req, ctx) {
     const endpointTemplate = ctx.endpoint ?? this.defaultEndpoint;
@@ -676,7 +768,11 @@ const ANTHROPIC: ProviderAdapter = {
     if (systemMessages.length > 0) {
       body.system = systemMessages.map((m) => m.content).join('\n\n');
     }
-    if (req.temperature !== undefined) body.temperature = req.temperature;
+    // Claude 4.x models reject `temperature` outright (Anthropic API change,
+    // June 2026). See `modelRejectsTemperature` for the full matrix.
+    if (req.temperature !== undefined && !modelRejectsTemperature('anthropic', req.model)) {
+      body.temperature = req.temperature;
+    }
     return {
       url: ctx.endpoint ?? this.defaultEndpoint,
       body: JSON.stringify(body),
@@ -741,9 +837,11 @@ const CEREBRAS: ProviderAdapter = {
   // available 235B MoE). Other Cerebras names reachable via file edit.
   knownModels: [
     'gpt-oss-120b',
-    'qwen-3-235b-a22b-instruct-2507',
     'zai-glm-4.7',
   ],
+  // qwen-3-235b-a22b-instruct-2507 was removed 2026-06: Cerebras's public
+  // catalogue (/v1/models) returned only gpt-oss-120b + zai-glm-4.7 against
+  // a live key. The smoke runner catches this regression structurally.
   envKeyName: 'CEREBRAS_API_KEY',
   // Cerebras's wafer-scale silicon serves gpt-oss-120b fast enough that
   // `medium` fits every OpenCues pipeline (358ms p50 fluid-blank,
@@ -757,7 +855,7 @@ const CEREBRAS: ProviderAdapter = {
     // gpt-oss-* / qwen-3-thinking-* and similar.
     return {
       url: ctx.endpoint ?? this.defaultEndpoint,
-      body: buildOpenAIBody(req, { defaultReasoningEffort: this.defaultReasoningEffort }),
+      body: buildOpenAIBody(req, { defaultReasoningEffort: this.defaultReasoningEffort, provider: this.id }),
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${ctx.apiKey}` },
     };
   },
@@ -892,7 +990,7 @@ const OPENCODE_ZEN: ProviderAdapter = {
     if (ctx.apiKey) headers.Authorization = `Bearer ${ctx.apiKey}`;
     return {
       url: ctx.endpoint ?? this.defaultEndpoint,
-      body: buildOpenAIBody(req, { defaultReasoningEffort: this.defaultReasoningEffort }),
+      body: buildOpenAIBody(req, { defaultReasoningEffort: this.defaultReasoningEffort, provider: this.id }),
       headers,
     };
   },

--- a/packages/opencues-core/src/llm-provider.ts
+++ b/packages/opencues-core/src/llm-provider.ts
@@ -20,9 +20,30 @@
  * model defaults + request/response translators. Nothing else changes.
  */
 
-export type ProviderId = 'groq' | 'openrouter' | 'gemini' | 'openai' | 'openai-subscription' | 'anthropic' | 'cerebras' | 'claude-cli' | 'opencode-zen';
+export type ProviderId = 'groq' | 'openrouter' | 'gemini' | 'openai' | 'openai-subscription' | 'anthropic' | 'cerebras' | 'claude-code-cli' | 'opencode-zen';
 
-export const PROVIDER_IDS: readonly ProviderId[] = ['groq', 'openrouter', 'gemini', 'openai', 'openai-subscription', 'anthropic', 'cerebras', 'claude-cli', 'opencode-zen'];
+export const PROVIDER_IDS: readonly ProviderId[] = ['groq', 'openrouter', 'gemini', 'openai', 'openai-subscription', 'anthropic', 'cerebras', 'claude-code-cli', 'opencode-zen'];
+
+/**
+ * Legacy provider-id aliases. User configs created before the rename
+ * (`claude-cli` → `claude-code-cli`, 2026-06-02) silently resolve via
+ * `getProvider`. The old id is retained ONLY for read; new writes
+ * always emit the canonical form. Drop after 2027-01-01.
+ */
+const LEGACY_PROVIDER_ALIASES: Readonly<Record<string, ProviderId>> = {
+  'claude-cli': 'claude-code-cli',
+};
+
+/**
+ * Canonicalises a provider id at every user-input boundary. Legacy
+ * aliases ({@link LEGACY_PROVIDER_ALIASES}) resolve to their current
+ * canonical id; unknown ids pass through unchanged for the caller to
+ * surface as `unknown-provider`. Internal call sites (buildRequest,
+ * fallback walkers) already receive canonical ids and don't need this.
+ */
+export function canonicalizeProviderId(id: string): string {
+  return LEGACY_PROVIDER_ALIASES[id] ?? id;
+}
 
 /**
  * Internal chat-request shape — provider-neutral. Each provider's
@@ -424,8 +445,11 @@ const GROQ: ProviderAdapter = {
   knownModels: [
     'openai/gpt-oss-120b',
     'openai/gpt-oss-20b',
-    'llama-3.3-70b-versatile',
   ],
+  // llama-3.3-70b-versatile removed 2026-06: not a reasoning model, so it
+  // 400s on the `reasoning_effort` field our adapter ships by default for
+  // its gpt-oss companions. Reachable via direct OPENCUES.md edit; the
+  // classifier just doesn't surface it.
   envKeyName: 'GROQ_API_KEY',
   // gpt-oss-120b at `medium`+`high` overshoots OpenCues' fluid-blank
   // (1500ms) and word-cue (500ms) budgets at Groq's throughput; `low`
@@ -888,8 +912,8 @@ const CEREBRAS: ProviderAdapter = {
  * install), but the field stays in the adapter for shape compatibility.
  */
 const CLAUDE_CLI: ProviderAdapter = {
-  id: 'claude-cli',
-  displayName: 'Claude (CLI, subscription)',
+  id: 'claude-code-cli',
+  displayName: 'Claude Code (CLI, subscription)',
   transport: 'cli',
   defaultEndpoint: '', // unused for CLI transport
   defaultModel: 'haiku', // fastest / cheapest of the supported aliases
@@ -906,10 +930,10 @@ const CLAUDE_CLI: ProviderAdapter = {
     // Never called for transport: 'cli'. Throw if it somehow IS called
     // so the bug surfaces immediately instead of silently producing
     // a malformed HTTP request.
-    throw new Error('claude-cli: buildRequest is not used (transport is cli)');
+    throw new Error('claude-code-cli: buildRequest is not used (transport is cli)');
   },
   parseResponse() {
-    throw new Error('claude-cli: parseResponse is not used (transport is cli)');
+    throw new Error('claude-code-cli: parseResponse is not used (transport is cli)');
   },
   async invokeCli(req) {
     // Extract system + user prompt from the neutral ChatRequest. The
@@ -1209,7 +1233,7 @@ const PROVIDERS: Readonly<Record<ProviderId, ProviderAdapter>> = {
   'openai-subscription': OPENAI_SUBSCRIPTION,
   anthropic: ANTHROPIC,
   cerebras: CEREBRAS,
-  'claude-cli': CLAUDE_CLI,
+  'claude-code-cli': CLAUDE_CLI,
   'opencode-zen': OPENCODE_ZEN,
 };
 
@@ -1268,7 +1292,8 @@ export function pickAutoProvider(apiKeys: Readonly<Record<string, string | undef
  */
 export function getProvider(id: string | undefined | null): ProviderAdapter | null {
   if (!id) return null;
-  const found = PROVIDERS[id as ProviderId];
+  const canonical = (LEGACY_PROVIDER_ALIASES[id] ?? id) as ProviderId;
+  const found = PROVIDERS[canonical];
   if (!found) {
     warnUnknownProviderOnce(id);
     return null;
@@ -1310,7 +1335,7 @@ export function validateEndpoint(
   endpoint: string | undefined | null,
 ): EndpointValidation {
   if (!providerId) return { ok: true, kind: 'default' };
-  const provider = PROVIDERS[providerId as ProviderId];
+  const provider = PROVIDERS[canonicalizeProviderId(providerId) as ProviderId];
   if (!provider) {
     return {
       ok: false,
@@ -1516,10 +1541,10 @@ const FALLBACK_PAIRS: Readonly<Record<ProviderId, ProviderId | undefined>> = {
   'openai-subscription': undefined,
   anthropic: undefined,
   gemini: undefined,
-  // claude-cli is a different transport entirely — no HTTP peer to fall
-  // back to. If the subscription daemon dies, the user picks a different
-  // provider in OPENCUES.md.
-  'claude-cli': undefined,
+  // claude-code-cli is a different transport entirely — no HTTP peer to
+  // fall back to. If the subscription daemon dies, the user picks a
+  // different provider in OPENCUES.md.
+  'claude-code-cli': undefined,
   // opencode-zen has its own pool-walking dispatcher
   // (dispatchWithFreePool); no cross-provider fallback needed.
   'opencode-zen': undefined,
@@ -1654,9 +1679,11 @@ export function resolveLLM(opts: ResolveLLMOptions): ResolvedLLM | null {
   // is suppressed when no tier picked it), so the literal here only
   // matters for "no keys, but we still need to emit a ProviderId".
   const autoPicked = providerTierIdx >= 0 ? null : pickAutoProvider(opts.apiKeys);
-  const providerId = (providerTierIdx >= 0
-    ? tiers[providerTierIdx].p!.trim()
-    : (autoPicked ?? 'cerebras')) as ProviderId;
+  const providerId = canonicalizeProviderId(
+    providerTierIdx >= 0
+      ? tiers[providerTierIdx].p!.trim()
+      : (autoPicked ?? 'cerebras')
+  ) as ProviderId;
   const provider = PROVIDERS[providerId];
   if (!provider) {
     warnUnknownProviderOnce(providerId);

--- a/packages/opencues-core/vitest.config.ts
+++ b/packages/opencues-core/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       'src/feature-registry.test.ts',
       'src/feature-registry-menu.drift.test.ts',
       'src/llm-provider.drift.test.ts',
+      'src/llm-provider.temperature.test.ts',
       'src/conformance.test.ts',
       'src/sources/fluid-blank-error-substitute.test.ts',
     ],

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/config-loader.ts
+++ b/packages/opencues-runtime/src/modules/config-loader.ts
@@ -242,7 +242,7 @@ export const DEFAULT_OPENCUES_STATE: OpenCuesState = {
 const VALID_BUCKET_PROVIDERS = new Set([
   'inherit',
   'groq', 'openrouter', 'gemini', 'openai', 'openai-subscription',
-  'anthropic', 'cerebras', 'claude-cli', 'opencode-zen',
+  'anthropic', 'cerebras', 'claude-code-cli', 'opencode-zen',
 ]);
 
 function bucketProvider(raw: string): string {

--- a/tests/integration/llm-providers-smoke.cjs
+++ b/tests/integration/llm-providers-smoke.cjs
@@ -40,11 +40,12 @@ try {
 const { getProvider } = llm;
 
 // Curated (provider, model) combos to verify. Pulled from each provider's
-// `knownModels:` list. CLI providers are excluded (separate path).
+// `knownModels:` list. CLI providers (claude-code-cli, openai-subscription)
+// are included — they're dispatched via `invokeCli(req, ctx)` instead of
+// fetch(), and `probe()` branches on `transport === 'cli'`.
 const COMBOS = [
   { provider: 'groq',       model: 'openai/gpt-oss-120b' },
   { provider: 'groq',       model: 'openai/gpt-oss-20b' },
-  { provider: 'groq',       model: 'llama-3.3-70b-versatile' },
   { provider: 'cerebras',   model: 'gpt-oss-120b' },
   { provider: 'cerebras',   model: 'zai-glm-4.7' },
   { provider: 'gemini',     model: 'gemini-3.1-flash-lite' },
@@ -61,6 +62,11 @@ const COMBOS = [
   { provider: 'openrouter', model: 'anthropic/claude-haiku-4-5' },
   { provider: 'openrouter', model: 'anthropic/claude-opus-4-7' },
   { provider: 'openrouter', model: 'google/gemini-3.1-flash-lite' },
+  // CLI transports — `invokeCli` path. Skipped automatically when the
+  // backing binary isn't on PATH (the daemon will warn-then-throw).
+  { provider: 'claude-code-cli',     model: 'haiku' },
+  { provider: 'claude-code-cli',     model: 'sonnet' },
+  { provider: 'openai-subscription', model: 'gpt-5.4-mini' },
 ];
 
 if (process.argv.includes('--models')) {
@@ -81,6 +87,26 @@ async function probe({ provider, model }) {
     temperature: 0,
     maxTokens: 16,
   };
+  // CLI transports — invokeCli spawns the backing binary (`claude`,
+  // `codex`) instead of POSTing. Skip with status=skipped if the binary
+  // is missing (the daemon will throw with ENOENT-ish).
+  if (adapter.transport === 'cli') {
+    const started = Date.now();
+    try {
+      const content = await adapter.invokeCli(req, { apiKey: apiKey ?? '', endpoint: '' });
+      const elapsed = Date.now() - started;
+      const trimmed = (content ?? '').trim().slice(0, 80);
+      return { provider, model, status: 'ok', reply: trimmed, ms: elapsed };
+    } catch (err) {
+      const msg = err && err.message ? err.message : String(err);
+      // Heuristic: a missing binary surfaces as ENOENT-ish text; report
+      // as skipped not failed so the smoke summary stays meaningful.
+      if (/ENOENT|not found|command not found|no such file/i.test(msg)) {
+        return { provider, model, status: 'skipped', reason: `CLI binary missing: ${msg.slice(0, 100)}` };
+      }
+      return { provider, model, status: 'failed', reason: msg.slice(0, 240), ms: Date.now() - started };
+    }
+  }
   let built;
   try {
     built = adapter.buildRequest(req, { apiKey: apiKey ?? '', endpoint: adapter.defaultEndpoint });

--- a/tests/integration/llm-providers-smoke.cjs
+++ b/tests/integration/llm-providers-smoke.cjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+'use strict';
+
+// Live smoke for every (provider, model) combination the runtime ships
+// with. Confirms each route ACTUALLY works against the live API with the
+// keys the user has set in their env.
+//
+// Usage:
+//   node tests/integration/llm-providers-smoke.cjs            # run with current env
+//   node tests/integration/llm-providers-smoke.cjs --models   # list known combos
+//
+// Per-provider behaviour:
+//   - HTTP providers (groq/anthropic/gemini/openai/openrouter/cerebras):
+//     POSTs a one-token "say ok" prompt with temperature=0 (the failure
+//     mode the user hit was specifically about temperature). Reports the
+//     full error message on 4xx so we can surface API-level deprecations
+//     before they kill blanks silently in production.
+//   - CLI providers (claude-cli, openai-subscription): skipped unless the
+//     binary is on PATH; reported as `skipped` not `failed` when missing.
+//
+// Why this is shaped as a runnable script rather than a vitest test:
+//   - Uses live network + real API keys; never wants to run in `pnpm test`.
+//   - Output is a human-readable table, not a green/red CI gate.
+//   - The unit tests in `llm-provider.temperature.test.ts` pin the
+//     request-building behaviour; this script verifies the live API still
+//     ACCEPTS those bodies. Different concerns, different runners.
+
+const path = require('node:path');
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const distEntry = path.join(repoRoot, 'packages/opencues-core/dist/llm-provider.js');
+let llm;
+try {
+  llm = require(distEntry);
+} catch (err) {
+  console.error('Could not load', distEntry);
+  console.error('Run `pnpm --filter @opencues/core build` first.');
+  process.exit(2);
+}
+const { getProvider } = llm;
+
+// Curated (provider, model) combos to verify. Pulled from each provider's
+// `knownModels:` list. CLI providers are excluded (separate path).
+const COMBOS = [
+  { provider: 'groq',       model: 'openai/gpt-oss-120b' },
+  { provider: 'groq',       model: 'openai/gpt-oss-20b' },
+  { provider: 'groq',       model: 'llama-3.3-70b-versatile' },
+  { provider: 'cerebras',   model: 'gpt-oss-120b' },
+  { provider: 'cerebras',   model: 'zai-glm-4.7' },
+  { provider: 'gemini',     model: 'gemini-3.1-flash-lite' },
+  { provider: 'gemini',     model: 'gemini-flash-latest' },
+  { provider: 'gemini',     model: 'gemini-pro-latest' },
+  { provider: 'anthropic',  model: 'claude-haiku-4-5-20251001' },
+  { provider: 'anthropic',  model: 'claude-sonnet-4-6' },
+  { provider: 'anthropic',  model: 'claude-opus-4-7' },
+  { provider: 'openai',     model: 'gpt-5.4-mini' },
+  { provider: 'openai',     model: 'gpt-5.4' },
+  { provider: 'openai',     model: 'gpt-5.4-nano' },
+  { provider: 'openrouter', model: 'openai/gpt-oss-120b:free' },
+  { provider: 'openrouter', model: 'openai/gpt-oss-120b' },
+  { provider: 'openrouter', model: 'anthropic/claude-haiku-4-5' },
+  { provider: 'openrouter', model: 'anthropic/claude-opus-4-7' },
+  { provider: 'openrouter', model: 'google/gemini-3.1-flash-lite' },
+];
+
+if (process.argv.includes('--models')) {
+  for (const { provider, model } of COMBOS) console.log(`${provider.padEnd(11)} ${model}`);
+  process.exit(0);
+}
+
+async function probe({ provider, model }) {
+  const adapter = getProvider(provider);
+  if (!adapter) return { provider, model, status: 'skipped', reason: 'unknown provider id' };
+  const apiKey = adapter.envKeyName ? process.env[adapter.envKeyName] : null;
+  if (adapter.envKeyName && !apiKey) {
+    return { provider, model, status: 'skipped', reason: `${adapter.envKeyName} not set` };
+  }
+  const req = {
+    model,
+    messages: [{ role: 'user', content: 'Reply with just the word OK and nothing else.' }],
+    temperature: 0,
+    maxTokens: 16,
+  };
+  let built;
+  try {
+    built = adapter.buildRequest(req, { apiKey: apiKey ?? '', endpoint: adapter.defaultEndpoint });
+  } catch (err) {
+    return { provider, model, status: 'failed', reason: `buildRequest threw: ${err.message}` };
+  }
+  const started = Date.now();
+  try {
+    const res = await fetch(built.url, { method: 'POST', headers: built.headers, body: built.body });
+    const elapsed = Date.now() - started;
+    const text = await res.text();
+    if (!res.ok) {
+      // Surface the API error verbatim — this is the whole point of the smoke.
+      return { provider, model, status: 'failed', reason: `HTTP ${res.status}: ${text.slice(0, 240)}`, ms: elapsed };
+    }
+    let content = '';
+    try { content = adapter.parseResponse(text); } catch (err) {
+      return { provider, model, status: 'failed', reason: `parseResponse threw: ${err.message}`, ms: elapsed };
+    }
+    const trimmed = content.trim().slice(0, 80);
+    return { provider, model, status: 'ok', reply: trimmed, ms: elapsed };
+  } catch (err) {
+    return { provider, model, status: 'failed', reason: `network: ${err.message}`, ms: Date.now() - started };
+  }
+}
+
+(async () => {
+  const results = [];
+  for (const combo of COMBOS) {
+    process.stdout.write(`▸ ${combo.provider.padEnd(11)} ${combo.model.padEnd(38)} `);
+    const r = await probe(combo);
+    results.push(r);
+    const tag = r.status === 'ok' ? '✓' : r.status === 'skipped' ? '·' : '✗';
+    const detail = r.status === 'ok' ? `(${r.ms}ms) "${r.reply}"`
+                 : r.status === 'skipped' ? `(skipped — ${r.reason})`
+                 : `(${r.reason})`;
+    console.log(`${tag} ${detail}`);
+  }
+  const pass = results.filter((r) => r.status === 'ok').length;
+  const fail = results.filter((r) => r.status === 'failed').length;
+  const skip = results.filter((r) => r.status === 'skipped').length;
+  console.log(`\n${pass} ok · ${fail} failed · ${skip} skipped (of ${results.length})`);
+  process.exit(fail === 0 ? 0 : 1);
+})();


### PR DESCRIPTION
## What started this

You reported \`draft email _\` in claude-cues producing nothing — doctor reported healthy, OPENCUES.md was correctly configured. Log trace caught the real failure:

\`\`\`
[cc][info] FluidBlank: failed (216ms, llm=anthropic/claude-opus-4-7) — 
  anthropic error: \`temperature\` is deprecated for this model.
\`\`\`

Every blank routing through \`blanks-llm-provider: anthropic\` was silently dying in the LLM call. Doctor checks **bundle freshness**, not **LLM compatibility** — so an upstream API deprecation slipped past every existing safeguard.

## Live smoke runner verified every shipped combo

Built [\`tests/integration/llm-providers-smoke.cjs\`](tests/integration/llm-providers-smoke.cjs) — pings every (provider, model) combo with a minimal prompt against real API keys.

**First run caught 4 failures in 20 combos:**

| Combo | Failure |
|---|---|
| ✗ anthropic + claude-opus-4-7 | \`temperature\` deprecated |
| ✗ openrouter + anthropic/claude-opus-4-7 | same (passthrough) |
| ✗ groq + llama-3.3-70b-versatile | HTTP 400: \`reasoning_effort\` not supported |
| ✗ cerebras + qwen-3-235b-a22b-instruct-2507 | HTTP 404: model_not_found |
| ✗ gemini + gemini-3.1-flash | HTTP 404 |
| ✗ gemini + gemini-3.1-pro | HTTP 404 |

**After this PR: 19/19 ok** (qwen removed entirely — Cerebras's \`/v1/models\` no longer returns it against a live key).

## Fixes

- **Anthropic Claude 4.x rejects \`temperature\`**. New \`modelRejectsTemperature(provider, model)\` predicate. Consulted by the Anthropic adapter inline AND by the shared \`buildOpenAIBody\` so OpenRouter passthrough to \`anthropic/claude-*\` is covered too.
- **Groq llama-* rejects \`reasoning_effort\`**. Parallel \`modelRejectsReasoningEffort\` predicate. gpt-oss companions (which *require* the field) keep getting it.
- **Cerebras**: removed \`qwen-3-235b-a22b-instruct-2507\`. \`/v1/models\` against a live key returns only \`gpt-oss-120b\` + \`zai-glm-4.7\`.
- **Gemini**: replaced \`gemini-3.1-flash\` + \`gemini-3.1-pro\` (both 404) with \`gemini-flash-latest\` + \`gemini-pro-latest\` rolling aliases — Google's current way of pinning "current Gemini 3.x family".

Capability matrix lives in two registry consts in \`llm-provider.ts\`. Adding a future deprecation is a one-line append; no adapter edits needed.

## Test plan

- [x] \`pnpm --filter @opencues/core exec vitest run src/llm-provider.temperature.test.ts\` → 24 unit pins green (predicates + Anthropic inline body + Groq/OpenRouter shared body)
- [x] \`pnpm --filter @opencues/core test\` → 141 passing
- [x] \`pnpm --filter @opencues/runtime test\` → 1544 passing  
- [x] \`node tests/integration/llm-providers-smoke.cjs\` → **19/19 ok** against live keys
- [x] \`bash scripts/lint-version-bump.sh\` clean (\`@opencues/core\` 0.1.7 → 0.1.8)
- [x] \`bash scripts/lint-shell-portability.sh\` clean

## After merge, to verify \`draft email _\` works

\`\`\`bash
git pull
opencues run claude-code    # self-heal rebuilds runtime bundle with the fix
\`\`\`

Then type \`draft email _\` — should fire TransformBlank/FluidBlank against anthropic and produce text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)