### PR TITLE
feat(cc): bump to 2.1.170 + seamless upgrade UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,8 @@ Two Claude Code installs exist on this machine. **OpenCues work targets `claude-
 |---|---|---|---|
 | `claude-cues` | `~/claude-code-cues` (local npm) | 2.1.110 (cli.js, pegged) | OpenCues patches applied here — npm cli.js shape |
 | `claude-cues-150` | `~/claude-code-cues-150` (local npm) | 2.1.150 (native bun-binary) | OpenCues patches applied here — native-binary shape (post-2.1.113 cutover) |
-| `claude-cues-158` | `~/claude-code-cues-158` (local npm) | 2.1.158 (native bun-binary) | OpenCues patches applied here — latest tested, same v2.1 adapter band as 150 (all 4 seams S1/S2/S3/S7 still hit) |
+| `claude-cues-158` | `~/claude-code-cues-158` (local npm) | 2.1.158 (native bun-binary) | OpenCues patches applied here — same v2.1 adapter band as 150 (all 4 seams S1/S2/S3/S7 still hit) |
+| `claude-cues-170` | `~/claude-code-cues-170` (local npm) | 2.1.170 (native bun-binary) | OpenCues patches applied here — **latest tested** (June 2026), same v2.1 adapter band; S6 still missing (gone since 2.1.150, statusline polls); S1/S2/S3/S7 all hit; agentic core suite (01/02/03/07/14) green |
 | `claude` | `~/.local/bin/claude` (native) | latest | Clean/unpatched — development use |
 
 - Both `claude-cues` and `claude-cues-150` are patched instances. `setup.sh` targets the cli.js fork; the native-binary fork is patched via tweakcc 4.0.13+'s `.bun` ELF section extract/repack.

--- a/integrations/claude-code/UPGRADING.md
+++ b/integrations/claude-code/UPGRADING.md
@@ -4,6 +4,41 @@ Runbook for moving the Claude Code integration from one upstream version to
 another. CC's distribution + patch surface have changed substantially across
 the 2.1.x line and this guide reflects the current state.
 
+## Are you a USER (your fork is behind) or a MAINTAINER (bumping the pin)?
+
+**User — your fork is at an older version, you want to catch up to the
+shipped `current-pin`:** one command.
+
+```bash
+git pull                           # gets the new compat.json from origin
+opencues update claude-code        # rewrites your fork's package.json pin
+                                   # + reinstalls + repatches
+# Restart Claude Code (close, then re-launch claude-cues)
+```
+
+That's the whole upgrade. The command is idempotent — re-running when
+already current prints `already at current-pin <ver> — nothing to do.`.
+
+**Cross-shape note (one-time, 2.1.111 → 2.1.113+):** Anthropic switched
+distribution shape from cli.js to a native bun-compile binary in 2.1.113.
+`opencues update` handles the cutover transparently — npm install drops
+the cli.js and writes the new `bin/claude.exe` into your fork's
+node_modules; tweakcc detects the shape and applies the right patch path.
+You don't need to do anything special. **However**, if you maintain a
+shell alias like `alias claude-cues='node ~/claude-code-cues/…/cli.js'`
+(the pre-2.1.113 shape), update it after upgrade — cli.js is gone:
+
+```bash
+alias claude-cues='~/claude-code-cues/node_modules/@anthropic-ai/claude-code/bin/claude.exe'
+```
+
+**Maintainer — you're validating a new upstream version and want to ship
+it as the default for everyone:** the runbook below ("The dance"). Probe
+seams, update `compat.json` + `CLAUDE.md` + the `tested:` array, run the
+agentic harness, commit.
+
+---
+
 ## TL;DR — the two patch shapes
 
 CC ships two different distribution shapes within the same minor line:
@@ -98,9 +133,11 @@ For the **native binary shape** (2.1.113+):
 npm pack @anthropic-ai/claude-code-linux-x64@<new-version> --pack-destination /tmp
 tar xzf /tmp/anthropic-ai-claude-code-linux-x64-*.tgz -C /tmp/cc-bin --strip-components=1
 # Tweakcc's nativeInstallation module extracts cli.js from the binary's
-# .bun ELF section. Use its CLI directly to dump for inspection:
+# .bun ELF section. Use its `unpack` subcommand to dump for inspection
+# (the env-var path is optional — `unpack` accepts the binary as a
+# positional too):
 cd integrations/claude-code/tweakcc
-TWEAKCC_CC_INSTALLATION_PATH=/tmp/cc-bin/claude node dist/index.mjs --dump-cli > /tmp/cc-bin-cli.js
+node dist/index.mjs unpack /tmp/cc-bin-cli.js /tmp/cc-bin/claude
 # Now grep for anchors against /tmp/cc-bin-cli.js the same way as above
 ```
 

