### PR TITLE
perf(resolver): skip identityContext forwarding when no consumer will fire (symmetric with #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Changed — Resolver also skips forwarding `identityContext` when no consumer source will fire (symmetric with the blank-context gate)
+
+PR #74 added a gate that skips the `blankContext` provider fetch when no consumer source (FluidBlank, TransformBlank) will fire. The symmetric site — `identityContext` forwarding in the same `_resolver.resolve(...)` call — was left as legacy "forward whenever `identity-context-mode !== 'off'`". The identity catalog is in-memory at ConfigLoader so the cost saving is small (no IO), but the symmetric correctness + payload-size win is worth the one-line gate.
+
+- **`@opencues/runtime` (0.2.5 → 0.2.6)** — the same `noBlankContextConsumer(cleanWords, claimed)` predicate that gates `blankContext` now also gates `identityContext`: skip when either (a) the buffer has no `_` at all, or (b) every `_` is in the keyword-bound set passed via `keywordBoundSlotIndices`.
+- **4 new regression tests** in `packages/opencues-runtime/src/modules/resolver.test.ts`'s new `identity-context skip for keyword-bound slots (symmetric with blank-context)` block: (1) every-`_`-claimed → not forwarded; (2) no-`_`-claimed → forwarded; (3) mode=off → not forwarded regardless; (4) no-`_` at all → not forwarded.
+
 ### Fixed — `volume _` and other keyword-bound blanks no longer pay a 1.2s wasted catalog fetch
 
 Typing `volume _` / `weather _` / `nvidia _` / `brightness _` / any keyword-bound script-backed blank was visibly slow — the spinner ran ~1.3s even though the underlying script (`volume-blank.sh`, etc.) returned in ~200ms. The agentic harness traced the wasted second to the `blankContextProvider()` fetch: every `_` resolve sequentially called `await blank.get(slot.slot)` for every blank with `as-context: safe|raw` in its frontmatter (weather, crypto, stocks, hackernews, claude-status). 5 network/script calls on every keystroke that contains a `_`. The catalog is only ever consumed by FluidBlankSource and TransformBlankSource — both of which **cede** when a keyword-bound BlankFill slot claims the `_`. For `volume _` the catalog was being built and immediately thrown away.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -609,7 +609,7 @@ done
 | `SPEC.md` (open-standard) | `cues-spec` | 0.2 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
 | `packages/opencues-core/` | `@opencues/core` | 0.3.0 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.2.3 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.2.6 | private |
 | `packages/opencues-cli/` | `opencues` (real CLI) | 0.2.0 | private |
 | `packages/opencues-park/` | `opencues` (placeholder) | 0.0.1 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.0 | private |

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/resolver.test.ts
+++ b/packages/opencues-runtime/src/modules/resolver.test.ts
@@ -946,6 +946,81 @@ describe('Resolver blank-context skip for keyword-bound slots (regression: volum
   });
 });
 
