### PR TITLE
fix(doctor): suppress arrow line for findings with no fix command

### DIFF
--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -1078,7 +1078,7 @@ module.exports = async function doctor(argv, ctx) {
   console.log(bold('## Suggested fixes'));
   for (const f of findings) {
     console.log(`  ${tag(f.sev === 'warn' ? 'warn' : 'info')} ${f.msg}`);
-    console.log(`     ${dim(G.arrow)} ${f.fix}`);
+    if (f.fix) console.log(`     ${dim(G.arrow)} ${f.fix}`);
   }
   await maybePrintUpdateNotice(ctx);
   const errors = findings.filter(f => f.sev === 'warn').length;


### PR DESCRIPTION
## Summary

PR #118 added info-level findings to `doctor.cjs` for fresh multi-fork CC dev installs (e.g. `~/claude-code-cues-158/` + `-170/`). These rows are purely informational — no action for the user to take, so no `fix:` field.

The renderer at `doctor.cjs:1081` unconditionally printed `→ ${f.fix}` even when `f.fix === undefined`, producing visible `→ undefined` lines in the doctor output.

Fix: only emit the arrow line when `f.fix` is set.

## Test plan

- [x] `opencues doctor` on a host with multi-fork dev installs no longer shows `→ undefined` under the info rows.
- [x] Warn-level findings (which still set `fix`) still render their fix command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)