### PR TITLE
sec(doctor): surface unconfined scripted-blank count (INFOSEC F9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Security — `opencues doctor` surfaces the unconfined-blanks footgun (INFOSEC F9)
+
+The OS sandbox (`bwrap` / `sandbox-exec`) was already checked, but it's only wired on `blankScript: sandbox: strict` — blanks that don't declare `sandbox: strict` run with the user's full filesystem + network privileges regardless of whether the OS confiner is installed. Most real-world scripted blanks don't opt in, so the "I have bwrap installed, I'm safe" assumption silently held nothing.
+
+- **`opencues doctor`** — new `scanScriptedBlanks` helper iterates `~/.cues/blanks/` + `$OPENCUES_HOME/blanks/` and reports "X of Y scripted blanks declare `sandbox: strict`". When Y > X, prints a loud `bad` line + a `warn` finding naming up to 3 unwrapped blanks by folder name.
+- **Status quo** — does NOT flip the default to strict (would break trusted/first-party blanks; that's the F9 follow-up that needs separate review).
+- **4 new tests** in `doctor.scanblanks.test.cjs`: mixed strict/unstrict counted correctly, empty install returns zeros, built-in TS blanks (no `blankScript:`) are ignored, malformed frontmatter silently skipped.
+
 ### Added — per-call `with <model>` LLM dispatch override for fluid-blank and transform-blank
 
 Adds a `with <name>` token anywhere in the buffer before `_` (`make formal X with opus _`, `atomic number of oxygen with cerebras _`) to flip the dispatch target for ONE call without writing any scalar to disk. The next `_` keystroke without `with X` goes back to the configured bucket. Five-tier token resolution: common aliases (opus / haiku / sonnet / nano / mini / flash / gpt-oss / llama / claude / anthropic / cerebras / groq / openai / gemini / openrouter), provider id, exact model name, prefix in any `knownModels`, substring fallback. Always on — no scalar gates it.

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -769,6 +769,15 @@ module.exports = async function doctor(argv, ctx) {
   //   - Other → no confiner wired; falls through unwrapped.
   // See packages/opencues-runtime/src/security/sandbox-runner.ts §
   // wrapForPlatform for the dispatcher.
+  //
+  // F9 (INFOSEC): the sandbox is opt-in. A scripted blank that doesn't
+  // declare `sandbox: strict` runs with the user's full filesystem +
+  // network privileges regardless of whether bwrap/sandbox-exec is
+  // installed. We now also surface the count of installed scripted
+  // blanks that AREN'T opted in, so the unwrapped-by-default footgun
+  // is visible to the user instead of being something they have to
+  // discover by reading the F9 finding.
+  let sandboxMechanismOK = false;
   {
     const s = section('OS-level sandbox', 'wraps `blankScript: sandbox: strict` runs in an OS confinement layer');
     if (process.platform === 'linux') {
@@ -779,6 +788,7 @@ module.exports = async function doctor(argv, ctx) {
       })();
       const platLabel = wslEnv ? 'WSL2 (Linux)' : 'Linux';
       s.ok(`${platLabel}: bwrap (bubblewrap) on PATH`, !!bwrap);
+      sandboxMechanismOK = !!bwrap;
       if (!bwrap) {
         findings.push({
           sev: 'warn',
@@ -789,6 +799,7 @@ module.exports = async function doctor(argv, ctx) {
     } else if (process.platform === 'darwin') {
       const sbx = fs.existsSync('/usr/bin/sandbox-exec');
       s.ok(`macOS: sandbox-exec at /usr/bin/sandbox-exec (Apple seatbelt)`, sbx);
+      sandboxMechanismOK = sbx;
       if (!sbx) {
         findings.push({
           sev: 'warn',
@@ -803,6 +814,29 @@ module.exports = async function doctor(argv, ctx) {
         msg: `no OS sandbox available for platform "${process.platform}" — strict-sandbox blanks run unwrapped`,
         fix: 'use macOS or Linux/WSL2 for confined blanks; otherwise treat `sandbox: strict` as documentation only',
       });
+    }
+
+    // F9: scan installed scripted blanks and report how many are
+    // opt-in to strict sandbox vs running unconfined. Catches the
+    // common case where the user has bwrap installed but their
+    // blanks don't declare `sandbox: strict`, so it's a no-op.
+    const scriptedBlanks = scanScriptedBlanks(HOME);
+    if (scriptedBlanks.total > 0) {
+      const strictCount = scriptedBlanks.strict;
+      const unstrictCount = scriptedBlanks.total - strictCount;
+      if (unstrictCount === 0) {
+        s.ok(`scripted blanks declaring sandbox: strict (${strictCount}/${scriptedBlanks.total})`, true);
+      } else {
+        s.bad(`scripted blanks declaring sandbox: strict (${strictCount}/${scriptedBlanks.total}) — ${unstrictCount} run UNCONFINED`, false);
+        findings.push({
+          sev: sandboxMechanismOK ? 'warn' : 'warn',
+          msg: `${unstrictCount} of ${scriptedBlanks.total} installed scripted blanks have no \`sandbox: strict\` — they run with the user's full filesystem + network privileges` +
+               (scriptedBlanks.unstrictPaths.length ? `\n         examples: ${scriptedBlanks.unstrictPaths.slice(0, 3).join(', ')}` : ''),
+          fix: 'add `sandbox: strict` to the blank\'s BLANK.md frontmatter, or remove the blank if you don\'t trust it',
+        });
+      }
+    } else {
+      s.info('no scripted blanks installed', dim('— sandbox status N/A'));
     }
     s.render();
   }
@@ -1038,6 +1072,51 @@ async function maybePrintUpdateNotice(ctx) {
   } catch { /* fail-silent */ }
 }
 
+// F9 (INFOSEC): scan ~/.cues/blanks/ + $OPENCUES_HOME/blanks/ for
+// every BLANK.md that declares `blankScript:` and check whether it
+// also declares `sandbox: strict`. Returns the counts so doctor can
+// surface "X of Y scripted blanks run unconfined" — the unwrapped-
+// by-default footgun the F9 finding called out.
+//
+// Best-effort YAML — we only need to spot the two scalars. The
+// runtime's CUES.md / cues-md.ts parser is the authoritative one;
+// this is purely diagnostic.
+function scanScriptedBlanks(home) {
+  const roots = [
+    path.join(home, '.cues', 'blanks'),
+    process.env.OPENCUES_HOME ? path.join(process.env.OPENCUES_HOME, 'blanks') : null,
+  ].filter(Boolean);
+  const result = { total: 0, strict: 0, unstrictPaths: [] };
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    let entries;
+    try { entries = fs.readdirSync(root, { withFileTypes: true }); }
+    catch { continue; }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const blankMd = path.join(root, entry.name, 'BLANK.md');
+      if (!fs.existsSync(blankMd)) continue;
+      let text;
+      try { text = fs.readFileSync(blankMd, 'utf8'); }
+      catch { continue; }
+      const fmMatch = text.match(/^---\n([\s\S]*?)\n---/);
+      if (!fmMatch) continue;
+      const fm = fmMatch[1];
+      // Only count blanks that actually shell out.
+      const hasScript = /^\s*blankScript\s*:/m.test(fm);
+      if (!hasScript) continue;
+      result.total++;
+      const strictMatch = fm.match(/^\s*sandbox\s*:\s*(\w+)/m);
+      if (strictMatch && strictMatch[1] === 'strict') {
+        result.strict++;
+      } else {
+        result.unstrictPaths.push(entry.name);
+      }
+    }
+  }
+  return result;
+}
+
 // Read OPENCUES.md (or CUES.md) frontmatter and return a flat
 // {scalar: value} map. Best-effort YAML — only top-level
 // `key: value` lines, no nesting. Missing file → empty object.
@@ -1223,3 +1302,6 @@ function printHelp() {
   console.log('  --strict   Treat info findings as failures too. Suitable for use as');
   console.log('             a one-line CI gate or as the final step of scripts/pre-pr.sh.');
 }
+
+// Internal helpers exposed for testing. Not part of the public surface.
+module.exports._internal = { scanScriptedBlanks };

--- a/packages/opencues-cli/src/commands/doctor.scanblanks.test.cjs
+++ b/packages/opencues-cli/src/commands/doctor.scanblanks.test.cjs
@@ -1,0 +1,81 @@
+// Tests for `opencues doctor`'s F9 sandbox-status helper (INFOSEC F9).
+//
+// Pins the unwrapped-by-default footgun visibility: when scripted
+// blanks are installed without `sandbox: strict`, doctor must count
+// them so users see the exposure.
+
+'use strict';
+
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { _internal } = require('./doctor.cjs');
+const { scanScriptedBlanks } = _internal;
+
+let tmpHome;
+
+before(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-doctor-scan-'));
+});
+
+after(() => {
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+function writeBlank(name, frontmatter) {
+  const dir = path.join(tmpHome, '.cues', 'blanks', name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'BLANK.md'), `---\n${frontmatter}\n---\n\n# ${name}\n`);
+}
+
+test('F9: counts scripted blanks with sandbox: strict separately from unconfined', () => {
+  writeBlank('volume', 'name: volume\nblankScript: ./vol.sh\nsandbox: strict');
+  writeBlank('brightness', 'name: brightness\nblankScript: ./b.sh');
+  writeBlank('weather', 'name: weather'); // not scripted — should be ignored
+  writeBlank('risky', 'name: risky\nblankScript: ./r.sh\nsandbox: off');
+  const r = scanScriptedBlanks(tmpHome);
+  assert.strictEqual(r.total, 3, 'should count 3 scripted blanks (volume, brightness, risky)');
+  assert.strictEqual(r.strict, 1, 'only volume has sandbox: strict');
+  assert.deepStrictEqual(r.unstrictPaths.sort(), ['brightness', 'risky']);
+});
+
+test('F9: no scripted blanks → zero totals', () => {
+  const emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-doctor-empty-'));
+  try {
+    const r = scanScriptedBlanks(emptyHome);
+    assert.strictEqual(r.total, 0);
+    assert.strictEqual(r.strict, 0);
+    assert.deepStrictEqual(r.unstrictPaths, []);
+  } finally {
+    fs.rmSync(emptyHome, { recursive: true, force: true });
+  }
+});
+
+test('F9: ignores BLANK.md files without `blankScript:` (built-in TS blanks)', () => {
+  const tsHome = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-doctor-ts-'));
+  try {
+    const dir = path.join(tsHome, '.cues', 'blanks', 'answer');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'BLANK.md'), '---\nname: answer\nimpl: AnswerBlank\n---\n');
+    const r = scanScriptedBlanks(tsHome);
+    assert.strictEqual(r.total, 0, 'built-in TS blank should not be counted as scripted');
+  } finally {
+    fs.rmSync(tsHome, { recursive: true, force: true });
+  }
+});
+
+test('F9: malformed frontmatter is silently skipped (best-effort)', () => {
+  const wonkyHome = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-doctor-wonky-'));
+  try {
+    const dir = path.join(wonkyHome, '.cues', 'blanks', 'broken');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'BLANK.md'), 'no frontmatter here at all');
+    const r = scanScriptedBlanks(wonkyHome);
+    assert.strictEqual(r.total, 0);
+  } finally {
+    fs.rmSync(wonkyHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- F9 audit doc called out the unwrapped-by-default footgun: `sandbox: strict` is opt-in, so installing bwrap doesn't actually confine the blanks that don't declare it.
- `opencues doctor` now scans `~/.cues/blanks/` + `\$OPENCUES_HOME/blanks/` and prints `X of Y scripted blanks declare sandbox: strict`. Unwrapped count appears as a `bad` line + a `warn` finding naming up to 3 by folder.
- Does NOT change the default sandbox mode — flipping unconfined→strict is a breaking change for trusted blanks; tracking as F9 follow-up.

INFOSEC findings doc, finding F9.

## Test plan

- [x] 4 new tests in `doctor.scanblanks.test.cjs` covering mixed counts, empty install, built-in TS blanks ignored, malformed frontmatter
- [x] Manual: `opencues doctor` on a dogfood install — surfaced "scripted blanks declaring sandbox: strict (1/5) — 4 run UNCONFINED" with a warn naming brightness/opencues/sentinel
- [x] `lint-version-bump.sh` clean, `lint-legacy-names.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)