### PR TITLE
test(resolver): align paste-scenario test with PR #90 diff-based arm

### DIFF
--- a/packages/opencues-runtime/src/modules/resolver.test.ts
+++ b/packages/opencues-runtime/src/modules/resolver.test.ts
@@ -1273,13 +1273,20 @@ describe('Resolver explicit-`_` gate', () => {
     expect(sawStandaloneUnderscore).toBe(true);
   });
 
-  it('paste scenario: programmatic `pushTextNoKeystroke` with a standalone `_` does NOT route to blank sources', async () => {
+  it('diff-based fallback: `pushTextNoKeystroke` that grows underscore count auto-arms (PR #90)', async () => {
+    // PR #90 added a diff-based fallback to the explicit-`_` gate: when the
+    // buffer underscore count goes UP without a keystroke arm (chrome focus-
+    // trap modals — LinkedIn share, Reddit's shreddit-composer — clear
+    // `currentTarget` during focus shuffle, so the document-level keydown
+    // listener early-returns before `onUnderscoreKey` arms the flag), the
+    // resolver treats the count delta itself as the arm signal. The cursor-
+    // split case (PR #52) is naturally excluded because it doesn't change
+    // the count — it only exposes an existing `_` via whitespace.
     const { adapter, seenWordsPerCall } = setupGateScenario();
     adapter.pushTextNoKeystroke('weather _');
     await new Promise(r => setTimeout(r, 80));
-    for (const words of seenWordsPerCall) {
-      expect(words).not.toContain('_');
-    }
+    const sawStandaloneUnderscore = seenWordsPerCall.some(words => words.includes('_'));
+    expect(sawStandaloneUnderscore).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Master CI has been red since PR #90 (818ffa6) landed. The paste-scenario test in `resolver.test.ts` asserted the pre-#90 invariant (programmatic underscore inserts must NOT route to blanks). PR #90 deliberately relaxed that — when underscore count goes UP without a keystroke arm, the resolver now treats the delta itself as an implicit arm. The test contradicts the intentional new behavior.

Updated the test name + body to pin the new behavior. The PR #52 cursor-split case (count unchanged → still suppressed) remains covered by the sibling test directly above.

## Why this was missed

PR #90 was the last PR that touched resolver.ts, and its CI was green at the time (test file wasn't included in the diff so vitest didn't re-run it on that exact path, OR cached test results masked it — needs follow-up). PR #91 (chrome version bump) was the first PR after #90 to touch any code that retriggered the full runtime test suite — surfaced the regression.

## Test plan
- [x] `pnpm --filter @opencues/runtime test` passes locally (1609/1609)
- [ ] CI green