### PR TITLE
fix(chrome): pierce shadow-DOM focus retargeting (Reddit attach broken)

### DIFF
--- a/integrations/chrome/CLAUDE.md
+++ b/integrations/chrome/CLAUDE.md
@@ -89,6 +89,19 @@ The branch is an `isNormalInput(el)` check at the top of every
 read/write helper in `opencues-bootstrap.ts`. Full spec + supported
 blank subset + caveats live in `docs/features/chrome-normal-inputs.md`.
 
+**Shadow-DOM focus piercing (June 2026)** — when the focused
+contenteditable is slotted into (or lives inside) a shadow root with
+`delegatesFocus: true`, the browser retargets `focusin.target` and
+`document.activeElement` to the shadow HOST (a custom element). The
+host fails `isTextInput()` and silent no-attach is the result. Canonical
+case: Reddit's `<shreddit-composer>` → `<reddit-rte
+shadowrootdelegatesfocus>`. Resolution lives in `src/shadow-focus.ts` —
+`composedPath()[0]` for event-driven attach (focusin/focusout/keydown),
+recursive `shadowRoot.activeElement` walk for state-driven attach
+(initial document.activeElement, diagnostic ping). Closed shadow roots
+terminate the walk at the host (same dead-end as today, no regression).
+Pinned by `src/shadow-focus.test.ts` (16 tests).
+
 **Sensitive inputs are NEVER attached** — even within normal-input
 mode. `isSensitiveField()` refuses to attach when the focused input
 looks like a password / OTP / payment / PII field (autocomplete

--- a/integrations/chrome/src/content.ts
+++ b/integrations/chrome/src/content.ts
@@ -25,9 +25,23 @@ import {
 import { clearStatusbar } from './runtime-statusbar';
 import { deriveOpenCuesColours } from './derive-colours';
 import { walkPlainText, plainOffsetOfPosition } from './dom-walk';
+import {
+  resolveFocusedFromEvent as _resolveFromEvent,
+  resolveFocusedElement as _resolveFromState,
+} from './shadow-focus';
 
 function isTextInput(el: HTMLElement): boolean {
   return el.isContentEditable || isNormalInput(el);
+}
+
+// Local wrappers — inject the isTextInput predicate into the shared
+// shadow-piercing helpers. Lets the shadow-focus module stay
+// chrome-host-agnostic + unit-testable.
+function resolveFocusedFromEvent(e: Event): HTMLElement | null {
+  return _resolveFromEvent(e, isTextInput);
+}
+function resolveFocusedElement(start: Element | null): HTMLElement | null {
+  return _resolveFromState(start, isTextInput);
 }
 
 // CSS Custom Highlight pseudo-elements don't reliably inherit CSS
@@ -154,7 +168,7 @@ async function init(): Promise<void> {
   };
 
   document.addEventListener('focusin', (e) => {
-    const el = e.target as HTMLElement;
+    const el = resolveFocusedFromEvent(e);
     if (el) attachToFocused(el);
     // Wipe any pending trust-gate credits. A `_` keypress in a
     // different field (e.g. an iframe OpenCues isn't attached to)
@@ -171,7 +185,9 @@ async function init(): Promise<void> {
   // input both count as "left the editor".
   document.addEventListener('focusout', (e) => {
     const evt = e as FocusEvent;
-    const next = evt.relatedTarget as HTMLElement | null;
+    // relatedTarget can be retargeted to a shadow host the same way
+    // focusin's target is — resolve before testing isTextInput.
+    const next = resolveFocusedElement(evt.relatedTarget as Element | null);
     if (!next || !isTextInput(next)) {
       if (currentTarget) {
         if (!isNormalInput(currentTarget)) clearDerivedColours(currentTarget);
@@ -187,9 +203,8 @@ async function init(): Promise<void> {
     }
   });
 
-  if (document.activeElement && document.activeElement instanceof HTMLElement) {
-    attachToFocused(document.activeElement);
-  }
+  const initialActive = resolveFocusedElement(document.activeElement);
+  if (initialActive) attachToFocused(initialActive);
 
   // Re-derive colours when the user toggles OS dark/light mode — host
   // pages that respect prefers-color-scheme will have flipped their
@@ -435,8 +450,10 @@ init();
 // on this tab?" without opening devtools.
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   if (msg?.type !== 'opencues:diagnostic-ping') return;
-  const active = document.activeElement;
-  const activeEl = active instanceof HTMLElement ? active : null;
+  // Shadow-piercing: Self-Check on shadow-DOM sites (Reddit's
+  // <shreddit-composer>, etc.) would otherwise report the wrapper custom
+  // element instead of the real focused contenteditable.
+  const activeEl = resolveFocusedElement(document.activeElement);
   const isCE = !!activeEl && activeEl.isContentEditable === true;
   const isNI = !!activeEl && (activeEl.tagName === 'INPUT' || activeEl.tagName === 'TEXTAREA');
   const activeAttachable = activeEl ? isTextInput(activeEl) : false;

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -2639,8 +2639,16 @@ function installKeyListener(): void {
     const normalInput = isNormalInput(target);
     const isBareUnderscore = e.key === '_' && !e.ctrlKey && !e.altKey && !e.metaKey;
     if (normalInput && !isBareUnderscore) return;
-    const active = document.activeElement;
-    if (active !== target && !target.contains(active)) return;
+    // Shadow-DOM piercing: on web-component editors with
+    // delegatesFocus (Reddit's <shreddit-composer>), document.activeElement
+    // reports the shadow HOST — usually an ANCESTOR of `target` —
+    // and target.contains(host) is false, so every key event silently
+    // no-ops. composedPath()[0] is the actual leaf the event came from
+    // (a Node, possibly Text), which IS inside target.
+    const path = (e as Event).composedPath();
+    const leaf = path.length > 0 ? path[0] as Node : document.activeElement;
+    const inTarget = leaf === target || (leaf instanceof Node && target.contains(leaf));
+    if (!inTarget) return;
     const text = readTargetText(target);
     const cursor = readCursorOffset();
     const ev: KeyEvent = {

--- a/integrations/chrome/src/shadow-focus.test.ts
+++ b/integrations/chrome/src/shadow-focus.test.ts
@@ -1,0 +1,217 @@
+// Pin shadow-DOM focus piercing across the patterns chrome attaches over.
+//
+// Canonical regression: Reddit's <shreddit-composer> nests its
+// contenteditable inside a Lit shadow root with delegatesFocus. Browser
+// retargets document.activeElement + focusin.target to the host. Our
+// isTextInput check fails on the custom-element wrapper and we never
+// attach — silent break for cues AND blanks.
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+import {
+  deepestFocused,
+  resolveFocusedFromEvent,
+  resolveFocusedElement,
+} from './shadow-focus';
+
+let dom: JSDOM;
+
+beforeEach(() => {
+  dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+  // Expose globals the helpers depend on.
+  (globalThis as unknown as { document: Document }).document = dom.window.document;
+  (globalThis as unknown as { HTMLElement: typeof HTMLElement }).HTMLElement = dom.window.HTMLElement;
+  (globalThis as unknown as { Element: typeof Element }).Element = dom.window.Element;
+});
+
+const isCE = (el: HTMLElement) => el.isContentEditable;
+const isInputLike = (el: HTMLElement) =>
+  el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable;
+
+describe('deepestFocused', () => {
+  it('returns the element itself when it already satisfies the leaf predicate', () => {
+    const doc = dom.window.document;
+    const div = doc.createElement('div');
+    div.setAttribute('contenteditable', 'true');
+    doc.body.appendChild(div);
+    expect(deepestFocused(div, isCE)).toBe(div);
+  });
+
+  it('returns the original element when it has no shadow root and is not a leaf', () => {
+    const doc = dom.window.document;
+    const span = doc.createElement('span');
+    doc.body.appendChild(span);
+    // Non-contenteditable span: walk has nowhere to go, fall back to host.
+    expect(deepestFocused(span, isCE)).toBe(span);
+  });
+
+  it('walks open shadow roots to find the focused contenteditable', () => {
+    const doc = dom.window.document;
+    // Mimic <shreddit-composer> structure: custom-element host with
+    // open shadow root containing a focused contenteditable.
+    const host = doc.createElement('shreddit-composer');
+    doc.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const ce = doc.createElement('div');
+    ce.setAttribute('contenteditable', 'true');
+    ce.tabIndex = 0;
+    shadow.appendChild(ce);
+    ce.focus();
+    // After focus(), shadow.activeElement === ce, but document.activeElement
+    // reports the host (the natural delegatesFocus retargeting that this
+    // module exists to undo).
+    expect(deepestFocused(host, isCE)).toBe(ce);
+  });
+
+  it('pierces nested shadow roots (host → host → contenteditable)', () => {
+    const doc = dom.window.document;
+    const outer = doc.createElement('shreddit-composer');
+    doc.body.appendChild(outer);
+    const outerShadow = outer.attachShadow({ mode: 'open' });
+    const inner = doc.createElement('reddit-rte');
+    outerShadow.appendChild(inner);
+    const innerShadow = inner.attachShadow({ mode: 'open' });
+    const ce = doc.createElement('div');
+    ce.setAttribute('contenteditable', 'true');
+    ce.tabIndex = 0;
+    innerShadow.appendChild(ce);
+    ce.focus();
+    expect(deepestFocused(outer, isCE)).toBe(ce);
+  });
+
+  it('terminates at closed shadow roots (returns the host)', () => {
+    const doc = dom.window.document;
+    const host = doc.createElement('locked-widget');
+    doc.body.appendChild(host);
+    // closed: shadow root is created but el.shadowRoot returns null
+    host.attachShadow({ mode: 'closed' });
+    // Closed: same as no shadow — we get back the host the caller passed.
+    expect(deepestFocused(host, isCE)).toBe(host);
+  });
+
+  it('terminates when the inner active element is the same node (no infinite loop)', () => {
+    const doc = dom.window.document;
+    const host = doc.createElement('weird-host');
+    doc.body.appendChild(host);
+    // No shadow attached — shadowRoot is null. Single iteration, return host.
+    expect(deepestFocused(host, isInputLike)).toBe(host);
+  });
+
+  it('is bounded — degrades gracefully under pathological shadow chains', () => {
+    const doc = dom.window.document;
+    // Build a 10-deep chain of nested shadow hosts where each inner
+    // host is the active element of the outer shadow root. The helper
+    // caps at 8 hops; the final node should be reachable from the root.
+    const root = doc.createElement('chain-0');
+    doc.body.appendChild(root);
+    let cur: HTMLElement = root;
+    for (let i = 1; i <= 10; i++) {
+      const shadow = cur.attachShadow({ mode: 'open' });
+      const next = doc.createElement(`chain-${i}`);
+      next.tabIndex = 0;
+      shadow.appendChild(next);
+      next.focus();
+      cur = next;
+    }
+    // 8-hop cap means we don't reach the deepest, but the function
+    // returns a valid node and doesn't loop forever.
+    const result = deepestFocused(root, isCE);
+    expect(result).toBeInstanceOf(dom.window.HTMLElement);
+  });
+});
+
+describe('resolveFocusedFromEvent', () => {
+  it('returns composedPath()[0] when path crosses a shadow boundary', () => {
+    const doc = dom.window.document;
+    const host = doc.createElement('shreddit-composer');
+    doc.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const ce = doc.createElement('div');
+    ce.setAttribute('contenteditable', 'true');
+    ce.tabIndex = 0;
+    shadow.appendChild(ce);
+    // Fake a focusin event with retargeted target. composedPath()[0]
+    // is the real leaf; .target is the host.
+    const fakeEvent = {
+      target: host,
+      composedPath: () => [ce, shadow, host, doc.body, doc],
+    } as unknown as Event;
+    expect(resolveFocusedFromEvent(fakeEvent, isCE)).toBe(ce);
+  });
+
+  it('falls back to event.target when composedPath is empty', () => {
+    const doc = dom.window.document;
+    const div = doc.createElement('div');
+    div.setAttribute('contenteditable', 'true');
+    doc.body.appendChild(div);
+    const fakeEvent = {
+      target: div,
+      composedPath: () => [],
+    } as unknown as Event;
+    expect(resolveFocusedFromEvent(fakeEvent, isCE)).toBe(div);
+  });
+
+  it('returns null when neither path[0] nor target is an HTMLElement', () => {
+    const fakeEvent = {
+      target: null,
+      composedPath: () => [],
+    } as unknown as Event;
+    expect(resolveFocusedFromEvent(fakeEvent, isCE)).toBeNull();
+  });
+});
+
+describe('resolveFocusedElement (state read)', () => {
+  it('walks into the shadow root when given a delegatesFocus host', () => {
+    const doc = dom.window.document;
+    const host = doc.createElement('shreddit-composer');
+    doc.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: 'open' });
+    const ce = doc.createElement('div');
+    ce.setAttribute('contenteditable', 'true');
+    ce.tabIndex = 0;
+    shadow.appendChild(ce);
+    ce.focus();
+    // Simulates document.activeElement === host (jsdom won't actually
+    // retarget, but the caller's signal is "we got the host as
+    // activeElement"; the helper walks inward).
+    expect(resolveFocusedElement(host, isCE)).toBe(ce);
+  });
+
+  it('returns null on null input', () => {
+    expect(resolveFocusedElement(null, isCE)).toBeNull();
+  });
+
+  it('returns null when given a non-Element node', () => {
+    expect(resolveFocusedElement({} as unknown as Element, isCE)).toBeNull();
+  });
+});
+
+describe('back-compat — light-DOM-only paths are unchanged', () => {
+  it('contenteditable directly in light DOM resolves to itself from event', () => {
+    const doc = dom.window.document;
+    const div = doc.createElement('div');
+    div.setAttribute('contenteditable', 'true');
+    doc.body.appendChild(div);
+    const fakeEvent = {
+      target: div,
+      composedPath: () => [div, doc.body, doc],
+    } as unknown as Event;
+    expect(resolveFocusedFromEvent(fakeEvent, isCE)).toBe(div);
+  });
+
+  it('plain <input> resolves to itself, not walked further', () => {
+    const doc = dom.window.document;
+    const input = doc.createElement('input');
+    input.type = 'text';
+    doc.body.appendChild(input);
+    expect(resolveFocusedElement(input, isInputLike)).toBe(input);
+  });
+
+  it('non-text-input elements are returned without walking', () => {
+    const doc = dom.window.document;
+    const button = doc.createElement('button');
+    doc.body.appendChild(button);
+    // No shadow root. Helper returns button; caller's isTextInput rejects.
+    expect(resolveFocusedElement(button, isCE)).toBe(button);
+  });
+});

--- a/integrations/chrome/src/shadow-focus.ts
+++ b/integrations/chrome/src/shadow-focus.ts
@@ -1,0 +1,51 @@
+// Shadow-DOM focus piercing.
+//
+// Sites built on web components (Reddit's <shreddit-composer>, many Lit
+// apps) wrap their editor in a shadow root with `delegatesFocus: true`.
+// Native effect: at document scope, `focusin.target` and
+// `document.activeElement` both retarget to the shadow HOST, not the
+// contenteditable inside. Our isTextInput() check then fails on the
+// custom-element host and we silently never attach.
+//
+// `composedPath()` crosses shadow boundaries so its [0] is the real leaf
+// for events that originated below a delegatesFocus root. For state
+// reads (document.activeElement), we walk shadowRoot.activeElement down
+// while the candidate is still an unfocusable host. Closed shadow roots
+// return null — the walk terminates and we fall back to the host (which
+// will fail isTextInput, same as today).
+//
+// `isLeaf` is a callback so callers can inject their own focusable
+// predicate without this module taking a dependency on chrome-host
+// concerns (isNormalInput, sensitive-field gates, etc.).
+
+export type LeafPredicate = (el: HTMLElement) => boolean;
+
+/** Walk down through shadow roots until we hit a node that satisfies
+ *  isLeaf, OR can't walk further (closed root / non-host element).
+ *  Bounded to 8 hops to defend against any future cycle in synthetic DOM. */
+export function deepestFocused(el: HTMLElement, isLeaf: LeafPredicate): HTMLElement {
+  let cur: HTMLElement = el;
+  for (let i = 0; i < 8; i++) {
+    if (isLeaf(cur)) return cur;
+    const inner = cur.shadowRoot?.activeElement;
+    if (!(inner instanceof HTMLElement) || inner === cur) return cur;
+    cur = inner;
+  }
+  return cur;
+}
+
+/** Resolve the real focused leaf from a focus-class event. Returns null
+ *  if the event has no usable target. */
+export function resolveFocusedFromEvent(e: Event, isLeaf: LeafPredicate): HTMLElement | null {
+  const path = e.composedPath();
+  const leaf = path.length > 0 ? path[0] : e.target;
+  if (!(leaf instanceof HTMLElement)) return null;
+  return deepestFocused(leaf, isLeaf);
+}
+
+/** Resolve the real focused leaf from a state read (document.activeElement,
+ *  FocusEvent.relatedTarget). Returns null on null / non-Element input. */
+export function resolveFocusedElement(start: Element | null, isLeaf: LeafPredicate): HTMLElement | null {
+  if (!(start instanceof HTMLElement)) return null;
+  return deepestFocused(start, isLeaf);
+}


### PR DESCRIPTION
## Summary

- Reddit's `<shreddit-composer>` migrated to nested Lit shadow roots with `shadowrootdelegatesfocus` — `focusin.target` and `document.activeElement` retarget to the custom-element host, which fails `isTextInput()` → silent no-attach. No cues, no blanks.
- We were never shadow-DOM aware (zero `composedPath`/`shadowRoot` references in `src/`). The break manifested when Reddit shipped the DOM change, not from anything in our tree.
- Fix routes focus through `composedPath()[0]` (event-driven) and recursive `shadowRoot.activeElement` (state-driven). Closed shadow roots terminate at the host (same dead-end as today; no regression).

## Why this PR is low-merge-risk

Touched files + scope:

| File | Δ | Notes |
|---|---|---|
| `integrations/chrome/src/shadow-focus.ts` | NEW | Pure helpers, no chrome-host coupling — `isLeaf` injected as callback. |
| `integrations/chrome/src/shadow-focus.test.ts` | NEW | 16 tests. |
| `integrations/chrome/src/content.ts` | ~12 lines | 4 sites (focusin, focusout, initial attach, diagnostic-ping) now route through helpers. |
| `integrations/chrome/src/opencues-bootstrap.ts` | ~4 lines | Key listener's `active !== target` guard now reads `composedPath()[0]` instead of `document.activeElement`. |
| `integrations/chrome/CLAUDE.md` | +14 lines | New "Shadow-DOM focus piercing" note under attach-modes section. |

No conflicts with anything currently in flight on `master` (last touches on `content.ts` focusin / `opencues-bootstrap.ts` key listener were PR #62 era, different lines).

## Behavior matrix — what changes, what doesn't

| Site | Engine | Before | After |
|---|---|---|---|
| Reddit | Lexical inside `<shreddit-composer>` shadow | ❌ never attached | ✅ attaches |
| Gmail / YouTube | generic contenteditable (light DOM) | ✅ works | ✅ works (identical code path — `composedPath()[0] === e.target`) |
| ChatGPT / claude.ai / LinkedIn / Luma | ProseMirror (light DOM) | ✅ works | ✅ works (identical) |
| Twitter/X | Draft.js (light DOM) | ✅ works | ✅ works (identical) |

On every light-DOM site, `composedPath()[0] === e.target`, so the behavior is byte-identical. Only retargeted paths get the new walk.

## What I checked

- **All existing chrome tests pass** — 156 → 172 (16 new).
- **Build clean** — `npm run build` succeeds; new symbols (`deepestFocused`, `composedPath`) present in `dist/content.js`.
- **Shell-portability lint** — clean.
- **Version-bump gate** — clean.
- **Manual DOM probe of real Reddit composer** — confirmed `<shreddit-composer>` with `<template shadowrootmode="open">` and inner `<reddit-rte>` with `shadowrootdelegatesfocus=""`. The contenteditable is the slotted `<div data-lexical-editor="true">` under shreddit-composer's light DOM.

## Per-buffer concerns NOT covered (deliberate)

- **Closed shadow roots**: `el.shadowRoot` returns null; loop terminates; we fall back to host (which fails `isTextInput`). Same dead-end as today — no improvement, no regression. If a future site uses closed roots for its composer we'll still be locked out and need a MAIN-world helper. Out of scope.
- **Cross-origin iframes**: `composedPath()` doesn't cross frame boundaries (different documents). Same as today.

## Test plan

- [x] Unit tests pass (172/172)
- [x] `npm run build` clean
- [ ] Manual: rebuild chrome → sync to `/mnt/c/...opencues-chrome/dist/` → reload extension → load Reddit comment composer → verify (a) cues paint, (b) `volume _` fires, (c) `[OpenCues] Attaching to` logs `DIV` not `SHREDDIT-COMPOSER`.
- [ ] Manual regression: smoke-check Gmail compose, ChatGPT, claude.ai still attach and accept transforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)