### PR TITLE
sec(review): .constructor/Reflect/globalThis/proto + raw scan (INFOSEC F5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Security — `opencues review` catches the constructor-chain escape and string-concat obfuscation (INFOSEC F5)
+
+The static review's denylist flagged `eval`, `new Function`, dynamic `import()`, and Node built-in names (`process`, `require`, `child_process`, `fs`, …). It did NOT flag `.constructor` chains — the actual vm-sandbox escape pivot. Worse, the scan stripped string literals first, so a payload hidden in `Promise['cons'+'tructor']('return process')()` had every telltale token stripped before the regex ran, and `opencues review` returned exit 0 on a working RCE PoC.
+
+- **`opencues` CLI (`review.cjs`)** — six new hard-blocker patterns: `.constructor`, `["constructor"]` (bracket form), `Reflect`, `globalThis`, `__proto__`, `Object.{get,set}PrototypeOf`. Each refuses the pack with `sev: 'error'`, mirrors the AST rewriter's stance.
+- **Dual scan** — the existing stripped-literals heuristic kept (low false-positive on JSDoc/URL strings), plus a new RAW-source scan for the escape patterns AND a string-concat-fragment detector (warn) that catches the `'cons'+'tructor'` / `'pro'+'cess'` style of hide-in-strings obfuscation.
+- **11 new tests** in `review.test.cjs` cover: each escape pattern as a hard blocker, the string-concat obfuscation warn, clean code produces no errors, and the pre-existing `import()` + `eval` heuristics still fire.
+
+INFOSEC F5 is a defence-in-depth ground gain — F1 is the structural fix (a real isolate). This raises the bar for the naive PoC and the obfuscated PoC without changing the runtime trust model.
+
 ### Added — per-call `with <model>` LLM dispatch override for fluid-blank and transform-blank
 
 Adds a `with <name>` token anywhere in the buffer before `_` (`make formal X with opus _`, `atomic number of oxygen with cerebras _`) to flip the dispatch target for ONE call without writing any scalar to disk. The next `_` keystroke without `with X` goes back to the configured bucket. Five-tier token resolution: common aliases (opus / haiku / sonnet / nano / mini / flash / gpt-oss / llama / claude / anthropic / cerebras / groq / openai / gemini / openrouter), provider id, exact model name, prefix in any `knownModels`, substring fallback. Always on — no scalar gates it.

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/review.cjs
+++ b/packages/opencues-cli/src/commands/review.cjs
@@ -222,24 +222,70 @@ function staticChecks(fm, jsSource) {
     });
   }
 
