### PR TITLE
fix(doctor): treat literal "default"/"inherit" as fall-through in LLM routing

### DIFF
--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -941,14 +941,45 @@ module.exports = async function doctor(argv, ctx) {
       if (autoPicked) return { provider: autoPicked, source: 'auto (env key)' };
       return { provider: null, source: 'none' };
     };
+    // Mirror normalizeModelScalar in opencues-runtime/src/modules/resolver.ts:
+    // literal "default"/"inherit"/empty in a *-llm-model scalar means
+    // "fall through" — the runtime resolves to the provider's
+    // defaultModel. Doctor must apply the same normalization or the
+    // displayed model misleads the user (e.g. shows "default" as if it
+    // were a real model name, when the runtime actually dispatches with
+    // the provider's default).
+    const normalizeBucketModel = (raw) => {
+      if (!raw) return undefined;
+      const t = String(raw).trim().toLowerCase();
+      if (t === '' || t === 'default' || t === 'inherit') return undefined;
+      return String(raw).trim();
+    };
     for (const bucketScalar of ['cues-llm-provider', 'auditors-llm-provider', 'blanks-llm-provider']) {
       const { provider, source } = resolveBucket(bucketScalar);
       const label = bucketScalar.replace('-llm-provider', '');
       if (provider) {
         const adapter = providers.getProvider(provider);
-        const model = scalars[bucketScalar.replace('provider', 'model')] || adapter?.defaultModel || '?';
+        const modelScalarName = bucketScalar.replace('provider', 'model');
+        const modelScalarRaw = scalars[modelScalarName];
+        const normalized = normalizeBucketModel(modelScalarRaw);
+        // Global fallback chain mirrors the runtime (build-sources.ts:
+        // effectiveGlobalModel + resolveLLM): bucket-model > global
+        // llm-model > provider defaultModel.
+        const globalLlmModel = normalizeBucketModel(scalars['llm-model']);
+        const model = normalized || globalLlmModel || adapter?.defaultModel || '?';
         const tag = source === bucketScalar ? '' : dim(` (← ${source})`);
         s.info(`${label}:`, `${provider} · ${model}${tag}`);
+        // Warn if the user wrote a literal "default"/"inherit" — it
+        // works (runtime treats it as fall-through) but it's confusing
+        // and a sign the menu cycle wrote a sentinel into a scalar
+        // expecting a real model name. Surface it so the user can
+        // clean it up.
+        if (modelScalarRaw && normalizeBucketModel(modelScalarRaw) === undefined) {
+          findings.push({
+            sev: 'info',
+            msg: `${modelScalarName}: "${modelScalarRaw}" is a fall-through sentinel — runtime treats it as unset and dispatches with ${model}. Delete this line if you want the global llm-model + provider default, or replace it with a real model name.`,
+          });
+        }
       } else {
         s.info(`${label}:`, dim('(none — no key + no scalar set)'));
       }


### PR DESCRIPTION
## Summary

Doctor's **LLM routing** section displayed `blanks-llm-model: default` literally:

```
LLM routing
├─ blanks:    cerebras · default
```

This contradicts the runtime: `normalizeModelScalar` in `resolver.ts` already treats literal `"default"` / `"inherit"` / `""` in any `*-llm-model:` scalar as unset, so the bucket falls through to the global `llm-model:` and finally the provider's `defaultModel`. Actual dispatch was already correct — `[cc][info] TransformBlank: starting (..., llm=cerebras/gpt-oss-120b)` — but the doctor display told users "your blanks bucket will send `model=default` to Cerebras," which is exactly the failure mode they hit earlier when chasing the silent `__oc.failed=true` regression.

## Fix

- Doctor's display now mirrors `normalizeModelScalar`: `default` / `inherit` / empty in a bucket-model scalar falls through to global `llm-model` → provider `defaultModel`. Display now matches what the runtime actually dispatches.
- New doctor **info** finding when a fall-through sentinel is observed: `blanks-llm-model: "default" is a fall-through sentinel — runtime treats it as unset and dispatches with gpt-oss-120b. Delete this line or replace with a real model name.` Informational, not a warning — the runtime works fine; the scalar is just clutter.

## Where the sentinel comes from (separate cleanup)

The sentinel landed in user OPENCUES.md files via the menu-cycle path when a bucket scalar was cycled to a value the menu offered but no provider exposes. Cleanup tracked separately: the selector/satellite write path shouldn't put `default` literal in a model scalar.

## Test plan

- [x] `opencues doctor` LLM routing display now reads `blanks: cerebras · gpt-oss-120b` (not `default`) when OPENCUES.md has `blanks-llm-model: default`.
- [x] Info finding surfaces under "Suggested fixes" with the right scalar name + the resolved model.
- [x] Runtime dispatch unchanged — verified via `/tmp/opencues.log`: `[cc][info] TransformBlank: starting (..., llm=cerebras/gpt-oss-120b)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)