### PR TITLE
fix(chrome): align manifest.json version with package.json (0.1.1 → 0.1.4)

### DIFF
--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": ["storage", "activeTab", "nativeMessaging"],
   "host_permissions": [


### PR DESCRIPTION
## Summary
- chrome://extensions panel was showing v0.1.1 while `package.json` had advanced to 0.1.4
- `chrome.runtime.getManifest().version` (which the popup banner also reads) is sourced from `manifest.json`, not `package.json`
- Three package bumps (0.1.2 → 0.1.3 → 0.1.4) landed without a matching manifest update

## Other integrations checked
All other integration `package.json` versions have no second source-of-truth file to drift against:
- claude-code 0.1.3, gemini-cli 0.1.1, opencode 0.1.3, shell 0.1.4 — single version field each
- chrome was the only host with a second declared version (manifest)

## Test plan
- [ ] Reload extension at chrome://extensions and confirm panel shows v0.1.4
- [ ] Open the popup and confirm the banner shows `v0.1.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)