### PR TITLE
fix(linkedin): messaging composer Send button stays disabled after transform-blank

### DIFF
--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -630,6 +630,20 @@ function isDraftJsEditor(el: HTMLElement): boolean {
   return !!el.closest('.public-DraftEditor-content');
 }
 
+/** LinkedIn messaging composer (`<div class="msg-form__contenteditable" ...>`).
+ *  No public marker for the underlying editor framework (LinkedIn ships a
+ *  private build). Empty-state shape is `<p><br></p>` and the Send button
+ *  is driven by React state that only flips when the editor's input
+ *  pipeline observes content. Generic `execCommand('insertHTML')` lands
+ *  the DOM but doesn't trip React's state — Send stays disabled even
+ *  though text is visible. The carve-out below uses per-line
+ *  `execCommand('insertText')` + `insertParagraph`, which fire trusted
+ *  `beforeinput`/`input` events whose `inputType` is the same shape real
+ *  typing produces — React's listener catches them and flips the state. */
+function isLinkedInMessaging(el: HTMLElement): boolean {
+  return !!el.closest('.msg-form__contenteditable');
+}
+
 function isQuillEditor(el: HTMLElement): boolean {
   return !!el.closest('.ql-editor');
 }
@@ -1312,6 +1326,47 @@ export function replaceAllText(text: string): void {
 
       const postFinal = target.textContent?.length ?? 0;
       log.info('[opencues] replaceAllText: draftjs path, preLen=' + pre + ', postLen=' + postFinal);
+      sourceReclassifier.markRuntimeWrite(text);
+      schedulePostReconcileRender();
+      return;
+    } else if (isLinkedInMessaging(target)) {
+      // LinkedIn messaging composer (`.msg-form__contenteditable`).
+      // No public marker for the underlying framework (LinkedIn ships a
+      // private build); empty-state shape is `<p><br></p>` and the Send
+      // button is gated by React state that only flips when the editor's
+      // input pipeline observes content. Generic `execCommand('insertHTML')`
+      // lands the DOM mutation but DOES NOT flip the React state — text
+      // appears in the box but Send stays disabled, like the placeholder
+      // is still active. Mirrors the Quill fallback's typing-simulation
+      // approach: Range-API select-all + per-line `insertText` +
+      // `insertParagraph` between. These fire `beforeinput`/`input`
+      // events whose `inputType` matches real typing
+      // (`"insertText"` / `"insertParagraph"`), so LinkedIn's React
+      // listener catches them and updates the state.
+      try {
+        const sel = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(target);
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+      } catch { /* selection unavailable */ }
+      const paragraphs = text.split(/\n\n+/);
+      for (let p = 0; p < paragraphs.length; p++) {
+        const lines = paragraphs[p].split('\n');
+        for (let l = 0; l < lines.length; l++) {
+          if (lines[l].length > 0) {
+            document.execCommand('insertText', false, lines[l]);
+          }
+          if (l < lines.length - 1) {
+            document.execCommand('insertParagraph');
+          }
+        }
+        if (p < paragraphs.length - 1) {
+          document.execCommand('insertParagraph');
+          document.execCommand('insertParagraph');
+        }
+      }
+      log.info('[opencues] replaceAllText: linkedin-messaging path, paragraphs=' + paragraphs.length);
       sourceReclassifier.markRuntimeWrite(text);
       schedulePostReconcileRender();
       return;


### PR DESCRIPTION
## Summary

LinkedIn's messaging composer (`<div class="msg-form__contenteditable">`) gates its Send button on React state that only flips when the editor's input pipeline observes content. Generic `execCommand('insertHTML')` lands the DOM mutation but DOES NOT trip the React state — text appears in the box but Send stays disabled, as if the placeholder was still active.

Add an `isLinkedInMessaging` carve-out that mirrors the Quill fallback: Range-API select-all + per-line `insertText` + `insertParagraph` between. These fire `inputType: "insertText"` / `"insertParagraph"` events matching real typing — LinkedIn's React listener catches them and flips the state.

## Risk surface

- **LinkedIn-specific selector** (`.msg-form__contenteditable`). No other site uses this class.
- **Share composer unaffected** — `.ql-editor` → `isQuillEditor` matches first.
- **Cycling unaffected** — only `replaceAllText` changed; `applyTextDiff` untouched.
- **Other managed editors unaffected** — branch only fires when LinkedIn messaging class is present.

## Trade-off

Multi-undo on LinkedIn messaging (one entry per execCommand) vs the single-entry contract other sites carry. Acceptable for now — the alternative is the "can't send" state, which is strictly worse. Single-entry path would require finding LinkedIn's private editor instance.

## Test plan
- [x] User verified Send button enables after transform-blank substitution in LinkedIn messaging
- [x] Other LinkedIn surfaces (share composer) and unrelated managed editors (Reddit Lexical, ChatGPT PM, Gmail) untouched
- [x] Chrome vitest suite green (176/176)
- [ ] CI green