+describe('Resolver identity-context skip for keyword-bound slots (symmetric with blank-context)', () => {
+  // FluidBlank and TransformBlank are the only consumers of
+  // `identityContext`. Both cede when a keyword-bound BlankFill slot
+  // claims the `_`. The catalog itself is cheap (in-memory at
+  // ConfigLoader), so the saving here is symmetric correctness +
+  // payload-size rather than an IO/cost win.
+  interface CapturedCtx { identityContext?: unknown }
+
+  function setup(opts: {
+    mode?: 'off' | 'safe' | 'raw';
+    keywordBoundSlotIndices?: (text: string) => readonly number[];
+  }) {
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: { '/mock/CUES.md': TIPS, '/proj/CUES.md': CUES_MD },
+    });
+    const hlState = new HighlightState();
+    const dynDefs = new DynDefs();
+    const loader = new ConfigLoader(adapter, { settingsFile: '/proj/CUES.md' });
+    if (opts.mode && opts.mode !== 'off') {
+      loader.applyOpenCuesScalar('identity-context-mode', opts.mode);
+    }
+
+    const resolver = new Resolver(
+      adapter, hlState, dynDefs, loader,
+      {
+        endpoint: 'http://test', apiKey: 'x', defaultModel: 'm', debounceMs: 10,
+        httpAdapter: {},
+        keywordBoundSlotIndices: opts.keywordBoundSlotIndices,
+      },
+    );
+    const capturedCtxs: CapturedCtx[] = [];
+    (resolver as unknown as { _resolver: { resolve(ctx: CapturedCtx): Promise<{ results: MockResult[] }> } })._resolver = {
+      resolve: async (ctx) => { capturedCtxs.push(ctx); return { results: [] }; },
+    };
+    return { resolver, capturedCtxs };
+  }
+
+  it('every `_` is keyword-bound → identityContext is NOT forwarded', async () => {
+    const { resolver, capturedCtxs } = setup({
+      mode: 'safe',
+      keywordBoundSlotIndices: text => text === 'volume _' ? [1] : [],
+    });
+    await resolver.resolveAndApply('volume _');
+    expect(capturedCtxs[0]?.identityContext).toBeUndefined();
+  });
+
+  it('no keyword-bound slot → identityContext IS forwarded', async () => {
+    const { resolver, capturedCtxs } = setup({
+      mode: 'safe',
+      keywordBoundSlotIndices: () => [],
+    });
+    await resolver.resolveAndApply('draft an email about my trip _');
+    expect(capturedCtxs[0]?.identityContext).toBeDefined();
+  });
+
+  it('mode=off → identityContext is NOT forwarded regardless of slot state', async () => {
+    const { resolver, capturedCtxs } = setup({
+      mode: 'off',
+      keywordBoundSlotIndices: () => [],
+    });
+    await resolver.resolveAndApply('draft an email about my trip _');
+    expect(capturedCtxs[0]?.identityContext).toBeUndefined();
+  });
+
+  it('no `_` in buffer → identityContext is NOT forwarded (no consumer source can fire)', async () => {
+    const { resolver, capturedCtxs } = setup({
+      mode: 'safe',
+      keywordBoundSlotIndices: () => [],
+    });
+    await resolver.resolveAndApply('the lawyer filed today');
+    expect(capturedCtxs[0]?.identityContext).toBeUndefined();
+  });
+});
+
 describe('Resolver blank-trigger-mode gate', () => {
   // The user-facing distinction: in `immediate` mode a bare `_` at the
   // end of the buffer bypasses the debounce and resolves NOW. In

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -1108,9 +1108,21 @@ export class Resolver {
         // `identity-context-mode` in OPENCUES.md (`off` by default — when
         // `off` we don't even forward the parsed catalog, so a future
         // misconfigured source can't accidentally read it). When on,
-        // ship the catalog + mode through to FluidBlankSource; no
-        // other source consumes this field today by design.
+        // ship the catalog + mode through to FluidBlank / TransformBlank;
+        // no other source consumes this field today by design.
+        //
+        // ALSO skipped via `noBlankContextConsumer` for the same reason as
+        // `blankContext` below: the two consumer sources (FluidBlank,
+        // TransformBlank) both cede when every `_` is claimed by a
+        // keyword-bound BlankFill slot (or when there's no `_` at all),
+        // so forwarding the catalog would just pass it down to be
+        // discarded. Symmetric with the blank-context gate; the
+        // identity catalog is already cached in-memory at the
+        // ConfigLoader so the cost saving is small (no IO), but the
+        // payload-size and structural-symmetry win is worth the
+        // 1-line gate.
         identityContext: this.configLoader.opencuesState.identityContextMode !== 'off'
+          && !noBlankContextConsumer(cleanWords, this.options.keywordBoundSlotIndices?.(text) ?? [])
           ? {
               fields: this.configLoader.identity.fields,
               catalog: this.configLoader.identity.catalog,


### PR DESCRIPTION
## Summary

- PR #74 added a gate that skips the `blankContext` provider fetch when no consumer source (FluidBlank, TransformBlank) will fire.
- The symmetric site — `identityContext` forwarding in the same `_resolver.resolve(...)` call — was left as legacy.
- The identity catalog is in-memory at ConfigLoader so the cost saving is small (no IO), but the symmetric correctness + payload-size win is worth the one-line gate.
- **Stacks on #74**. Base targets that branch.

## What changed

### `@opencues/runtime` (0.2.5 → 0.2.6)
- The same `noBlankContextConsumer(cleanWords, claimed)` predicate that gates `blankContext` now also gates `identityContext`: skip when either (a) the buffer has no `_` at all, or (b) every `_` is in the keyword-bound set passed via `keywordBoundSlotIndices`.

## Test plan

- [x] 4 new regression tests in `packages/opencues-runtime/src/modules/resolver.test.ts` under a new describe block:
  1. Every `_` claimed → not forwarded
  2. No claim → forwarded
  3. mode=off → not forwarded regardless
  4. No `_` in buffer → not forwarded
- [x] Full resolver suite: 65 / 65 pass.
- [x] All 9 pre-PR gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)