### PR TITLE
sec(set-key): always chmod 0o600 ~/.cues/.env (INFOSEC F7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Security — `opencues set-key` always tightens `~/.cues/.env` perms (INFOSEC F7)
+
+`fs.writeFileSync({ mode: 0o600 })` only applies the mode when the file is newly created. An existing `~/.cues/.env` with looser perms (created by hand or copied with default umask) was rewritten in place without ever being chmod'd, so plaintext API keys could remain world/group-readable. The chrome host then loads this file into `process.env` and hands it to every scripted blank ([F2](../INFOSEC_FINDINGS.md#f2)), so loose perms compounded that exposure.
+
+- **`opencues` CLI (`set-key`)** — always `chmod 0o600` the file and `0o700` the parent dir after writing, regardless of whether the file pre-existed. Warns when the prior mode was broader than `0600` so users know their key was previously readable.
+- Three regression tests in `set-key.test.cjs`: create-from-scratch lands at 0600/0700; pre-existing 0644 file gets tightened; pre-existing 0640 file gets tightened. Existing key lines preserved across the rewrite.
+
 ### Added — per-call `with <model>` LLM dispatch override for fluid-blank and transform-blank
 
 Adds a `with <name>` token anywhere in the buffer before `_` (`make formal X with opus _`, `atomic number of oxygen with cerebras _`) to flip the dispatch target for ONE call without writing any scalar to disk. The next `_` keystroke without `with X` goes back to the configured bucket. Five-tier token resolution: common aliases (opus / haiku / sonnet / nano / mini / flash / gpt-oss / llama / claude / anthropic / cerebras / groq / openai / gemini / openrouter), provider id, exact model name, prefix in any `knownModels`, substring fallback. Always on — no scalar gates it.

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/set-key.cjs
+++ b/packages/opencues-cli/src/commands/set-key.cjs
@@ -38,9 +38,14 @@ module.exports = function setKey(argv, ctx) {
   }
 
   const envFile = path.join(os.homedir(), '.cues', '.env');
-  fs.mkdirSync(path.dirname(envFile), { recursive: true });
+  const envDir = path.dirname(envFile);
+  fs.mkdirSync(envDir, { recursive: true });
 
-  // Read existing, replace or append the line for this var.
+  let preExistingMode = null;
+  if (fs.existsSync(envFile)) {
+    try { preExistingMode = fs.statSync(envFile).mode & 0o777; } catch {}
+  }
+
   let lines = [];
   if (fs.existsSync(envFile)) {
     lines = fs.readFileSync(envFile, 'utf8').split('\n');
@@ -50,6 +55,15 @@ module.exports = function setKey(argv, ctx) {
   if (idx >= 0) lines[idx] = newLine;
   else lines.push(newLine);
   fs.writeFileSync(envFile, lines.filter(Boolean).join('\n') + '\n', { mode: 0o600 });
+
+  // writeFileSync's mode is only applied on creation. Apply unconditionally
+  // so an existing file with looser perms gets tightened.
+  try { fs.chmodSync(envFile, 0o600); } catch {}
+  try { fs.chmodSync(envDir, 0o700); } catch {}
+
+  if (preExistingMode !== null && (preExistingMode & 0o077) !== 0) {
+    console.log(`${tag('warn')} previous ${fileLink(envFile, envFile)} mode was ${preExistingMode.toString(8).padStart(4, '0')} (group/other readable); tightened to 0600.`);
+  }
 
   console.log(`${tag('ok')} stored ${bold(envName)} in ${fileLink(envFile, envFile)}`);
   console.log('');

--- a/packages/opencues-cli/src/commands/set-key.test.cjs
+++ b/packages/opencues-cli/src/commands/set-key.test.cjs
@@ -1,0 +1,87 @@
+// Tests for set-key's at-rest perm hardening (INFOSEC F7).
+//
+// Contract: regardless of pre-existing perms on ~/.cues/.env, after
+// `opencues set-key` runs, the file is mode 0o600 and the parent dir
+// is 0o700. Verifies the writeFileSync({mode}) gotcha (mode only on
+// creation) is no longer load-bearing.
+
+'use strict';
+
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const setKey = require('./set-key.cjs');
+
+let realHome;
+let tmpHome;
+
+before(() => {
+  realHome = process.env.HOME;
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-set-key-test-'));
+  process.env.HOME = tmpHome;
+});
+
+after(() => {
+  process.env.HOME = realHome;
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+function envFilePath() {
+  return path.join(os.homedir(), '.cues', '.env');
+}
+
+function runSetKey(args) {
+  // Swallow stdout/stderr to keep test output clean.
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = () => {};
+  console.error = () => {};
+  try { setKey(args, { version: 'test' }); }
+  finally { console.log = origLog; console.error = origErr; }
+}
+
+test('set-key creates file with mode 0o600 + parent dir 0o700', { skip: process.platform === 'win32' }, () => {
+  const file = envFilePath();
+  try { fs.unlinkSync(file); } catch {}
+  try { fs.rmdirSync(path.dirname(file)); } catch {}
+
+  runSetKey(['groq', 'gsk_test_create']);
+
+  const fileMode = fs.statSync(file).mode & 0o777;
+  const dirMode = fs.statSync(path.dirname(file)).mode & 0o777;
+  assert.strictEqual(fileMode, 0o600, `expected 0600, got ${fileMode.toString(8)}`);
+  assert.strictEqual(dirMode, 0o700, `expected 0700, got ${dirMode.toString(8)}`);
+});
+
+test('set-key tightens pre-existing world-readable file to 0o600', { skip: process.platform === 'win32' }, () => {
+  const file = envFilePath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, 'EXISTING_KEY=foo\n');
+  fs.chmodSync(file, 0o644);
+  fs.chmodSync(path.dirname(file), 0o755);
+  assert.strictEqual(fs.statSync(file).mode & 0o777, 0o644);
+
+  runSetKey(['groq', 'gsk_test_tighten']);
+
+  assert.strictEqual(fs.statSync(file).mode & 0o777, 0o600);
+  assert.strictEqual(fs.statSync(path.dirname(file)).mode & 0o777, 0o700);
+
+  // Existing key preserved, new key added.
+  const contents = fs.readFileSync(file, 'utf8');
+  assert.match(contents, /EXISTING_KEY=foo/);
+  assert.match(contents, /GROQ_API_KEY=gsk_test_tighten/);
+});
+
+test('set-key tightens pre-existing group-readable file to 0o600', { skip: process.platform === 'win32' }, () => {
+  const file = envFilePath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, 'KEY=val\n');
+  fs.chmodSync(file, 0o640);
+
+  runSetKey(['groq', 'gsk_test_group']);
+
+  assert.strictEqual(fs.statSync(file).mode & 0o777, 0o600);
+});


### PR DESCRIPTION
## Summary

- `fs.writeFileSync({ mode: 0o600 })` only applies the mode on file *creation*. Pre-existing `~/.cues/.env` with looser perms got rewritten in place without ever being tightened, so API keys could remain world/group-readable. Compounds [F2](../master/INFOSEC_FINDINGS.md#f2) since the chrome host loads this file into `process.env`.
- Always `chmod 0o600` the file and `0o700` the parent dir after writing, regardless of prior state.
- Warn when the prior mode was broader than `0600`.

INFOSEC findings doc, finding F7. First of the easier infosec PRs landing as standalone changes.

## Test plan

- [x] 3 new unit tests in `set-key.test.cjs` — create-from-scratch lands at 0600/0700; pre-existing 0644 tightens; pre-existing 0640 tightens
- [x] `bash scripts/lint-version-bump.sh` — clean
- [x] `bash scripts/lint-legacy-names.sh` — clean
- [ ] `opencues set-key groq gsk_test` against a manually chmod'd 0644 file, verify mode flips to 0600 + warn line printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)