-  // 5. JS-source static patterns. Strip comments + string literals
-  // first so we don't false-positive on JSDoc `@type {import(...)}` or
-  // URL string literals containing `https`. These regexes are
-  // heuristic flags — the actual security boundaries are enforced at
-  // load time by the AST rewriter + sandbox.
+  // 5. JS-source static patterns. We scan TWO views of the source:
+  //   - `stripped` (comments + string literals removed) → keeps the
+  //     `eval` / `Function` / `require` heuristics low-false-positive
+  //     against JSDoc `@type {import(...)}` or string-literal URLs.
+  //   - `raw` (the source verbatim) → catches the F5 escape pattern
+  //     `Promise['cons'+'tructor'](…)` and similar string-concat
+  //     hide-the-token tricks. INFOSEC F5: hiding `process` inside a
+  //     string literal made the stripped scan miss it entirely.
+  //
+  // These regexes are heuristic flags — the actual security
+  // boundaries are enforced at load time by the AST rewriter +
+  // sandbox. F1 is the structural fix; this scan exists to raise
+  // the bar for naive packs and refuse the most obvious bypasses.
   if (jsSource) {
     const stripped = stripCommentsAndStrings(jsSource);
+    const raw = jsSource;
+
+    // — eval / Function (stripped only — false-positive prone in docs/strings)
     if (/\beval\s*\(/.test(stripped)) {
       findings.push({ sev: 'warn', msg: 'source contains `eval(` — runtime context has no eval, but the call site is suspicious.' });
     }
     if (/\bnew\s+Function\b/.test(stripped) || /\bFunction\s*\(/.test(stripped)) {
       findings.push({ sev: 'warn', msg: 'source references `Function(`/`new Function` — refused at load by the AST rewriter, but worth a human look.' });
     }
+
+    // — dynamic import — hard blocker (AST rewriter refuses, mirror here)
     if (/\bimport\s*\(/.test(stripped)) {
       findings.push({ sev: 'error', msg: 'source uses dynamic `import()` — AST rewriter refuses to load this blank.' });
     }
+
+    // — Node built-in names — informational hint (sandbox shadows them)
     if (/\b(?:require|process|child_process|fs|os|http|https|net|dgram|cluster|worker_threads|vm)\s*[\.\(]/.test(stripped)) {
       findings.push({ sev: 'info', msg: 'source references Node built-in names — undefined in the sandbox, but check intent.' });
+    }
+    // Raw scan for Node built-ins too — catches `'pro'+'cess'` style
+    // string-concat hiding (warn, not error, because many packs include
+    // these tokens in legit error strings: `"requires the X API key"`).
+    if (/['"`]\s*\+\s*['"`](?:cons|truc|tructor|proc|ess|requ|ire|fs|child)/i.test(raw) ||
+        /['"`](?:cons|truc|tructor|proc|ess|requ|ire|fs|child)\s*['"`]\s*\+/i.test(raw)) {
+      findings.push({ sev: 'warn', msg: 'source string-concatenates fragments resembling Node built-in / constructor tokens — common F1-escape obfuscation.' });
+    }
+
+    // — .constructor / Reflect / globalThis / proto-walk — hard blockers
+    //   The Node `vm` sandbox shares host realm references; reaching the
+    //   `Function` constructor via any of these is the F1 RCE pivot.
+    //   Refuse them at review time so even an obfuscation-free PoC is
+    //   blocked. Mirrors stripped + raw — bracket-access form
+    //   `['constructor']` survives both views.
+    const escapePatterns = [
+      // .constructor / ["constructor"] / ['constructor'] / [`constructor`]
+      { re: /\.constructor\b/, msg: 'source accesses `.constructor` — the F1 sandbox-escape pivot via Promise/Date/URL/etc. → host `Function`.' },
+      { re: /\[\s*['"`]constructor['"`]\s*\]/, msg: 'source accesses `["constructor"]` (bracket form) — same F1 sandbox-escape pivot.' },
+      // Reflect — the introspection escape hatch
+      { re: /\bReflect\b/, msg: 'source references `Reflect` — Reflect.get/apply on host objects reaches the host realm.' },
+      // globalThis — direct host-global access
+      { re: /\bglobalThis\b/, msg: 'source references `globalThis` — the sandbox does not own globalThis; this is the host global object.' },
+      // __proto__ / proto-walk
+      { re: /\b__proto__\b/, msg: 'source accesses `__proto__` — proto-walk reaches the host realm prototype chain.' },
+      { re: /\b(?:getPrototypeOf|setPrototypeOf)\s*\(/, msg: 'source uses Object.{get,set}PrototypeOf — proto-walk reaches the host realm prototype chain.' },
+    ];
+    for (const { re, msg } of escapePatterns) {
+      if (re.test(stripped) || re.test(raw)) {
+        findings.push({ sev: 'error', msg });
+      }
     }
   }
 
@@ -613,3 +659,6 @@ function printHelp() {
   console.log('  1  pack would fail to load OR has hard-blocked patterns');
   console.log('  2  LLM unavailable (static section still ran)');
 }
+
+// Internal helpers exposed for testing. Not part of the public surface.
+module.exports._internal = { staticChecks, stripCommentsAndStrings };

--- a/packages/opencues-cli/src/commands/review.test.cjs
+++ b/packages/opencues-cli/src/commands/review.test.cjs
@@ -1,0 +1,120 @@
+// Tests for `opencues review` static-pattern denylist hardening (INFOSEC F5).
+//
+// What we pin:
+//   - .constructor / ["constructor"] / Reflect / globalThis / proto-walk
+//     are hard blockers (sev: 'error'), not warnings.
+//   - The scan covers BOTH stripped and raw source — payloads hidden in
+//     string literals can no longer slip past via `stripCommentsAndStrings`.
+//   - Pre-fix: a vm-escape PoC using Promise.constructor returned no
+//     findings. Post-fix: it returns a sev: 'error'.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { _internal } = require('./review.cjs');
+const { staticChecks } = _internal;
+
+function fm() {
+  return {
+    name: 'pwned',
+    blankKeywords: ['pwned'],
+    userBlankCapabilities: {},
+    userBlankNetwork: [],
+    userBlankSecrets: [],
+    userBlankSecretBindings: {},
+  };
+}
+
+function severities(findings, msgPattern) {
+  return findings.filter(f => msgPattern.test(f.msg)).map(f => f.sev);
+}
+
+test('F5: .constructor access is a hard blocker', () => {
+  const src = `
+    export async function get() {
+      const p = Promise.constructor('return process')();
+      return { tip: p.env.GROQ_API_KEY };
+    }
+  `;
+  const findings = staticChecks(fm(), src);
+  assert.deepStrictEqual(severities(findings, /\.constructor/), ['error']);
+});
+
+test('F5: ["constructor"] bracket form is a hard blocker', () => {
+  const src = `
+    export async function get() {
+      const p = Promise["constructor"]('return process')();
+      return { tip: p.env.GROQ_API_KEY };
+    }
+  `;
+  const findings = staticChecks(fm(), src);
+  assert.deepStrictEqual(severities(findings, /bracket form/), ['error']);
+});
+
+test('F5: Reflect reference is a hard blocker', () => {
+  const findings = staticChecks(fm(), 'export async function get() { return Reflect.apply(x, [], []); }');
+  assert.deepStrictEqual(severities(findings, /Reflect/), ['error']);
+});
+
+test('F5: globalThis reference is a hard blocker', () => {
+  const findings = staticChecks(fm(), 'export async function get() { return globalThis.process.env; }');
+  assert.deepStrictEqual(severities(findings, /globalThis/), ['error']);
+});
+
+test('F5: __proto__ access is a hard blocker', () => {
+  const findings = staticChecks(fm(), 'export async function get() { return ({}).__proto__.constructor; }');
+  assert.deepStrictEqual(severities(findings, /__proto__/), ['error']);
+});
+
+test('F5: Object.getPrototypeOf is a hard blocker', () => {
+  const findings = staticChecks(fm(), 'export async function get() { return Object.getPrototypeOf({}); }');
+  assert.deepStrictEqual(severities(findings, /PrototypeOf/), ['error']);
+});
+
+test('F5: Object.setPrototypeOf is a hard blocker', () => {
+  const findings = staticChecks(fm(), 'export async function get() { Object.setPrototypeOf({}, null); }');
+  assert.deepStrictEqual(severities(findings, /PrototypeOf/), ['error']);
+});
+
+test('F5: payload hidden in string literal is still flagged via raw scan', () => {
+  // The pre-F5 review stripped string literals before scanning, so a
+  // payload like `Promise['cons'+'tructor']('return process')()` had
+  // every telltale token removed before the regexes ran. The raw scan
+  // catches the string-concat fragments.
+  const src = `
+    export async function get() {
+      // Comment to ensure stripping still runs
+      const tok = 'cons' + 'tructor';
+      const p = Promise[tok]('return ' + 'process')();
+      return { tip: 'k=' + p.env.GROQ_API_KEY };
+    }
+  `;
+  const findings = staticChecks(fm(), src);
+  // Raw scan should catch the concat-fragment pattern.
+  const concatHits = findings.filter(f => /string-concatenates/.test(f.msg));
+  assert.ok(concatHits.length > 0, 'expected raw-scan to flag concat fragments');
+});
+
+test('F5: clean code (no escape patterns) produces no error-level findings', () => {
+  const src = `
+    export async function get(arg) {
+      return { tip: 'hello ' + arg };
+    }
+  `;
+  const findings = staticChecks(fm(), src);
+  const errors = findings.filter(f => f.sev === 'error');
+  assert.deepStrictEqual(errors, [], `expected no errors, got: ${JSON.stringify(errors)}`);
+});
+
+test('F5: stripped scan still catches dynamic import as a hard blocker', () => {
+  // Pre-existing rule — confirm we didn't regress it.
+  const findings = staticChecks(fm(), 'export async function get() { return import("./x.js"); }');
+  assert.deepStrictEqual(severities(findings, /dynamic `import\(\)`/), ['error']);
+});
+
+test('F5: stripped scan still catches eval as a warning', () => {
+  const findings = staticChecks(fm(), 'export async function get() { return eval("1+1"); }');
+  assert.deepStrictEqual(severities(findings, /`eval\(`/), ['warn']);
+});


### PR DESCRIPTION
## Summary

- Pre-fix: `opencues review` flagged eval/Function/import()/Node-builtins but NOT `.constructor` chains. Worse, the scan stripped string literals first, so `Promise['cons'+'tructor']('return process')()` had every telltale token stripped before regex ran. A working F1 RCE PoC passed review with exit 0.
- Six new hard-blocker patterns added: `.constructor`, `["constructor"]`, `Reflect`, `globalThis`, `__proto__`, `Object.{get,set}PrototypeOf`.
- Dual-scan now: stripped (existing) PLUS raw (catches string-hidden payloads).
- String-concat-fragment detector flags `'cons'+'tructor'` / `'pro'+'cess'` style obfuscation.

INFOSEC findings doc, finding F5. Defence-in-depth — F1 (isolated-vm) is the structural fix.

## Test plan

- [x] 11 new tests in `review.test.cjs` covering each escape pattern, string-concat obfuscation, clean code, and pre-existing import()/eval heuristics
- [x] `lint-version-bump.sh` clean, `lint-legacy-names.sh` clean
- [ ] Manual: `opencues review <path>` against a blank with `Promise.constructor('return process')()` — expect exit 1 + error finding
- [ ] Manual: against a stealth variant using `'cons'+'tructor'` — expect at least the warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)