--- a/integrations/claude-code/bin/install.cjs
+++ b/integrations/claude-code/bin/install.cjs
@@ -216,6 +216,12 @@ function doInstall() {
         // runtime bundle." Now the srcHash check rebuilds automatically
         // on drift; --rebuild is still useful for force-from-scratch.
         console.log(`  ${'\x1b[2m'}Pass${'\x1b[0m'} ${'\x1b[1m--rebuild\x1b[0m'} ${'\x1b[2m'}to force a nuke-and-reinstall from scratch.${'\x1b[0m'}`);
+        // Still fire the stale-alias detector — a user could be
+        // running `opencues install` post-upgrade purely as a sanity
+        // check, and they're equally affected by a stale alias in
+        // their shell rc. The detector is a no-op when nothing's
+        // stale.
+        warnStaleClaudeCuesAlias(fork);
         return;
       }
       console.log(`${'\x1b[33m▸\x1b[0m'} bundle stale (${drift.reason}). Rebuilding...`);
@@ -235,6 +241,14 @@ function doInstall() {
     process.exit(1);
   }
   console.log(`\n✓ ${fork.root} (${fork.shape}) installed + validated.`);
+
+  // Stale-alias detector. Pre-2.1.113 the launch alias pointed at
+  // `node <fork>/.../cli.js`. Post-cutover the fork ships a native
+  // bun-binary at `<fork>/.../bin/claude.exe` with NO cli.js — so the
+  // old alias is broken after the user upgrades. Doesn't auto-edit
+  // their shell rc (that's invasive); just prints the correct alias
+  // line and the rc paths that mention it.
+  warnStaleClaudeCuesAlias(fork);
 
   // Print the opt-in hint for the statusline. We install statusline.sh
   // into the fork's .cues/ dir but do NOT auto-edit ~/.claude/settings.json
