### PR TITLE
sec(gemini): API key in x-goog-api-key header (INFOSEC F8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
-### Added — per-call `with <model>` LLM dispatch override for fluid-blank and transform-blank
+### Security — Gemini API key moved off URL query string into `x-goog-api-key` header (INFOSEC F8)
+
+`?key=<apiKey>` puts secrets in URLs — they land in server/proxy access logs, browser history, the Referer header, and the chrome path also pipes them through the `opencues:fetch` SW proxy. Other providers correctly use `Authorization: Bearer` / `x-api-key` headers. Gemini's documented API contract accepts the key in either place, so the fix is mechanical: switch to `x-goog-api-key`.
+
+- **`@opencues/core`** — `GEMINI` adapter `buildRequest` returns a URL with no query string and a `x-goog-api-key` header. Test updated to assert the URL contains neither `gem_test` nor `key=`, and the header carries the key.
+- **`opencues check-keys` (CLI probe)** — same shape.
+- **chrome popup boot-time key audit + popup probe** — same shape.
+
+### Security — `opencues set-key` always tightens `~/.cues/.env` perms (INFOSEC F7)
 
 Adds a `with <name>` token anywhere in the buffer before `_` (`make formal X with opus _`, `atomic number of oxygen with cerebras _`) to flip the dispatch target for ONE call without writing any scalar to disk. The next `_` keystroke without `with X` goes back to the configured bucket. Five-tier token resolution: common aliases (opus / haiku / sonnet / nano / mini / flash / gpt-oss / llama / claude / anthropic / cerebras / groq / openai / gemini / openrouter), provider id, exact model name, prefix in any `knownModels`, substring fallback. Always on — no scalar gates it.
 

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -2154,7 +2154,7 @@ const PROVIDER_KEY_CHECKS: Record<string, (key: string) => { url: string; header
   openai:     (k) => ({ url: 'https://api.openai.com/v1/models',                        headers: { Authorization: `Bearer ${k}` } }),
   anthropic:  (k) => ({ url: 'https://api.anthropic.com/v1/models',                     headers: { 'x-api-key': k, 'anthropic-version': '2023-06-01' } }),
   openrouter: (k) => ({ url: 'https://openrouter.ai/api/v1/models',                     headers: { Authorization: `Bearer ${k}` } }),
-  gemini:     (k) => ({ url: `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(k)}`, headers: {} }),
+  gemini:     (k) => ({ url: 'https://generativelanguage.googleapis.com/v1beta/models',                headers: { 'x-goog-api-key': k } }), // INFOSEC F8: header not URL
 };
 
 /** Verify LLM keys at boot — runs once after the runtime is constructed.

--- a/integrations/chrome/src/popup/popup.ts
+++ b/integrations/chrome/src/popup/popup.ts
@@ -521,7 +521,7 @@ const PROBE_ENDPOINTS: Record<string, { url: string; headers: (k: string) => Rec
   OPENAI_API_KEY:     { url: 'https://api.openai.com/v1/models',                                                                                       headers: k => ({ Authorization: `Bearer ${k}` }) },
   ANTHROPIC_API_KEY:  { url: 'https://api.anthropic.com/v1/models',                                                                                    headers: k => ({ 'x-api-key': k, 'anthropic-version': '2023-06-01' }) },
   OPENROUTER_API_KEY: { url: 'https://openrouter.ai/api/v1/models',                                                                                    headers: k => ({ Authorization: `Bearer ${k}` }) },
-  GEMINI_API_KEY:     { url: `https://generativelanguage.googleapis.com/v1beta/models?key=__KEY__`,                                                    headers: () => ({}) },
+  GEMINI_API_KEY:     { url: 'https://generativelanguage.googleapis.com/v1beta/models',                                                                headers: k => ({ 'x-goog-api-key': k }) }, // INFOSEC F8: header not URL
 };
 
 async function probeOneKey(envName: string, key: string, out: (line: string) => void): Promise<void> {

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/check-keys.cjs
+++ b/packages/opencues-cli/src/commands/check-keys.cjs
@@ -105,8 +105,9 @@ function checkOpenRouter(key) {
     .then(j => `${(j.data || []).length} models available`);
 }
 function checkGemini(key) {
-  // Gemini takes the key in the query string, not a header.
-  return httpJson(`https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(key)}`)
+  // INFOSEC F8: x-goog-api-key header instead of `?key=` to keep the
+  // secret out of URL access logs / browser history / referrer.
+  return httpJson('https://generativelanguage.googleapis.com/v1beta/models', { 'x-goog-api-key': key })
     .then(j => `${(j.models || []).length} models available`);
 }
 function checkFinnhub(key) {
@@ -136,7 +137,7 @@ function printHelp() {
   console.log('  - openai:     GET /v1/models');
   console.log('  - anthropic:  GET /v1/models  (x-api-key + anthropic-version header)');
   console.log('  - openrouter: GET /api/v1/models');
-  console.log('  - gemini:     GET /v1beta/models?key=… (key in query)');
+  console.log('  - gemini:     GET /v1beta/models  (x-goog-api-key header)');
   console.log('  - finnhub:    GET /quote?symbol=AAPL  (free tier, 1 req)');
   console.log('');
   console.log('Reads keys from process.env first, then ~/.cues/.env. Exits 1 if any');

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/llm-provider.test.ts
+++ b/packages/opencues-core/src/llm-provider.test.ts
@@ -262,7 +262,7 @@ describe('openai provider — direct OpenAI', () => {
 });
 
 describe('gemini provider — translates to/from Google’s shape', () => {
-  it('buildRequest: model in URL path, key in query string, no auth header', () => {
+  it('buildRequest: model in URL path, key in x-goog-api-key header (NOT URL — INFOSEC F8)', () => {
     const built = buildProviderRequest(
       'gemini',
       { model: 'gemini-3.1-flash-lite', messages: [{ role: 'user', content: 'hi' }] },
@@ -270,9 +270,13 @@ describe('gemini provider — translates to/from Google’s shape', () => {
     );
     assert.strictEqual(
       built.url,
-      'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent?key=gem_test',
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite:generateContent',
     );
-    assert.deepStrictEqual(built.headers, { 'Content-Type': 'application/json' });
+    // F8: key MUST NOT appear in URL (access logs / browser history / referrer leak).
+    assert.ok(!built.url.includes('gem_test'), 'API key leaked into URL');
+    assert.ok(!built.url.includes('key='), 'URL still uses ?key= query param');
+    assert.strictEqual(built.headers['x-goog-api-key'], 'gem_test');
+    assert.strictEqual(built.headers['Content-Type'], 'application/json');
   });
 
   it('buildRequest: maps messages → contents (parts[].text), assistant → model', () => {

--- a/packages/opencues-core/src/llm-provider.ts
+++ b/packages/opencues-core/src/llm-provider.ts
@@ -651,12 +651,16 @@ const OPENAI_SUBSCRIPTION: ProviderAdapter = {
 
 /**
  * Gemini's API takes a fundamentally different shape:
- *   POST /v1beta/models/{model}:generateContent?key={apiKey}
+ *   POST /v1beta/models/{model}:generateContent
+ *   Header: x-goog-api-key: {apiKey}
  *   { contents: [{ role, parts: [{ text }] }],
  *     generationConfig: { maxOutputTokens, temperature } }
  *
  * Notable differences from OpenAI-shape:
- *   - Auth via `?key=` query param (NOT bearer header).
+ *   - Auth via `x-goog-api-key` header (per Google's API surface — also
+ *     accepts `?key=` query param, but URL-embedded keys have a wider
+ *     logging/caching surface: server access logs, proxy logs, browser
+ *     history, referrer. Header form keeps it out of URLs. INFOSEC F8.
  *   - Model embedded in URL path (NOT request body).
  *   - System role unsupported in `contents` — must go in
  *     `systemInstruction` separately.
@@ -713,11 +717,15 @@ const GEMINI: ProviderAdapter = {
     if (req.temperature !== undefined) generationConfig.temperature = req.temperature;
     if (Object.keys(generationConfig).length > 0) body.generationConfig = generationConfig;
     return {
-      // Gemini auth is query param, not header. The api key never goes
-      // in a body field, so logging the body is safe.
-      url: `${url}?key=${encodeURIComponent(ctx.apiKey)}`,
+      // INFOSEC F8: key in header, not URL — keeps it out of access logs,
+      // browser history, referrer. URL form (`?key=…`) still works on
+      // Google's side but is the higher-exposure shape.
+      url,
       body: JSON.stringify(body),
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': ctx.apiKey,
+      },
     };
   },
   parseResponse(rawJson) {

--- a/packages/opencues-core/src/sources/build-sources.providers.test.ts
+++ b/packages/opencues-core/src/sources/build-sources.providers.test.ts
@@ -84,7 +84,11 @@ describe('buildSourcesFromConfig — per-feature provider routing', () => {
     await fluid!.getCues({ text: 'capital of france _', words: ['capital', 'of', 'france', '_'] });
     assert.ok(calls.length > 0);
     assert.match(calls[0].url, /generativelanguage\.googleapis\.com/);
-    assert.match(calls[0].url, /models\/gemini-3\.1-flash-lite:generateContent\?key=gem_k/);
+    assert.match(calls[0].url, /models\/gemini-3\.1-flash-lite:generateContent$/);
+    // INFOSEC F8: API key in header, not URL.
+    assert.ok(!calls[0].url.includes('key='), 'F8: URL must not contain ?key=');
+    assert.ok(!calls[0].url.includes('gem_k'), 'F8: URL must not contain the API key');
+    assert.strictEqual(calls[0].headers['x-goog-api-key'], 'gem_k');
     const body = JSON.parse(calls[0].body);
     assert.ok(body.contents, 'expected gemini-shaped body with `contents`');
     assert.ok(body.systemInstruction, 'expected systemInstruction (gemini-shape)');


### PR DESCRIPTION
## Summary

- Gemini's API accepts the key either as `?key=` query param OR as `x-goog-api-key` header. We were using the query form, which leaks the key into server/proxy access logs, browser history, Referer headers, and chrome's `opencues:fetch` SW proxy.
- Switched every Gemini probe + the production GEMINI adapter to the header form. Mechanical, no behaviour change beyond the URL shape.

INFOSEC findings doc, finding F8.

## Test plan

- [x] Updated `llm-provider.test.ts` to assert URL contains neither the key nor `key=` and the header carries it. All 106 provider tests still pass.
- [x] `bash scripts/lint-version-bump.sh` — clean
- [x] `bash scripts/lint-legacy-names.sh` — clean
- [ ] Manual: `opencues check-keys` against a real GEMINI_API_KEY — verify model count returns
- [ ] Manual: chrome popup → enter GEMINI_API_KEY → click probe → verify model list

## Notes

Benchmark scripts under `tests/benchmarks/{transform-blank,fluid-blank,agent-rewrite}/gemini.ts` still hand-build URLs with `?key=`. They're standalone dev-runners, not shipping code, and don't log URLs — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)