### PR TITLE
fix(chrome): forward bare `_` keystroke in normal-input mode

### DIFF
--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -2632,11 +2632,16 @@ function installKeyListener(): void {
     // Normal `<input>` / `<textarea>` mode has no painted cues / cycling
     // band / navigation overlay, so the runtime's key dispatch has
     // nothing to act on (cycling would mutate text invisibly — worse
-    // than no-op). Let browser-default key behavior pass through.
-    if (isNormalInput(target)) return;
+    // than no-op). Let browser-default key behavior pass through —
+    // EXCEPT a bare `_` keypress, which the resolver's explicit-`_`
+    // gate (runtime PR #52) requires to arm blank dispatch. Without
+    // this carve-out every blank silently no-ops in normal-input mode.
+    const normalInput = isNormalInput(target);
+    const isBareUnderscore = e.key === '_' && !e.ctrlKey && !e.altKey && !e.metaKey;
+    if (normalInput && !isBareUnderscore) return;
     const active = document.activeElement;
     if (active !== target && !target.contains(active)) return;
-    const text = walkPlainText(target).text;
+    const text = readTargetText(target);
     const cursor = readCursorOffset();
     const ev: KeyEvent = {
       key: normaliseKey(e.key),


### PR DESCRIPTION
## Summary

- PR #52 made the `_` keystroke load-bearing for blank dispatch (resolver's explicit-`_` gate, fixing the cursor-split bug). Chrome's normal-input key path early-returned for every `<input>`/`<textarea>` keydown, so the gate was never armed and every blank silently no-op'd in `<input>`/`<textarea>`. Contenteditable kept working because that branch reached `dispatchKey`.
- Carve-out: a bare `_` keypress (no ctrl/alt/meta) now dispatches through even in normal-input mode; other keys still skip — there's no cycling/navigation overlay for them to act on.
- Also switched the key path's text read from `walkPlainText` to `readTargetText` so the runtime sees `target.value` for normal inputs (the prior path returned empty for them).

## Why it ever worked

Pre-#52 blank dispatch was purely buffer-state driven (`Resolver.onTextChange` scanned for standalone `_` after every text change). Normal-input blanks reached the resolver via chrome's `input`-event → `notifyTextChange` path and worked fine without any key forwarding. PR #52 shifted the contract from buffer-scan to key-armed without updating chrome's normal-input key path, hence the silent regression.

## Test plan

- [ ] `cd integrations/chrome && npm run build` — succeeds; bundle contains `isBareUnderscore`.
- [ ] Sync `dist/` + `manifest.json` to `/mnt/c/Users/wilfred/AppData/Local/opencues-chrome/`, reload extension, hard-refresh.
- [ ] In a plain `<textarea>` / `<input>`: type `weather _` → fluid-blank fires (regression fix).
- [ ] In a plain `<textarea>` / `<input>`: type `monologue_` → split to `monologue _` → blank does NOT fire (the cursor-split bug PR #52 fixed stays fixed).
- [ ] In a contenteditable (Gmail / claude.ai): existing blanks still fire (no regression in the path that was already working).
- [ ] Arrow / Ctrl+Alt+arrow in normal-input still pass through to browser default (no invisible mutations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)