@@ -674,6 +688,50 @@ function validateFork(fork) {
   fork.shape = liveShape;
   fork.target = liveShape === 'cli.js' ? cliJs : nativeBin;
   return { ok: true };
+}
+
+// Best-effort stale-alias detector. Greps the common shell rc files
+// (~/.bashrc, ~/.zshrc, ~/.bash_aliases, ~/.config/fish/config.fish)
+// for an `alias claude-cues=…` line that points at a cli.js path. If
+// we installed a native-binary shape, the cli.js path is dead and
+// running `claude-cues` after upgrade fails with "Cannot find
+// module". Print one info block with the correct line + the file
+// they need to edit. No write — that's invasive.
+function warnStaleClaudeCuesAlias(fork) {
+  if (fork.shape !== 'native') return; // cli.js fork — old alias still works
+  const candidates = [
+    path.join(HOME, '.bashrc'),
+    path.join(HOME, '.zshrc'),
+    path.join(HOME, '.bash_aliases'),
+    path.join(HOME, '.config', 'fish', 'config.fish'),
+  ];
+  const stale = [];
+  // Match: alias claude-cues=… that mentions cli.js. Allows quotes +
+  // bash/zsh/fish variants. Doesn't match an alias pointing at
+  // bin/claude.exe (already correct).
+  const re = /alias\s+claude-cues\s*[= ].*cli\.js/;
+  for (const f of candidates) {
+    if (!fs.existsSync(f)) continue;
+    try {
+      const lines = fs.readFileSync(f, 'utf8').split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (re.test(lines[i])) stale.push({ file: f, lineNo: i + 1, line: lines[i].trim() });
+      }
+    } catch { /* fail-silent */ }
+  }
+  if (stale.length === 0) return;
+  const correct = `alias claude-cues='${path.join(fork.root, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe')}'`;
+  console.log('');
+  console.log('\x1b[33mNote:\x1b[0m your shell config has a `claude-cues` alias pointing at the pre-2.1.113 cli.js path,');
+  console.log('which no longer exists after the upgrade to a native-binary CC version. Update it to:');
+  console.log('');
+  console.log(`  ${correct}`);
+  console.log('');
+  console.log('Detected stale alias in:');
+  for (const s of stale) {
+    console.log(`  ${s.file}:${s.lineNo}`);
+    console.log(`    \x1b[2m${s.line}\x1b[0m`);
+  }
 }
 
 function checkCompat(cliJsPath) {

--- a/integrations/claude-code/compat.json
+++ b/integrations/claude-code/compat.json
@@ -2,14 +2,14 @@
   "//": "OpenCues compatibility manifest for Claude Code. Read by `opencues update claude-code [--check|--to <version>]`. Keep in sync with manual testing — every time someone validates a new claude-code version, add it to `tested` (and bump `current-pin` if you want it to become the default).",
   "host-kind": "npm",
   "host-package": "@anthropic-ai/claude-code",
-  "current-pin": "2.1.158",
+  "current-pin": "2.1.170",
   "pin-location": {
     "kind": "npm-package-json",
     "path-from-fork": "package.json",
     "field": "dependencies.@anthropic-ai/claude-code",
     "fork-default": "~/claude-code-cues"
   },
-  "tested": ["2.1.110", "2.1.150", "2.1.158"],
+  "tested": ["2.1.110", "2.1.150", "2.1.158", "2.1.170"],
   "compat-range": "2.1.x",
   "//notes": {
     "binary-cutover": "2.1.113 (not 2.1.119 — that was an earlier guess). From 2.1.113 onward, @anthropic-ai/claude-code ships a thin Node wrapper + a bun-compile native binary in @anthropic-ai/claude-code-<platform>. Tweakcc 4.0.13+ extracts cli.js from the binary's .bun ELF section, patches the text, and repacks (handles ELF/MachO/PE). Same tweakcc anchor regexes work on both formats; the cli.js text inside the .bun section runs unchanged at startup (bun honours text over its own precompiled bytecode).",

--- a/integrations/claude-code/patches/setup.sh
+++ b/integrations/claude-code/patches/setup.sh
@@ -130,13 +130,20 @@ if [ -n "${OPENCUES_CC_TARGET:-}" ]; then
   #   <fork>/node_modules/@anthropic-ai/claude-code/bin/claude.exe  (4 dirs deep)
   # Pre-2.1.113 we only ever ran against cli.js. The native-binary
   # fork (2.1.113+) needs the extra hop. Detect by basename + adjust.
+  #
+  # Path resolution uses `realpath -m` (no-existence-required) so a
+  # FRESH fork (e.g. ~/claude-code-cues-170 with just a package.json
+  # and no node_modules yet) doesn't trip the `cd && pwd` form on
+  # missing intermediate dirs. node-pinned forks bootstrap their npm
+  # install in step 4; cd-based resolution would fail before that
+  # ever runs.
   _TARGET_BASENAME="$(basename "$OPENCUES_CC_TARGET")"
   case "$_TARGET_BASENAME" in
     cli.js)
-      CC_FORK_DIR="$(cd "$(dirname "$OPENCUES_CC_TARGET")/../../.." && pwd)"
+      CC_FORK_DIR="$(realpath -m "$(dirname "$OPENCUES_CC_TARGET")/../../..")"
       ;;
     claude.exe|claude)
-      CC_FORK_DIR="$(cd "$(dirname "$OPENCUES_CC_TARGET")/../../../.." && pwd)"
+      CC_FORK_DIR="$(realpath -m "$(dirname "$OPENCUES_CC_TARGET")/../../../..")"
       ;;
     *)
       echo "Error: OPENCUES_CC_TARGET basename '$_TARGET_BASENAME' not recognised." >&4

--- a/integrations/claude-code/patches/setup.sh
+++ b/integrations/claude-code/patches/setup.sh
@@ -131,19 +131,20 @@ if [ -n "${OPENCUES_CC_TARGET:-}" ]; then
   # Pre-2.1.113 we only ever ran against cli.js. The native-binary
   # fork (2.1.113+) needs the extra hop. Detect by basename + adjust.
   #
-  # Path resolution uses `realpath -m` (no-existence-required) so a
-  # FRESH fork (e.g. ~/claude-code-cues-170 with just a package.json
-  # and no node_modules yet) doesn't trip the `cd && pwd` form on
-  # missing intermediate dirs. node-pinned forks bootstrap their npm
-  # install in step 4; cd-based resolution would fail before that
-  # ever runs.
+  # Path resolution uses Node's `path.resolve` so a FRESH fork (e.g.
+  # ~/claude-code-cues-170 with just a package.json and no node_modules
+  # yet) doesn't trip the `cd && pwd` form on missing intermediate dirs.
+  # We can't use `realpath -m` here — that's a GNU coreutils flag and
+  # BSD realpath on macOS lacks it (see CLAUDE.md § "Cross-platform
+  # shell scripts"). Node is a hard install pre-req anyway, so shelling
+  # out gives a portable normalizer with no extra dependency.
   _TARGET_BASENAME="$(basename "$OPENCUES_CC_TARGET")"
   case "$_TARGET_BASENAME" in
     cli.js)
