### PR TITLE
fix(runtime): fluid + transform blank cycle order, plus multi-word span fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fixed — fluid-blank chain extension now survives a multi-word first answer
+
+Pre-existing regression surfaced by live-testing the scroll-order fix below. Fluid-blank stored its DynDef `spanEnd` as the END OF THE FIRST WORD of the substitution (`newSpanEnd = newWord.end` in `resolver.ts:1235`). For a single-word answer that happened to be correct; for a multi-word answer like `William Shakespeare` inserted at char 0, `spanEnd` landed at 7 (end of `William`) instead of 19 (end of `Shakespeare`). The next substitute's chain verbatim check (`liveText.slice(spanStart, spanEnd) === currentAlt`) then compared `"William "` against `"William Shakespeare"` and bailed, dropping the first link from the chain — a 3-step lookup chain ended up only 2 links deep, with the original prompt + first answer silently missing from the walk-back history.
+
+Fix: set `newSpanEnd = start + answer.length` (the FULL substituted range) in `resolver.ts:1235`. New scenario test at `blank-chain.scenarios.test.ts` pins the case explicitly.
+
+Version bumped: `@opencues/runtime` 0.1.17 → 0.1.18.
+
+### Fixed — fluid-blank AND transform-blank cycle order now match every other blank type ([#61](https://github.com/opencues/opencues/issues/61))
+
+Cycling through a fluid-blank chain (`translate to japanese _` → `… translate to chinese _`) or a transform-blank chain (`draft email _` → continue → another transform) moved in the opposite direction from list-blanks / selector-satellite / sentence-cues. After the first substitution the buffer showed the answer (`こんにちは`); the DynDef stored `[question, answer]` with `currentIndex: 1`, so pressing Up (+1) wrapped from the end of the array straight to the oldest question instead of stepping back one item. With a chain `[q1, a1, q2, a2]` at `currentIndex=3`, Up jumped all the way to `q1` while Down only walked to `q2` — opposite of every other blank where `alts[0]` is the current visible and Up advances through `alts[1..]` one entry at a time.
+
+The bug structurally affected both LLM-blank chain pipelines (`fluid-blank` and `transform-blank`) because they share the same `[oldest, …, newest]` chronological layout with `currentIndex` pointing at the tail. The initial PR only fixed fluid-blank per the narrow issue title; manual testing in CC surfaced that `draft email _` (transform-blank) had identical broken cycling, so the fix was extended to transform-blank.
+
+Fix: store both fluid-blank AND transform-blank alternatives in reverse-chronological order — `[newestAnswer, newestQuestion, …priorItems]` with `currentIndex: 0`. Up now walks backward through history one entry at a time (newest answer → newest question → prior answer → original prompt), matching the convention list-blanks and sentence-cues already use. Chain truncate-on-branch flipped accordingly for both pipelines: drop the items NEWER than where the user cycled to (the indices BELOW `currentIndex` in the new layout) before prepending the next substitution. Tests at `packages/opencues-runtime/src/modules/blank-chain.scenarios.test.ts` and `transform-blank.scenarios.test.ts` updated for the new shape.
+
+Version bumped: `@opencues/runtime` 0.1.15 → 0.1.17.
+
 ### Fixed — Claude Code: second `_` in a chain silently dropped (ZWS leaks into KeyEvent)
 
 CC-only regression after [#52](https://github.com/opencues/opencues/pull/52). Chaining `_` triggers (`draft email _` → `… translate to japanese _`) worked on OpenCode but failed on Claude Code: the second transform never fired, the `_` just sat in the buffer. Root cause: the CC adapter's `dispatchKey` passed `iz.text` straight into `normaliseKeyEvent` (`packages/opencues-runtime/adapters/cc/v2.1/boot.ts:708-727`) without stripping the render-kick `\u200B`/`\u200C` marker that `__oc_pushHostText` toggles to defeat React's string-equality bail. Resolver's `onUnderscoreKey` (added by #52) simulates the standalone-`_` check via `splitWords`, which matches `\S+`; the ZWS is non-whitespace, so it glues to the cursor word — the trailing `_` is no longer detected as standalone, the one-shot gate refuses to arm, and `onTextChange` falls through to the debounced path with `allowBlanks=false`, masking the blank source. OC isn't affected because it doesn't render-kick.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.1.15",
+  "version": "0.1.18",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/blank-chain.scenarios.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-chain.scenarios.test.ts
@@ -7,8 +7,12 @@
  *   2. FluidBlank/TransformBlank fires → buffer becomes "こんにちは世界"
  *   3. User appends " translate to chinese _"
  *   4. Same pipeline fires → buffer becomes "你好世界"
- *   5. Pressing Down should walk: 你好世界 → "こんにちは世界 translate to
- *      chinese _" → こんにちは世界 → "hello world translate to japanese _"
+ *   5. For fluid-blank, pressing Up should walk back through history
+ *      one step at a time (reverse-chronological — newest first):
+ *      你好世界 → "こんにちは世界 translate to chinese _" → こんにちは世界
+ *      → "hello world translate to japanese _". Matches the convention
+ *      every other blank type uses (alts[0] = baseline, alts[1+] =
+ *      forward-cycle targets).
  *
  * Before this feature, step 4 clobbered the def from step 2 — the
  * japanese waypoint and the original english prompt were both lost.
@@ -110,7 +114,7 @@ function transformWhole(currentText: string, rewritten: string): ScriptedResult 
 }
 
 describe('fluid-blank chain — sequential WIPE substitutions', () => {
-  it('captures the user\'s question as alternatives[0] (not just "_")', async () => {
+  it('captures the user\'s question alongside the answer (reverse-chronological)', async () => {
     const { adapter, dynDefs, resolver, scriptNext } = setupChainScenario(
       'translate hello to japanese _',
     );
@@ -120,10 +124,13 @@ describe('fluid-blank chain — sequential WIPE substitutions', () => {
     expect(adapter.getText()).toBe('こんにちは');
     const def = findFluidBlankDef(dynDefs);
     expect(def).toBeDefined();
-    // Down-arrow target = the prompt the user typed, not a bare "_".
-    expect(def!.alternatives[0]).toBe('translate hello to japanese _');
-    expect(def!.alternatives[1]).toBe('こんにちは');
-    expect(def!.currentIndex).toBe(1);
+    // alts[0] = current visible (the answer); alts[1] = the prompt the
+    // user typed. Up-arrow advances to alts[1] (revert to prompt). This
+    // matches the convention every other blank type uses: alts[0] =
+    // baseline, alts[1+] = forward-cycle targets.
+    expect(def!.alternatives[0]).toBe('こんにちは');
+    expect(def!.alternatives[1]).toBe('translate hello to japanese _');
+    expect(def!.currentIndex).toBe(0);
   });
 
   it('extends the chain when a second WIPE encompasses the first result', async () => {
@@ -141,15 +148,16 @@ describe('fluid-blank chain — sequential WIPE substitutions', () => {
     expect(adapter.getText()).toBe('你好');
     const def = findFluidBlankDef(dynDefs);
     expect(def).toBeDefined();
-    // Chain depth 4: [original english prompt, japanese result,
-    //                 mid-chain question, chinese result]
+    // Chain depth 4, reverse-chronological — newest at index 0 so
+    // pressing Up walks back through history one step at a time:
+    //   [newest answer, newest question, prior answer, original prompt]
     expect(def!.alternatives).toEqual([
-      'translate hello to japanese _',
-      'こんにちは',
-      'こんにちは translate to chinese _',
       '你好',
+      'こんにちは translate to chinese _',
+      'こんにちは',
+      'translate hello to japanese _',
     ]);
-    expect(def!.currentIndex).toBe(3);
+    expect(def!.currentIndex).toBe(0);
   });
 
   it('does NOT extend when the prior result was edited inside (verbatim check fails)', async () => {
@@ -168,12 +176,13 @@ describe('fluid-blank chain — sequential WIPE substitutions', () => {
 
     const def = findFluidBlankDef(dynDefs);
     expect(def).toBeDefined();
-    // Fresh def — no japanese in the chain.
+    // Fresh def — no japanese in the chain. Reverse-chronological:
+    // answer first, question second.
     expect(def!.alternatives).toEqual([
-      'hola translate to chinese _',
       '你好',
+      'hola translate to chinese _',
     ]);
-    expect(def!.currentIndex).toBe(1);
+    expect(def!.currentIndex).toBe(0);
   });
 
   it('truncates the abandoned tail when the user cycled mid-chain before re-summoning', async () => {
@@ -187,13 +196,14 @@ describe('fluid-blank chain — sequential WIPE substitutions', () => {
     scriptNext([fluidWipe('こんにちは translate to chinese _', '你好')]);
     await resolver.resolveAndApply(adapter.getText());
 
-    // User cycles back to "こんにちは" (currentIndex 1) then re-summons.
+    // User cycles Up twice to land on "こんにちは" (index 2 in the new
+    // reverse-chronological ['你好', q2, 'こんにちは', q1]) then re-summons.
     const def = findFluidBlankDef(dynDefs);
     expect(def).toBeDefined();
     // Simulate the cycled state — production code does this via applyAltCycle,
     // but we set it directly to keep the test focused on truncate semantics.
     rewriteDef(dynDefs, def!, {
-      currentIndex: 1,
+      currentIndex: 2,
       spanStart: 0,
       spanEnd: 'こんにちは'.length,
     });
@@ -203,15 +213,56 @@ describe('fluid-blank chain — sequential WIPE substitutions', () => {
 
     const finalDef = findFluidBlankDef(dynDefs);
     expect(finalDef).toBeDefined();
-    // Tail "[こんにちは translate to chinese _, 你好]" was discarded;
-    // new branch "[こんにちは translate to korean _, 안녕하세요]" took its place.
+    // Abandoned head ["你好", "こんにちは translate to chinese _"] (items
+    // newer than where the user cycled to) was discarded; the new branch
+    // ["안녕하세요", "こんにちは translate to korean _"] is prepended.
     expect(finalDef!.alternatives).toEqual([
-      'translate hello to japanese _',
-      'こんにちは',
-      'こんにちは translate to korean _',
       '안녕하세요',
+      'こんにちは translate to korean _',
+      'こんにちは',
+      'translate hello to japanese _',
     ]);
-    expect(finalDef!.currentIndex).toBe(3);
+    expect(finalDef!.currentIndex).toBe(0);
+  });
+
+  it('chains across a multi-word answer (spanEnd covers the WHOLE answer, not just the first word)', async () => {
+    // Pre-fix regression: fluid-blank set spanEnd to the END OF THE
+    // FIRST WORD of the substitute. For a single-word answer that
+    // happens to be correct; for a multi-word answer like "William
+    // Shakespeare" at start=0, spanEnd was 7 (end of "William") rather
+    // than 19 (end of "Shakespeare"). The next substitute's chain
+    // verbatim check (`liveText.slice(spanStart, spanEnd) === currentAlt`)
+    // then compared "William " against "William Shakespeare" and bailed,
+    // dropping the first link from the chain.
+    const { adapter, dynDefs, resolver, scriptNext } = setupChainScenario(
+      'who wrote hamlet _',
+    );
+    scriptNext([fluidWipe('who wrote hamlet _', 'William Shakespeare')]);
+    await resolver.resolveAndApply(adapter.getText());
+    expect(adapter.getText()).toBe('William Shakespeare');
+
+    const firstDef = findFluidBlankDef(dynDefs);
+    expect(firstDef).toBeDefined();
+    // spanEnd MUST cover the whole "William Shakespeare" answer.
+    expect(firstDef!.spanStart).toBe(0);
+    expect(firstDef!.spanEnd).toBe('William Shakespeare'.length);
+
+    // Second substitute wraps the answer in a new lookup phrase. With the
+    // bug, this would create a FRESH def (chain broken); with the fix,
+    // the chain extends.
+    adapter.pushText('William Shakespeare year of birth _');
+    scriptNext([fluidWipe('William Shakespeare year of birth _', '1564')]);
+    await resolver.resolveAndApply(adapter.getText());
+
+    const def = findFluidBlankDef(dynDefs);
+    expect(def).toBeDefined();
+    expect(def!.alternatives).toEqual([
+      '1564',
+      'William Shakespeare year of birth _',
+      'William Shakespeare',
+      'who wrote hamlet _',
+    ]);
+    expect(def!.currentIndex).toBe(0);
   });
 });
 
@@ -231,13 +282,16 @@ describe('transform-blank chain — sequential whole-buffer rewrites', () => {
 
     const def = findTransformBlankDef(dynDefs);
     expect(def).toBeDefined();
+    // Reverse-chronological — newest at index 0 so pressing Up walks
+    // back through history one step at a time. Matches fluid-blank
+    // and every other blank type (alts[0] = current visible).
     expect(def!.alternatives).toEqual([
-      'translate hello to japanese _',
-      'こんにちは',
-      'こんにちは translate to chinese _',
       '你好',
+      'こんにちは translate to chinese _',
+      'こんにちは',
+      'translate hello to japanese _',
     ]);
-    expect(def!.currentIndex).toBe(3);
+    expect(def!.currentIndex).toBe(0);
   });
 
   it('does NOT graft a fluid-blank onto a transform-blank chain', async () => {
@@ -252,14 +306,15 @@ describe('transform-blank chain — sequential whole-buffer rewrites', () => {
     await resolver.resolveAndApply(adapter.getText());
 
     // Two independent defs: one transform-blank (japanese chain), one
-    // fresh fluid-blank (chinese substitute). The fluid-blank's alts[0]
-    // = the question; alts[1] = 你好 — no japanese leaked in.
+    // fresh fluid-blank (chinese substitute). The fluid-blank def is
+    // reverse-chronological — alts[0] = answer, alts[1] = question —
+    // no japanese leaked in.
     const transformDef = findTransformBlankDef(dynDefs);
     const fluidDef = findFluidBlankDef(dynDefs);
     expect(fluidDef).toBeDefined();
     expect(fluidDef!.alternatives).toEqual([
-      'こんにちは translate to chinese _',
       '你好',
+      'こんにちは translate to chinese _',
     ]);
     // The transform-blank def may have been pruned (its span [0, 'こんにちは'.length)
     // overlaps the fluid-blank wipe range). What we care about: NO chain merge.

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -1232,7 +1232,15 @@ export class Resolver {
         const newWords = splitWords(newText);
         const newWord = newWords.find(w => w.start === start);
         const newWordIndex = newWord ? newWord.index : r.wordIndex;
-        const newSpanEnd = newWord ? newWord.end : sub.newCursor;
+        // spanEnd must cover the FULL substituted range, not just the
+        // first word's end. For a multi-word answer like "William
+        // Shakespeare" spliced at start=0, the substituted text occupies
+        // [0, answer.length); using newWord.end here would give 7
+        // (end of "William"), and the chain-extension verbatim check
+        // (`liveText.slice(spanStart, spanEnd) === currentAlt`) would
+        // fail on the next substitute because the slice excludes
+        // "Shakespeare". Pinned by `fluid-blank-multiword-span.test.ts`.
+        const newSpanEnd = start + answer.length;
 
         // The "question" — the buffer slice we're replacing. For WIPE
         // mode this is the user's full prompt phrase (e.g. "translate
@@ -1245,22 +1253,25 @@ export class Resolver {
         // new span and is still verbatim at its recorded position, the
         // user is doing a sequence of substitutions on the same content
         // (translate to japanese → translate to chinese). Extend the
-        // existing alternatives with [question, answer] so Down walks
-        // back through the full chain. Truncate-on-branch: if the user
-        // cycled back mid-chain before re-summoning, discard the
-        // abandoned tail (alt-history equivalent of git branch).
+        // existing alternatives in REVERSE chronological order — newest
+        // at index 0 — so Up walks back through history one step at a
+        // time (matching the convention every other blank type uses:
+        // alts[0] = current, Up = +1 = next in cycle).
+        // Truncate-on-branch: if the user cycled back mid-chain before
+        // re-summoning, discard the abandoned tail (now the items at
+        // indices BELOW currentIndex — newer than where the user landed).
         const existingChain = this.dynDefs.findChainableLlmDef(
           text, start, end, ['fluid-blank'],
         );
         let fluidDef: WordDef;
         if (existingChain) {
           const baseAlts = existingChain.def.alternatives
-            .slice(0, existingChain.def.currentIndex + 1);
-          const chainedAlts = [...baseAlts, question, alts[0]];
+            .slice(existingChain.def.currentIndex);
+          const chainedAlts = [alts[0], question, ...baseAlts];
           fluidDef = {
             originalWord: existingChain.def.originalWord,
             alternatives: chainedAlts,
-            currentIndex: chainedAlts.length - 1,
+            currentIndex: 0,
             spanStart: start,
             spanEnd: newSpanEnd,
             blankName: 'fluid-blank',
@@ -1272,8 +1283,8 @@ export class Resolver {
         } else {
           fluidDef = {
             originalWord: question,
-            alternatives: [question, alts[0]],
-            currentIndex: 1,
+            alternatives: [alts[0], question],
+            currentIndex: 0,
             spanStart: start,
             spanEnd: newSpanEnd,
             // blankName locks this def against re-resolution by the LLM —
@@ -1699,11 +1710,14 @@ export class Resolver {
         // is still verbatim inside the pre-substitute buffer, the user
         // is doing a sequence of rewrites on the same content
         // (translate to japanese → translate to chinese). Extend the
-        // existing chain with [pre-substitute-buffer, post-substitute-
-        // buffer] so Down walks back through every rewrite waypoint
-        // AND the user's prompt-additions between them.
-        // Truncate-on-branch: if the user cycled mid-chain before
-        // re-summoning, discard the abandoned tail.
+        // existing chain in REVERSE chronological order — newest at
+        // index 0 — so Up walks back through history one step at a
+        // time (matching the convention every other blank type uses:
+        // alts[0] = current visible, Up = +1 = next in cycle).
+        // Truncate-on-branch: if the user cycled back mid-chain before
+        // re-summoning, discard the abandoned head (items NEWER than
+        // where the user landed — indices BELOW currentIndex in the
+        // new reverse-chronological layout).
         const existingChain = this.dynDefs.findChainableLlmDef(
           originalText, 0, originalText.length, ['transform-blank'],
         );
@@ -1711,12 +1725,12 @@ export class Resolver {
         let extendedFromIdx: number | null = null;
         if (existingChain) {
           const baseAlts = existingChain.def.alternatives
-            .slice(0, existingChain.def.currentIndex + 1);
-          const chainedAlts = [...baseAlts, originalText, bufferText];
+            .slice(existingChain.def.currentIndex);
+          const chainedAlts = [bufferText, originalText, ...baseAlts];
           transformDef = {
             originalWord: existingChain.def.originalWord,
             alternatives: chainedAlts,
-            currentIndex: chainedAlts.length - 1,
+            currentIndex: 0,
             spanStart: 0,
             spanEnd: newSpanEnd,
             blankName: 'transform-blank',
@@ -1729,10 +1743,10 @@ export class Resolver {
         } else {
           transformDef = {
             originalWord: originalText,
-            // alternatives[0] = original full text (cycle Down to revert)
-            // alternatives[1] = the post-substitution buffer (cycle Up returns here)
-            alternatives: [originalText, bufferText],
-            currentIndex: 1,            // showing rewrite
+            // alternatives[0] = the post-substitution buffer (current visible)
+            // alternatives[1] = original full text (cycle Up to revert)
+            alternatives: [bufferText, originalText],
+            currentIndex: 0,
             spanStart: 0,
             spanEnd: newSpanEnd,
             // blankName locks this def from re-resolution by the LLM —

--- a/packages/opencues-runtime/src/modules/transform-blank.scenarios.test.ts
+++ b/packages/opencues-runtime/src/modules/transform-blank.scenarios.test.ts
@@ -520,7 +520,7 @@ describe('TransformBlank surgical splice — cursor lands at end of new buffer',
 });
 
 describe('TransformBlank surgical splice — DynDef shape', () => {
-  it('alternatives[0] = original, alternatives[1] = final buffer (round-trip via cycle)', async () => {
+  it('alternatives[0] = final buffer, alternatives[1] = original (reverse-chronological)', async () => {
     const { adapter, resolver, dynDefs } = setupTransformScenario({
       originalText: 'hi my name is wilfred\n\nmake wilfred bold _',
       rewrittenText: 'hi my name is **wilfred**',
@@ -530,9 +530,13 @@ describe('TransformBlank surgical splice — DynDef shape', () => {
     await resolver.resolveAndApply(adapter.getText());
     expect(dynDefs.size).toBe(1);
     const def = [...dynDefs.entries()][0]?.[1];
-    expect(def!.alternatives[0]).toBe('hi my name is wilfred\n\nmake wilfred bold _');
-    expect(def!.alternatives[1]).toBe('hi my name is wilfred\n\n');
-    expect(def!.currentIndex).toBe(1);
+    // alts[0] = the post-substitution buffer (current visible).
+    // alts[1] = the original prompt (cycle Up reverts). Matches
+    // fluid-blank and every other blank type — alts[0] is the
+    // current visible, alts[1+] are forward-cycle targets.
+    expect(def!.alternatives[0]).toBe('hi my name is wilfred\n\n');
+    expect(def!.alternatives[1]).toBe('hi my name is wilfred\n\nmake wilfred bold _');
+    expect(def!.currentIndex).toBe(0);
     expect(def!.blankName).toBe('transform-blank');
   });
 });


### PR DESCRIPTION
## Summary

Fixes [#61](https://github.com/opencues/opencues/issues/61): fluid-blank scroll order inverted relative to every other blank type. Also fixes a pre-existing chain-extension bug surfaced by live-testing.

- **Reverse-chronological array shape** for both fluid-blank AND transform-blank chains. `alts[0]` = current visible, `alts[1+]` = older history. Pressing Ctrl+Alt+Up now walks back through history one step at a time instead of wrap-jumping to the oldest entry.
- **`spanEnd` covers the full substituted range** (`start + answer.length`) — previously only the first word's end, which broke the chain verbatim check for multi-word answers.

## Root cause framing

The cycling engine treats Up as "advance forward through `alternatives`". It doesn't and shouldn't know about source types. Each source declares its cycling semantic by choosing its array order:

- **Menu sources** (list blanks, word cues, sentence cues): `[current, opt1, opt2, …]` — Up rotates through curated options.
- **History sources** (fluid, transform): need `[newestState, priorState, …, oldest]` — Up steps back in time.

Both shapes satisfy the same structural rule (`alts[0]` = current visible). Before this fix, history sources were declaring chronological order with `currentIndex` at the tail, so the engine's forward wrap landed on the oldest entry. No engine changes — just the sources telling the truth about their cycling order.

## Discovered bug (multi-word span)

While live-testing the chain via the agentic harness, a 3-step lookup chain only produced 4 entries instead of 6. The first link kept getting dropped on the next substitute because fluid-blank's `spanEnd` was the END OF THE FIRST WORD (`newWord.end`) of the substitute. For a multi-word answer like `William Shakespeare` at `start=0`, `spanEnd` landed at 7 (end of `William`) instead of 19 (end of `Shakespeare`). The chain verbatim check then compared `"William "` against `"William Shakespeare"` and bailed. Fix is one-liner: `newSpanEnd = start + answer.length`.

## Verification

- **Unit**: 1548/1548 passing. New regression test (`blank-chain.scenarios.test.ts` § "chains across a multi-word answer") pins the multi-word span case explicitly.
- **Live (agentic harness, OpenCode 0.1.18)**: 3-step fluid-blank chain (`who wrote hamlet _` → `… what year was he born _` → `… which country _`) produces 6 reverse-chronological entries; all 17 walk-back assertions pass. Up steps back one waypoint at a time (newest answer → newest prompt → mid answer → mid prompt → oldest answer → original prompt → wraps).

## Test plan

- [x] `pnpm --filter @opencues/runtime test` — 1548/1548 ✓
- [x] `bash scripts/pre-pr.sh` — all 7 gates green
- [x] Live: 3-step chain via `tests/agentic/scenarios-ts/fluid-blank-3-chain.ts` — 17/17 ✓
- [x] Live: single-substitution scroll order via fluid-blank-scroll-order.ts + transform-blank-scroll-order.ts ✓
- [x] All forks redeployed to runtime 0.1.18

## Version

`@opencues/runtime` 0.1.15 → 0.1.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)