### PR TITLE
fix(install): probe isolated-vm + document the native dep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,6 +490,7 @@ Bash-syntax-check every shell-script edit before handing back: `bash -n <file>`.
 
 ## Environment
 
+- **Native build dep**: `isolated-vm` (runtime sandbox, INFOSEC F1). Prebuilt binaries cover linux/darwin x64+arm64 + win32 x64; rare arches fall back to `node-gyp rebuild` which needs a C++ toolchain (`build-essential` + `python3` on Linux, `xcode-select --install` on macOS). `opencues install` probes the binding load and prints actionable platform-specific guidance if it can't — bypass with `OPENCUES_SKIP_NATIVE_PROBE=1` once verified.
 - **API Key**: `GROQ_API_KEY` for Groq (default provider)
 - **API Key**: `FINNHUB_API_KEY` for Finnhub (stock prices)
 - **Debug**: `DEBUG=cues*` for debug logging

--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ in `~/.opencues/vendor/` so `opencues uninstall <host>` cleans them
 up; system packages prompt for sudo once and stay where your package
 manager put them. Pass `--no-prompts` to skip every offer (CI mode).
 
+> **Native module fallback.** The runtime sandbox uses
+> [`isolated-vm`](https://github.com/laverdet/isolated-vm), a native
+> C++ binding. Prebuilt binaries cover linux/darwin x64+arm64 and
+> win32 x64 — those install without any toolchain. On rarer arches
+> (e.g. armv7, FreeBSD) `pnpm install` falls back to `node-gyp
+> rebuild`, which needs `build-essential` + `python3` on Linux or
+> `xcode-select --install` on macOS. The installer probes the binding
+> on every run; if it can't load, you get one actionable line with
+> the right fix for your platform before any host build starts.
+
 ### 2. Get an LLM API key
 
 **Cerebras is the recommended default** — same `gpt-oss-120b` weights

--- a/packages/opencues-cli/src/commands/install.cjs
+++ b/packages/opencues-cli/src/commands/install.cjs
@@ -118,6 +118,16 @@ module.exports = async function install(argv, ctx) {
   // auto-run `pnpm install` if any are missing.
   ensureWorkspaceDeps(ctx);
 
+  // Native-binding probe: `isolated-vm` ships prebuilt binaries for
+  // common platforms (linux/darwin x64+arm64, win32 x64), but rare
+  // arches fall back to `node-gyp rebuild` which silently fails when
+  // no C++ toolchain is present. pnpm reports install success either
+  // way; the per-host build then dies at `require('isolated-vm')`
+  // with a confusing TS2307. Probe the load AFTER deps are installed
+  // so users get actionable guidance early. Skip with
+  // OPENCUES_SKIP_NATIVE_PROBE=1 if you know your env is fine.
+  ensureNativeBindings(ctx);
+
   // Run seed-configs FIRST so the user-level ~/.cues/ tree is current
   // before any host installer runs. seed-configs handles all shared writes:
   // first-time copy, library-script sync, OPENCUES.md self-heal, .cs compile.
@@ -598,6 +608,53 @@ function ensureWorkspaceDeps(ctx) {
     process.exit(r.status ?? 1);
   }
   console.log('');
+}
+
+// Verify each declared native module loads. Today's only entry is
+// `isolated-vm` (used by the user-blanks JS sandbox — INFOSEC F1, June
+// 2026). When `pnpm install`'s postinstall hook drops back to
+// `node-gyp rebuild` and that fails for lack of a C++ toolchain,
+// pnpm's exit code can still report success but `require('isolated-vm')`
+// throws ENOENT for the .node binding. Detect the failure mode here
+// and print actionable platform-specific guidance instead of letting
+// the per-host build die at TS2307 mid-stream.
+function ensureNativeBindings(ctx) {
+  if (process.env.OPENCUES_SKIP_NATIVE_PROBE === '1') return;
+  const repoRoot = ctx.REPO_ROOT;
+  const runtimeDir = path.join(repoRoot, 'packages/opencues-runtime');
+  if (!fs.existsSync(path.join(runtimeDir, 'node_modules'))) return;
+
+  const { createRequire } = require('node:module');
+  const requireFromRuntime = createRequire(path.join(runtimeDir, 'package.json'));
+  try {
+    const ivm = requireFromRuntime('isolated-vm');
+    if (!ivm || typeof ivm.Isolate !== 'function') {
+      throw new Error('isolated-vm loaded but Isolate constructor missing');
+    }
+  } catch (err) {
+    console.log('');
+    console.error(`${tag('err')} native module ${bold('isolated-vm')} failed to load (${err.message})`);
+    console.error('');
+    console.error('   isolated-vm is a NATIVE C++ binding (required by the user-blanks');
+    console.error('   sandbox — INFOSEC F1). pnpm tried prebuild-install for your');
+    console.error('   platform; if no prebuilt binary matched, it fell back to compiling');
+    console.error('   via node-gyp, which needs a working C++ toolchain.');
+    console.error('');
+    const platform = process.platform;
+    if (platform === 'linux') {
+      console.error('   On Debian/Ubuntu/WSL:');
+      console.error('     sudo apt-get install build-essential python3');
+    } else if (platform === 'darwin') {
+      console.error('   On macOS:');
+      console.error('     xcode-select --install   # installs Apple\'s clang toolchain');
+    }
+    console.error('   Then re-run:');
+    console.error('     pnpm rebuild isolated-vm');
+    console.error('     pnpm exec opencues install <host>');
+    console.error('');
+    console.error(`   ${dim('Skip this probe with OPENCUES_SKIP_NATIVE_PROBE=1 once you\'ve verified the binding loads from packages/opencues-runtime/.')}`);
+    process.exit(1);
+  }
 }
 
 function runHostInstaller(host, action, extraArgs, ctx) {


### PR DESCRIPTION
## Summary

Replaces #111 (closed because force-push to update the stacked branch was policy-blocked after PR #110 merged).

- \`isolated-vm\` (added in b460076 to close INFOSEC F1) is a native C++ binding. pnpm's postinstall runs \`prebuild-install || node-gyp rebuild\`: prebuilt binaries cover linux/darwin x64+arm64 + win32 x64. Rare arches fall through to node-gyp, which silently fails without a C++ toolchain — pnpm still exits 0, the per-host build then dies at \`require('isolated-vm')\` with a confusing TS2307.
- New \`ensureNativeBindings\` probe in \`install.cjs\` (runs after #110's deps gate). On failure, prints the platform-specific fix (Debian \`build-essential\`, macOS \`xcode-select\`) plus rebuild + retry steps. Bypass with \`OPENCUES_SKIP_NATIVE_PROBE=1\`.
- README's "System prerequisites" + CLAUDE.md's "Environment" now name the dep so uncommon-platform users know what to expect before they hit the probe.

## Test plan

- [x] Simulated broken binding (moved \`isolated_vm.node\` aside) → probe fired with the full guidance block + exited 1
- [x] Restored binding → \`opencues install chrome --dry-run\` runs silently through the probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)