### PR TITLE
sec(user-blanks): F1 stopgap — load-time warn + honest audit (INFOSEC F1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Security — F1 stopgap: load-time warning + honest audit + tracked follow-up (INFOSEC F1)
+
+The critical finding from the static + dynamic security review: Node's `vm.runInContext` is NOT a security boundary against adversarial JS. `Promise.constructor('return process')()` reaches the host realm, then `process.env` exposes every API key and `child_process.execSync` runs arbitrary commands. Live-confirmed June 2026 against the shipped sandbox composition. The structural fix (migrate to `isolated-vm` or out-of-process Node with `--experimental-permission`) is ~1-2 weeks of integration work and a separate PR — this PR is the stopgap.
+
+- **`@opencues/runtime` (0.2.8 → 0.2.9)** — `node-loader.ts`:
+  - **Header comment rewritten** to reflect the actual security posture. The prior comment claimed the vm boundary was "well-understood" and primitive wrappers couldn't reach the host realm; that's false. New comment names the constructor-chain escape explicitly and points to the audit row + the F5 install-time defence.
+  - **One-time loud warn at first load per blank path**: `console.warn` AND the adapter log fire on first `loadUserBlank` for each unique `absJsPath`. Message mentions "INFOSEC F1", "FULL host privileges", "constructor-chain", and points at `opencues review`. Warn dedup'd via a per-process Set so steady-state operation isn't spammed.
+  - **`_resetF1WarnCache()`** exported for testing.
+- **5 new tests** in `node-loader.f1-warn.test.ts`: first load warns, subsequent loads silent, different paths each warn once, `_resetF1WarnCache` clears state, warn flows through the supplied adapter log.
+- **`security-audit.md` row #2** flipped 🟢 → 🟡 with accurate description: F5 install-time denylist + F1 load-time warn raise the bar but don't structurally close the gap. Concrete residual risk + the "treat `impl: ./blank.js` as fully trusted" warning included.
+- **`security-audit.md` § Open follow-ups** new entry: "#2 (vm-sandbox escape — INFOSEC F1)" — names `isolated-vm` vs out-of-process Node as the two candidate fixes, sketches integration cost + the chrome-bundle native-module consideration. Pairs with the existing #17 Windows-sandbox follow-up.
+
+This PR does NOT change runtime behaviour for legitimate users — packs that loaded before still load. It adds visibility so users + developers understand the trust model is "fully trusted, gated by install-time review" rather than "sandboxed."
+
 ### Added — per-call `with <model>` LLM dispatch override for fluid-blank and transform-blank
 
 Adds a `with <name>` token anywhere in the buffer before `_` (`make formal X with opus _`, `atomic number of oxygen with cerebras _`) to flip the dispatch target for ONE call without writing any scalar to disk. The next `_` keystroke without `with X` goes back to the configured bucket. Five-tier token resolution: common aliases (opus / haiku / sonnet / nano / mini / flash / gpt-oss / llama / claude / anthropic / cerebras / groq / openai / gemini / openrouter), provider id, exact model name, prefix in any `knownModels`, substring fallback. Always on — no scalar gates it.

--- a/docs/architecture/security-audit.md
+++ b/docs/architecture/security-audit.md
@@ -63,7 +63,7 @@ Status colour: 🟢 green = closed, 🟡 amber = closed with caveat, ⚪ N/A.
 | # | Attack class | Concrete threat | Defence | Residual risk | Status |
 |---|---|---|---|---|---|
 | 1 | Prompt injection via pack | Malicious word-cue prompt poisons every word | `RoutedWordSourceGroup` — per-word dispatch to ONE source; pack's prompt can only affect words its source claims | A domain-matching pack could still produce hostile alts for matched words. Bounded by `match:` scope. | 🟢 |
-| 2 | Malicious user-blank JS — eval/Function escape | Blank code uses `Function`/`eval` to break out of Worker harness | Worker harness embeds source at construction; no Function/eval used by runtime. Strict-CSP pages block it anyway. | A blank can still call user-provided Function inside its own code on non-CSP pages — but that runs IN the Worker, can't escape it. | 🟢 |
+| 2 | Malicious user-blank JS — sandbox escape | Blank code reaches the host realm via `Promise.constructor('return process')()` (constructor chain) or via `Reflect`/`globalThis`/`__proto__` proto-walk, then reads `process.env` / `child_process.execSync` for arbitrary command execution and secret theft | **PARTIAL (INFOSEC F1)**: Worker harness on chrome embeds source at construction (no Function/eval); strict-CSP pages block dynamic exec; `opencues review` denylist refuses `.constructor` / `Reflect` / `globalThis` / `__proto__` / `getPrototypeOf` at install time (F5); node-loader emits a one-time loud warn on first load surfacing the "full host privilege" reality. **NOT closed structurally**: `vm.runInContext` is NOT a security boundary when host-realm objects are shared into the context (Node's own docs say so); a constructor-chain escape was live-confirmed June 2026 against the shipped sandbox composition. | A custom `impl: ./blank.js` pack that passes `opencues review` clean and avoids the static patterns still gets full host privileges via any host-realm intrinsic exposed in the sandbox (Promise, URL, Date, Math, RegExp, setTimeout, console.log, ctx fns). **Real fix tracked in `Open follow-ups` below — replace `vm.runInContext` with `isolated-vm` (real V8 isolate) or out-of-process with `--experimental-permission`.** | 🟡 |
 | 3 | Malicious blank — ESM rewrite escape | Crafted source where `export default` inside a string survives parse but gets rewritten | AST-based rewriter via acorn — only syntactic `export default` is rewritten; string/template/comment literals are never touched. | None — AST parse is byte-exact. | 🟢 |
 | 4 | Malicious blank — dynamic import escape | Blank uses `import('./other.js')` to load unsandboxed code | acorn-walk catches `ImportExpression` at load time → throws "dynamic import not supported". | None. | 🟢 |
 | 5 | Network exfil via allow-list smuggle | Pack declares `network: [api.legit.com, evil.com]` and POSTs secrets to evil.com | Per-secret host binding (`secret-hosts.NAME: [host]`). `ctx.fetch` scans URL/headers/body for bound secret values; refuses unbound hosts. **Required** — a blank that declares `secrets:` without matching `secret-hosts.<NAME>` is refused at load time. | None. | 🟢 |
@@ -91,6 +91,18 @@ Status colour: 🟢 green = closed, 🟡 amber = closed with caveat, ⚪ N/A.
 
 The amber items each have a known next step:
 
+- **#2 (vm-sandbox escape — INFOSEC F1)** — `vm.runInContext` is not a
+  security boundary against adversarial JS. Real fix: migrate the
+  user-blank loader to `isolated-vm` (a real V8 isolate, fresh realm,
+  no host-object leakage) OR to an out-of-process Node child with
+  `--experimental-permission`. `isolated-vm` is a native module so it
+  needs build-time consideration for the chrome bundle path; the
+  out-of-process route is heavier but works under any bundling. Either
+  way, plan for ~1-2 weeks of integration work + a benchmark sweep
+  (per-invocation cost should stay sub-millisecond for the cache-hit
+  case). Until then: `opencues review` denylist (F5) + the load-time
+  warn (F1 stopgap) raise the bar but don't close the gap. Treat
+  `impl: ./blank.js` packs as fully trusted.
 - **#17** — Windows native still has no OS-sandbox wrapper.
   Investigate AppContainer / Job Objects when there's concrete demand.
 

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/user-blanks/node-loader.f1-warn.test.ts
+++ b/packages/opencues-runtime/src/user-blanks/node-loader.f1-warn.test.ts
@@ -1,0 +1,85 @@
+// Test for the F1 stopgap warn-once mechanism (INFOSEC F1).
+//
+// Pins:
+//   - First load of a blank emits a loud `console.warn` containing
+//     "INFOSEC F1" + "full host privileges".
+//   - Same blank loaded again is silent (warn-once per path).
+//   - Different blank paths each warn once.
+//   - `_resetF1WarnCache` clears the dedup set.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadUserBlank, _resetF1WarnCache } from './node-loader';
+
+let workdir: string;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-f1-warn-test-'));
+  _resetF1WarnCache();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  _resetF1WarnCache();
+  try { fs.rmSync(workdir, { recursive: true, force: true }); } catch { /* */ }
+});
+
+function writeBlank(name: string): string {
+  const p = path.join(workdir, name);
+  fs.writeFileSync(p, `export default { async get() { return 'hello'; } };`);
+  return p;
+}
+
+describe('F1 stopgap — loud warn at first load (INFOSEC F1)', () => {
+  it('emits a loud console.warn on first load mentioning INFOSEC F1 + host privileges', () => {
+    const p = writeBlank('a.js');
+    loadUserBlank(p, { capabilities: {} });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = String(warnSpy.mock.calls[0][0]);
+    expect(msg).toMatch(/INFOSEC F1/);
+    expect(msg).toMatch(/FULL host privileges/i);
+    expect(msg).toMatch(/constructor-chain/i);
+    expect(msg).toMatch(/opencues review/);
+  });
+
+  it('subsequent loads of the SAME blank path are silent (warn-once)', () => {
+    const p = writeBlank('a.js');
+    loadUserBlank(p, { capabilities: {} });
+    loadUserBlank(p, { capabilities: {} });
+    loadUserBlank(p, { capabilities: {} });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('different blank paths each warn once', () => {
+    const a = writeBlank('a.js');
+    const b = writeBlank('b.js');
+    loadUserBlank(a, { capabilities: {} });
+    loadUserBlank(b, { capabilities: {} });
+    loadUserBlank(a, { capabilities: {} }); // already-warned
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('_resetF1WarnCache clears the dedup set', () => {
+    const p = writeBlank('a.js');
+    loadUserBlank(p, { capabilities: {} });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    _resetF1WarnCache();
+    loadUserBlank(p, { capabilities: {} });
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('warn also flows through the supplied adapter log', () => {
+    const logCalls: Array<{ lvl: string; msg: string }> = [];
+    const p = writeBlank('a.js');
+    loadUserBlank(p, {
+      capabilities: {},
+      log: (lvl, msg) => logCalls.push({ lvl, msg: String(msg) }),
+    });
+    const warnLog = logCalls.find(c => c.lvl === 'warn' && /INFOSEC F1/.test(c.msg));
+    expect(warnLog).toBeDefined();
+  });
+});

--- a/packages/opencues-runtime/src/user-blanks/node-loader.ts
+++ b/packages/opencues-runtime/src/user-blanks/node-loader.ts
@@ -20,16 +20,49 @@
 //   - `Buffer`, `__dirname`, `__filename` — no Node primitives
 //   - The runtime's own globals (CueResolver, host adapters, etc.)
 //
-// The `vm.runInContext` boundary is well-understood. Known escape
-// vectors (prototype-chain walking to find the host realm) are
-// mitigated by:
+// SECURITY POSTURE — IMPORTANT (INFOSEC F1):
+//
+// Node's `vm` module is NOT a security boundary when host-realm
+// objects/functions are shared into the context. The Node docs say
+// so directly. The sandbox below shares `Promise`, `URL`, `Date`,
+// `Math`, `RegExp`, `setTimeout`, `console.log`, and every function
+// on `ctx` — every one of those exposes the host realm's `Function`
+// constructor via `.constructor`, and a host-realm `Function` resolves
+// free identifiers (`process`, `require`, `globalThis`) against the
+// HOST global scope. Concretely:
+//
+//   Promise.constructor('return process')()
+//     // returns the host's `process` — env vars, child_process, fs, …
+//
+// This is the F1 finding (live-confirmed June 2026). Treat `impl:
+// ./blank.js` packs as **full host privilege** today, not as
+// sandboxed code. Each one can read your env, spawn processes, and
+// touch any file the user has access to.
+//
+// **Real fix**: replace `vm.runInContext` with `isolated-vm` (a real
+// V8 isolate boundary) or out-of-process Node with `--experimental-
+// permission`. Tracked at docs/architecture/security-audit.md row #2.
+//
+// **Current stopgap**: a one-time loud warn fires on first load of
+// each blank name (see `_warnedBlankNames` below) so the developer
+// using `opencues run` is reminded that custom JS packs are
+// effectively trusted. `opencues review` (CLI) already refuses the
+// most common escape patterns (.constructor / Reflect / globalThis /
+// proto-walk) as hard blockers under F5 — install-time review +
+// load-time warn together raise the bar but do not close the gap.
+//
+// **What we DO mitigate (orthogonal to the vm boundary)**:
 //   - Each blank gets a FRESH context (no shared globals across
-//     invocations)
-//   - The context is created with `vm.createContext({})` — empty
-//     start, we add only what we want
-//   - User code can't traverse to the host realm via primitive
-//     wrappers because we don't expose primitive wrappers from the
-//     host (we expose fresh ones from inside the context).
+//     invocations).
+//   - `require` / `import` / `process` / `Buffer` / `__dirname` are
+//     not exposed; the loader's ESM rewriter rejects dynamic
+//     `import()`.
+//   - `ctx.fetch` enforces network allow-list + bound-secret
+//     destination control (F4).
+//   - `ctx.secrets` only contains names the blank declared.
+//
+// These limit the BLAST RADIUS of a benign-but-buggy blank. They do
+// not stop a deliberate constructor-chain escape.
 
 import * as vm from 'node:vm';
 import * as fs from 'node:fs';
@@ -138,6 +171,15 @@ export interface LoaderOptions {
   readonly timeoutMs?: number;
 }
 
+// F1 (INFOSEC) stopgap: track which JS paths we've already warned
+// about in this process, so the loud-warn fires once per unique blank
+// at first load and then stays silent. Cleared by `_resetF1WarnCache`
+// for tests.
+const _warnedBlankPaths = new Set<string>();
+export function _resetF1WarnCache(): void {
+  _warnedBlankPaths.clear();
+}
+
 /**
  * Load a user blank from disk into an isolated vm context.
  *
@@ -146,12 +188,36 @@ export interface LoaderOptions {
  * functions, but the functions themselves execute inside the sandbox.
  * Throws when the file can't be read, when the JS doesn't parse, or
  * when the exported shape is wrong.
+ *
+ * **F1 SECURITY POSTURE (June 2026)**: this loader uses `vm.runInContext`
+ * which is NOT a security boundary for adversarial JS. See the file
+ * header for the constructor-chain escape pivot. A one-time loud
+ * warn fires per blank path on first load.
  */
 export function loadUserBlank(absJsPath: string, opts: LoaderOptions): LoadedUserBlank {
   const source = fs.readFileSync(absJsPath, 'utf8');
   const folder = path.dirname(absJsPath);
   const caps = opts.capabilities;
   const log = opts.log ?? ((lvl, msg) => console.log(`[user-blank] [${lvl}] ${msg}`));
+
+  // F1 (INFOSEC) stopgap loud-warn — fires once per unique JS path
+  // per process. Surfaces the "this pack runs with full host
+  // privileges" reality so developers + users have visibility while
+  // the real isolated-vm migration is in progress. The warning lands
+  // on console.warn (visible in every host) AND through the adapter
+  // log (visible in /tmp/opencues.log for steady-state diagnostics).
+  if (!_warnedBlankPaths.has(absJsPath)) {
+    _warnedBlankPaths.add(absJsPath);
+    const msg =
+      `[opencues] loading custom JS blank: ${absJsPath}\n` +
+      `[opencues] WARNING (INFOSEC F1): user-blank JS runs with FULL host privileges.\n` +
+      `[opencues]   The Node \`vm\` sandbox does NOT contain adversarial code — a constructor-chain\n` +
+      `[opencues]   escape can reach the host's process, env vars, child_process, and fs.\n` +
+      `[opencues]   Only install blanks you trust. \`opencues review <pack>\` refuses the most\n` +
+      `[opencues]   common escape patterns at install time. Tracked at security-audit.md row #2.`;
+    try { console.warn(msg); } catch { /* swallow */ }
+    try { log('warn', msg); } catch { /* swallow */ }
+  }
 
   // Build the context proxy that gets injected into the sandbox.
   const ctx = buildBlankContext(caps, opts, log);


### PR DESCRIPTION
## Summary

**The critical finding.** Node's `vm.runInContext` is not a security boundary against adversarial JS — `Promise.constructor('return process')()` reaches the host realm, then `process.env` exposes every API key and `child_process.execSync` runs arbitrary commands. Live-confirmed June 2026 against the shipped sandbox composition.

**This PR is the stopgap, not the fix.** The structural fix (migrate to `isolated-vm` or out-of-process Node with `--experimental-permission`) is ~1-2 weeks of integration work and warrants a separate PR + benchmark sweep + chrome-bundle native-module consideration. Tracked as an Open follow-up in `security-audit.md`.

Stopgap changes:
- **Header comment in `node-loader.ts` rewritten** to reflect actual posture. The prior comment falsely claimed primitive wrappers couldn't reach the host realm. New comment names the constructor-chain escape explicitly.
- **One-time loud warn** on first load of each blank path. `console.warn` + adapter log. Dedup'd per-process so steady-state isn't spammed. Mentions "INFOSEC F1", "FULL host privileges", "constructor-chain", and points at `opencues review`.
- **`security-audit.md` row #2** flipped 🟢 → 🟡 with honest residual-risk description.
- **`security-audit.md` § Open follow-ups** gains an entry naming `isolated-vm` vs out-of-process as the candidate fixes + the integration cost.

INFOSEC findings doc, finding F1.

## Test plan

- [x] 5 new tests in `node-loader.f1-warn.test.ts` cover: first load warns, dedup works, different paths warn independently, `_resetF1WarnCache` works, warn flows through adapter log
- [x] All 24 node-loader tests + 52 user-blank tests still pass
- [x] `lint-version-bump.sh`, `lint-legacy-names.sh` clean
- [x] Runtime builds cleanly

## Notes — what this PR does NOT do

- Does NOT replace `vm.runInContext` with a real isolate. That's the real fix, tracked separately.
- Does NOT refuse to load `impl: ./blank.js` packs. Backwards-incompatible — would break every existing custom-JS install.
- Does NOT add a per-pack consent prompt at install time. `opencues review` (F5) is the install-time gate today; its denylist now refuses the most common escape patterns. A consent prompt would belong with the registry work tracked in the pre-registry follow-ups.

## Migration path for the real fix

When `isolated-vm` lands:
1. Add `isolated-vm` as a runtime dep (native module — needs build-time consideration for the chrome bundle path).
2. Replace `vm.createContext` + `vm.runInContext` with `IsolatedVM.createSnapshot` + `Isolate.createContext`.
3. Drop the F1 stopgap warn (the warn copy then becomes inaccurate).
4. Re-benchmark per-invocation cost — keep cache-hit case sub-ms.
5. Flip security-audit.md row #2 amber → green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)