-      CC_FORK_DIR="$(realpath -m "$(dirname "$OPENCUES_CC_TARGET")/../../..")"
+      CC_FORK_DIR="$(node -e 'var p=require("path");process.stdout.write(p.resolve(p.dirname(process.argv[1]), "..", "..", ".."))' "$OPENCUES_CC_TARGET")"
       ;;
     claude.exe|claude)
-      CC_FORK_DIR="$(realpath -m "$(dirname "$OPENCUES_CC_TARGET")/../../../..")"
+      CC_FORK_DIR="$(node -e 'var p=require("path");process.stdout.write(p.resolve(p.dirname(process.argv[1]), "..", "..", "..", ".."))' "$OPENCUES_CC_TARGET")"
       ;;
     *)
       echo "Error: OPENCUES_CC_TARGET basename '$_TARGET_BASENAME' not recognised." >&4


### PR DESCRIPTION
## Summary

Bumps Claude Code's tested pin to **2.1.170** (latest on npm) and ships the supporting UX so existing users get a one-command upgrade.

User upgrade path:

\`\`\`bash
git pull && opencues update claude-code
\`\`\`

\`opencues update claude-code\` reads compat.json's current-pin (now 2.1.170), rewrites the fork's package.json, re-runs install, and tweakcc patches the new binary. Cross-shape transitions (cli.js → native binary, the 2.1.113 cutover) are handled transparently.

## Verification (manual + agentic harness)

- **Seam probe against 2.1.170**: S1/S2/S3 HIT (required), S7 HIT (render-kick), S6 MISS (expected — gone since 2.1.150, statusline falls back to polling).
- **Upgrade 158 → 170 locally**: \`opencues update claude-code\` rewrote ~/claude-code-cues/package.json + reinstalled cleanly + repatched.
- **Agentic core suite on upgraded canonical fork** (via \`oc-launch-cc-pty\` + scenario-runner):
  - 01-basic-cycling: 8/8 (361ms)
  - 02-clear-on-new-text: 8/8 (4.1s)
  - 03-tip-from-tips-cue: 6/6 (3.3s)
  - 07-event-stream-cycling: 10/10 (393ms)
  - 14-opencues-settings-cycle: 18/18 (2.2s)
- **Interactive launch**: confirmed working by the maintainer.

## Changes

- \`integrations/claude-code/compat.json\` — \`current-pin: "2.1.170"\` + appended to \`tested\` array.
- \`CLAUDE.md\` — new \`claude-cues-170\` row in the Claude Installs table; \`claude-cues-158\` row updated to remove the "latest tested" label.
- \`integrations/claude-code/patches/setup.sh\` — replaced \`cd && pwd\` (failed when the fork has no node_modules yet) with Node \`path.resolve\` (portable, no GNU-only flags; \`realpath -m\` would have broken macOS).
- \`integrations/claude-code/UPGRADING.md\` — new top-of-doc section distinguishing USER upgrades (one command) from MAINTAINER pin bumps (the existing runbook). Cross-shape alias caveat documented inline. Stale \`--dump-cli\` reference → \`unpack\`.
- \`integrations/claude-code/bin/install.cjs\` — new \`warnStaleClaudeCuesAlias()\` greps shell rc files for \`alias claude-cues=…cli.js\` and prints the correct native-binary line. Read-only; never edits the user's shell config. Fires on both the install path AND the "already healthy" short-circuit.

## What I did NOT touch

- **S6 seam regex** — gone since 2.1.150; current behaviour (polling fallback via \`statusLine.refreshInterval\`) is already working. Re-anchoring for event-driven refresh is an optional follow-up if statusline cycling feels laggy.

## Test plan

- [x] \`git pull && opencues update claude-code\` from a 158 fork → bumps to 170 cleanly
- [x] Agentic harness core suite green on upgraded fork
- [x] Interactive \`claude-cues\` launch works (maintainer-verified)
- [x] Stale-alias detector fires before fix, silent after
- [x] Fresh fork bootstrap (no node_modules yet) — setup.sh path resolution works

[skip version-bump] config + docs + CLI infra; no shipping runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)