### PR TITLE
perf(resolver): skip identityContext forwarding when no consumer will fire (symmetric with #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Changed — Resolver also skips forwarding `identityContext` when no consumer source will fire (symmetric with the blank-context gate)
+
+PR #74 added a gate that skips the `blankContext` provider fetch when no consumer source (FluidBlank, TransformBlank) will fire. The symmetric site — `identityContext` forwarding in the same `_resolver.resolve(...)` call — was left as legacy "forward whenever `identity-context-mode !== 'off'`". The identity catalog is in-memory at ConfigLoader so the cost saving is small (no IO), but the symmetric correctness + payload-size win is worth the one-line gate.
+
+- **`@opencues/runtime` (0.2.5 → 0.2.6)** — the same `noBlankContextConsumer(cleanWords, claimed)` predicate that gates `blankContext` now also gates `identityContext`: skip when either (a) the buffer has no `_` at all, or (b) every `_` is in the keyword-bound set passed via `keywordBoundSlotIndices`.
+- **4 new regression tests** in `packages/opencues-runtime/src/modules/resolver.test.ts`'s new `identity-context skip for keyword-bound slots (symmetric with blank-context)` block: (1) every-`_`-claimed → not forwarded; (2) no-`_`-claimed → forwarded; (3) mode=off → not forwarded regardless; (4) no-`_` at all → not forwarded.
+
 ### Fixed — Parallel resolver enforces claim-then-bail semantics (TransformBlank → FluidBlank vandalism prevented)
 
 The runtime resolver always passes `parallel: true` to the underlying `CueResolver`. Pre-fix, parallel mode dispatched every source with the SAME starting `consumedBlankSlots` (each call saw an empty claim set), and the post-dispatch processing didn't enforce the claim either — a lower-priority source's `wordIndex` results overlapping a higher-priority source's `consumedBlankSlots` (or its own filled `wordIndex`) would slip through, "vandalising" the higher-priority intent. Concrete shape: TransformBlank classifies `make this draft more formal _ hi bob` as TRANSFORM but APPLY emits no rewrite → `consumedBlankSlots: [last `_`]`. FluidBlank in the same batch produces a stray lookup answer for the same `_` and substitutes it, turning the user's compose intent into a question answer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -609,7 +609,7 @@ done
 | `SPEC.md` (open-standard) | `cues-spec` | 0.2 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
 | `packages/opencues-core/` | `@opencues/core` | 0.3.3 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.2.5 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.2.6 | private |
 | `packages/opencues-cli/` | `opencues` (real CLI) | 0.2.0 | private |
 | `packages/opencues-park/` | `opencues` (placeholder) | 0.0.1 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.0 | private |

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/resolver.test.ts
+++ b/packages/opencues-runtime/src/modules/resolver.test.ts
@@ -956,7 +956,7 @@ describe('Resolver per-resolve AbortController (stale-generation cancellation)',
   // (via `dispatchChat`); the runtime's job is just to create the
   // controller and roll it on generation increment.
 
-  interface CapturedCtx { signal?: AbortSignal }
+  interface CapturedAbortCtx { signal?: AbortSignal }
 
   function setup() {
     const adapter = new MockAdapter({
@@ -975,8 +975,8 @@ describe('Resolver per-resolve AbortController (stale-generation cancellation)',
 
   it('a fresh AbortSignal lands in the ctx of every resolve', async () => {
     const { resolver } = setup();
-    const captured: CapturedCtx[] = [];
-    (resolver as unknown as { _resolver: { resolve(ctx: CapturedCtx): Promise<{ results: MockResult[] }> } })._resolver = {
+    const captured: CapturedAbortCtx[] = [];
+    (resolver as unknown as { _resolver: { resolve(ctx: CapturedAbortCtx): Promise<{ results: MockResult[] }> } })._resolver = {
       resolve: async (ctx) => { captured.push(ctx); return { results: [] }; },
     };
     await resolver.resolveAndApply('alpha');
@@ -989,20 +989,16 @@ describe('Resolver per-resolve AbortController (stale-generation cancellation)',
 
   it('a newer resolveAndApply aborts the PRIOR one\'s signal mid-flight', async () => {
     const { resolver } = setup();
-    // Long-running resolve that we'll observe the signal on. Resolves
-    // when the SECOND call comes in.
     let firstSignal: AbortSignal | undefined;
     let firstStarted!: (v: void) => void;
     const firstStartedP = new Promise<void>(r => { firstStarted = r; });
     let firstResolve!: (v: { results: MockResult[] }) => void;
     let secondCalled = false;
-    (resolver as unknown as { _resolver: { resolve(ctx: CapturedCtx): Promise<{ results: MockResult[] }> } })._resolver = {
+    (resolver as unknown as { _resolver: { resolve(ctx: CapturedAbortCtx): Promise<{ results: MockResult[] }> } })._resolver = {
       resolve: async (ctx) => {
         if (!secondCalled) {
           firstSignal = ctx.signal;
           firstStarted();
-          // First call blocks until we resolve it externally — simulating
-          // a real LLM call that is still in flight.
           return new Promise(r => { firstResolve = r; });
         }
         return { results: [] };
@@ -1011,13 +1007,10 @@ describe('Resolver per-resolve AbortController (stale-generation cancellation)',
     const firstP = resolver.resolveAndApply('alpha');
     await firstStartedP;
     expect(firstSignal?.aborted).toBe(false);
-    // Fire a newer resolve — should abort the first signal.
     secondCalled = true;
     const secondP = resolver.resolveAndApply('alpha _');
-    // Give the abort a microtask to fire.
     await Promise.resolve();
     expect(firstSignal?.aborted).toBe(true);
-    // Unblock the first call so the test can clean up.
     firstResolve({ results: [] });
     await firstP;
     await secondP;
@@ -1030,12 +1023,11 @@ describe('Resolver per-resolve AbortController (stale-generation cancellation)',
     const firstStartedP = new Promise<void>(r => { firstStarted = r; });
     let abortedRejection!: (e: Error) => void;
     let secondCalled = false;
-    (resolver as unknown as { _resolver: { resolve(ctx: CapturedCtx): Promise<{ results: MockResult[] }> } })._resolver = {
+    (resolver as unknown as { _resolver: { resolve(ctx: CapturedAbortCtx): Promise<{ results: MockResult[] }> } })._resolver = {
       resolve: async (ctx) => {
         if (!secondCalled) {
           firstSignal = ctx.signal;
           firstStarted();
-          // Simulate a source that throws AbortError when its signal trips.
           return new Promise((_resolve, reject) => {
             ctx.signal?.addEventListener('abort', () => {
               const err = new Error('aborted');
@@ -1063,6 +1055,81 @@ describe('Resolver per-resolve AbortController (stale-generation cancellation)',
     await secondP;
     expect(firstSignal?.aborted).toBe(true);
     expect(errors).toEqual([]);
+  });
+});
+
+describe('Resolver identity-context skip for keyword-bound slots (symmetric with blank-context)', () => {
+  // FluidBlank and TransformBlank are the only consumers of
+  // `identityContext`. Both cede when a keyword-bound BlankFill slot
+  // claims the `_`. The catalog itself is cheap (in-memory at
+  // ConfigLoader), so the saving here is symmetric correctness +
+  // payload-size rather than an IO/cost win.
+  interface CapturedIdentityCtx { identityContext?: unknown }
+
+  function setup(opts: {
+    mode?: 'off' | 'safe' | 'raw';
+    keywordBoundSlotIndices?: (text: string) => readonly number[];
+  }) {
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: { '/mock/CUES.md': TIPS, '/proj/CUES.md': CUES_MD },
+    });
+    const hlState = new HighlightState();
+    const dynDefs = new DynDefs();
+    const loader = new ConfigLoader(adapter, { settingsFile: '/proj/CUES.md' });
+    if (opts.mode && opts.mode !== 'off') {
+      loader.applyOpenCuesScalar('identity-context-mode', opts.mode);
+    }
+
+    const resolver = new Resolver(
+      adapter, hlState, dynDefs, loader,
+      {
+        endpoint: 'http://test', apiKey: 'x', defaultModel: 'm', debounceMs: 10,
+        httpAdapter: {},
+        keywordBoundSlotIndices: opts.keywordBoundSlotIndices,
+      },
+    );
+    const capturedCtxs: CapturedIdentityCtx[] = [];
+    (resolver as unknown as { _resolver: { resolve(ctx: CapturedIdentityCtx): Promise<{ results: MockResult[] }> } })._resolver = {
+      resolve: async (ctx) => { capturedCtxs.push(ctx); return { results: [] }; },
+    };
+    return { resolver, capturedCtxs };
+  }
+
+  it('every `_` is keyword-bound → identityContext is NOT forwarded', async () => {
+    const { resolver, capturedCtxs } = setup({
+      mode: 'safe',
+      keywordBoundSlotIndices: text => text === 'volume _' ? [1] : [],
+    });
+    await resolver.resolveAndApply('volume _');
+    expect(capturedCtxs[0]?.identityContext).toBeUndefined();
+  });
+
+  it('no keyword-bound slot → identityContext IS forwarded', async () => {
+    const { resolver, capturedCtxs } = setup({
+      mode: 'safe',
+      keywordBoundSlotIndices: () => [],
+    });
+    await resolver.resolveAndApply('draft an email about my trip _');
+    expect(capturedCtxs[0]?.identityContext).toBeDefined();
+  });
+
+  it('mode=off → identityContext is NOT forwarded regardless of slot state', async () => {
+    const { resolver, capturedCtxs } = setup({
+      mode: 'off',
+      keywordBoundSlotIndices: () => [],
+    });
+    await resolver.resolveAndApply('draft an email about my trip _');
+    expect(capturedCtxs[0]?.identityContext).toBeUndefined();
+  });
+
+  it('no `_` in buffer → identityContext is NOT forwarded (no consumer source can fire)', async () => {
+    const { resolver, capturedCtxs } = setup({
+      mode: 'safe',
+      keywordBoundSlotIndices: () => [],
+    });
+    await resolver.resolveAndApply('the lawyer filed today');
+    expect(capturedCtxs[0]?.identityContext).toBeUndefined();
   });
 });
 

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -1130,9 +1130,21 @@ export class Resolver {
         // `identity-context-mode` in OPENCUES.md (`off` by default — when
         // `off` we don't even forward the parsed catalog, so a future
         // misconfigured source can't accidentally read it). When on,
-        // ship the catalog + mode through to FluidBlankSource; no
-        // other source consumes this field today by design.
+        // ship the catalog + mode through to FluidBlank / TransformBlank;
+        // no other source consumes this field today by design.
+        //
+        // ALSO skipped via `noBlankContextConsumer` for the same reason as
+        // `blankContext` below: the two consumer sources (FluidBlank,
+        // TransformBlank) both cede when every `_` is claimed by a
+        // keyword-bound BlankFill slot (or when there's no `_` at all),
+        // so forwarding the catalog would just pass it down to be
+        // discarded. Symmetric with the blank-context gate; the
+        // identity catalog is already cached in-memory at the
+        // ConfigLoader so the cost saving is small (no IO), but the
+        // payload-size and structural-symmetry win is worth the
+        // 1-line gate.
         identityContext: this.configLoader.opencuesState.identityContextMode !== 'off'
+          && !noBlankContextConsumer(cleanWords, this.options.keywordBoundSlotIndices?.(text) ?? [])
           ? {
               fields: this.configLoader.identity.fields,
               catalog: this.configLoader.identity.catalog,


### PR DESCRIPTION
> Re-PR of #79 — rebased cleanly on master after #74/#84/#85/#86 merged.

## Summary

- #74 added a gate that skips the `blankContext` provider fetch when no consumer source (FluidBlank, TransformBlank) will fire.
- The symmetric site — `identityContext` forwarding in the same `_resolver.resolve(...)` call — was left as legacy "forward whenever `identity-context-mode !== 'off'`".
- The identity catalog is in-memory at ConfigLoader so the cost saving is small (no IO), but the symmetric correctness + payload-size win is worth the one-line gate.

## What changed

### `@opencues/runtime` (0.2.5 → 0.2.6)
- The same `noBlankContextConsumer(cleanWords, claimed)` predicate that gates `blankContext` now also gates `identityContext`: skip when either (a) the buffer has no `_` at all, or (b) every `_` is in the keyword-bound set passed via `keywordBoundSlotIndices`.

## Test plan

- [x] 4 new regression tests in `packages/opencues-runtime/src/modules/resolver.test.ts` under a new describe block:
  1. Every `_` claimed → not forwarded
  2. No claim → forwarded
  3. mode=off → not forwarded regardless
  4. No `_` in buffer → not forwarded
- [x] Full resolver suite: 68/68 pass (prior 64 + 4 new identity-context skip tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)