### PR TITLE
fix(runtime): BlankFill skips keyword match inside substituted DynDef span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — BlankFill stops looping on substituted output that contains a registered keyword
+
+Concrete shape: `nvda _` substitutes to `Nvidia NVDA: $200.42`. The substituted span contains `nvidia` (one of the stocks blank's keywords). On the NEXT text-change BlankFill scanned the new buffer, matched `nvidia` against the next `_` in the buffer, and re-fired the substitute. Buffer kept looping; sibling blanks (`+ apple _`, `= _`) never got a stable scan to fire against. Canonical reproducer: `nvda _ + apple _ = _` — both sibling blanks got stuck in loading frames (`apple •`, `= •`) because nvda's loop kept resetting state.
+
+Fix: `BlankFill.matchKeyword` now consults `DynDefs.findSpanContaining` for each candidate keyword word index and skips matches that fall inside an already-substituted multi-word span. Single-word substitutions stay matchable (findSpanContaining only returns multi-word spans, mirroring how the broader runtime treats single-word DynDefs as the original-keyword-is-unchanged case).
+
+`@opencues/runtime` 0.3.2 → 0.3.3.
+
+Pinned by two new tests in `packages/opencues-runtime/src/modules/blank-fill.test.ts`:
+- `skips keyword match inside an already-substituted multi-word span`
+- `still matches keyword OUTSIDE substituted spans`
+
+Known follow-up (not in this PR): when two unique-keyword blanks are typed simultaneously (`nvda _ + apple _`), the first to substitute shifts word indices; the second one's invoke completes but its substitute may not write back cleanly. Tracked separately — needs a more careful look at how concurrent invokes coordinate with span writes.
+
 ### Fix — Multi-fork CC install fan-out + boot-smoke gate + per-fork drift advisory
 
 PR #117 (Claude Fable 5) added `packages/opencues-core/src/providers/claude-cli-daemon.ts`. `integrations/claude-code/patches/setup.sh` hard-coded the dist subdirs it copied into each fork (`sources` only), so the new `providers/` subdir was silently dropped at install time. The installed bundle's `@opencues/core/model-aliases.js` then `require('./providers/claude-cli-daemon')` blew up at boot, the CC patch's outer try/catch swallowed the error, and every CC session came up with `__oc.failed=true` — no cues, no blanks, no log line, no install error. The install reported `✓ installed + validated`.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/blank-fill.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.test.ts
@@ -5,6 +5,7 @@ import { MockAdapter, wrapTipsAsCuesMd } from '../../testing/mock-adapter';
 import { SpanFillState } from '../state/span-fill';
 import { DismissedBlanks } from '../state/dismissed-blanks';
 import { SelectorSatelliteState } from '../state/selector-satellite';
+import { DynDefs } from '../state/dyn-defs';
 
 const TIPS = wrapTipsAsCuesMd({ concepts: [] });
 
@@ -118,6 +119,96 @@ describe('BlankFill detection', () => {
     adapter.pushText('affirm _');
     expect(bf.slots).toHaveLength(1);
     expect(bf.slots[0].blankName).toBe('affirmations');
+  });
+
+  // Regression: stocks-chain loop (June 2026 — `nvda _ + apple _ = _`)
+  //
+  // BlankFill was looping on substituted output whose text contained a
+  // registered keyword. Concrete shape: `nvda _` → `Nvidia NVDA: $200.42`.
+  // The substituted span contained `nvidia` (one of the stocks blank's
+  // keywords); on the NEXT text-change BlankFill scanned the new buffer,
+  // matched `nvidia` against the still-present `_` further along, and
+  // re-fired the substitute. Buffer kept looping; sibling blanks
+  // (`apple _`, `= _`) never got a stable scan to fire against.
+  //
+  // Fix: matchKeyword skips candidates whose keyword indices fall
+  // inside an already-substituted multi-word DynDef span.
+  it('skips keyword match inside an already-substituted multi-word span', async () => {
+    const STOCKS = `---
+type: blank
+name: stocks
+blankKeywords: nvidia, nvda, apple, aapl
+blankProximity: 0
+---
+`;
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: {
+        '/mock/CUES.md': TIPS,
+        '/proj/blanks/stocks/BLANK.md': STOCKS,
+      },
+    });
+    const loader = new ConfigLoader(adapter);
+    await loader.load();
+    const dynDefs = new DynDefs();
+    // Mimic the post-substitute state: stocks substituted "nvda _" to
+    // "Nvidia NVDA: $200.42" (3 words, indices 0-2). DynDefs registers
+    // that span. The user then appends " + apple _", giving the full
+    // buffer "Nvidia NVDA: $200.42 + apple _" (7 words, _ at index 6).
+    dynDefs.set(0, {
+      originalWord: 'nvda',
+      alternatives: ['Nvidia NVDA: $200.42'],
+      currentIndex: 0,
+      spanStart: 0,
+      spanEnd: 20,
+      blankName: 'stocks',
+    });
+    const bf = new BlankFill(adapter, loader, undefined, undefined, undefined, dynDefs);
+    const slots = bf.scan('Nvidia NVDA: $200.42 + apple _');
+    // Only the apple slot at _ (index 6) should match. The substituted
+    // span's "Nvidia" / "NVDA:" must NOT be picked up as an
+    // nvidia/nvda keyword candidate.
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({
+      keyword: 'apple',
+      blankName: 'stocks',
+    });
+  });
+
+  it('still matches keyword OUTSIDE substituted spans', async () => {
+    const STOCKS = `---
+type: blank
+name: stocks
+blankKeywords: nvidia, nvda, apple
+blankProximity: 0
+---
+`;
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: {
+        '/mock/CUES.md': TIPS,
+        '/proj/blanks/stocks/BLANK.md': STOCKS,
+      },
+    });
+    const loader = new ConfigLoader(adapter);
+    await loader.load();
+    // Belt-and-braces: a DynDefs with a SINGLE-word substituted entry
+    // shouldn't suppress matches anywhere (findSpanContaining only
+    // returns multi-word spans). The "apple" keyword at index 0 should
+    // still match.
+    const dynDefs = new DynDefs();
+    dynDefs.set(2, {
+      originalWord: 'foo',
+      alternatives: ['BAR'],
+      currentIndex: 0,
+      spanStart: 6,
+      spanEnd: 9,
+      blankName: 'other',
+    });
+    const bf = new BlankFill(adapter, loader, undefined, undefined, undefined, dynDefs);
+    const slots = bf.scan('apple _ BAR');
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({ keyword: 'apple', blankName: 'stocks' });
   });
 });
 

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -1188,6 +1188,22 @@ export class BlankFill {
     // auto-populate the system volume even though the user can't see
     // or cycle the result.
     const supportsCycling = this.adapter.supportsCycling?.() ?? true;
+    // Skip candidate keyword matches that fall inside an already-
+    // substituted multi-word span. Without this guard, BlankFill loops
+    // on substituted output that contains a registered keyword:
+    // `nvda _` → `Nvidia NVDA: $200.42`; then `nvidia` (inside the
+    // substituted text) re-matches the stocks blank's `nvidia`
+    // keyword on every next text-change, re-firing the substitute
+    // forever and clobbering any sibling blanks (`+ apple _`, `= _`)
+    // that try to fire alongside it. The stocks-chain regression
+    // (June 2026) is the canonical incident — `nvda _ + apple _ = _`
+    // produced "apple •" + "= •" stuck loading because nvda kept
+    // re-substituting and reset the resolver's state.
+    const indexInsideSubstitutedSpan = (idx: number): boolean => {
+      if (!this.dynDefs) return false;
+      const span = this.dynDefs.findSpanContaining(idx);
+      return span !== null;
+    };
     for (let j = blankIdx - 1; j >= 0; j -= 1) {
       for (const [name, blank] of this.configLoader.blanks.entries()) {
         const blankKeywords = (blank as { blankKeywords?: readonly string[] }).blankKeywords;
@@ -1218,6 +1234,18 @@ export class BlankFill {
             }
           }
           if (matches) {
+            // Reject the match if any word in the keyword span sits
+            // inside an already-substituted multi-word DynDef span.
+            // See `indexInsideSubstitutedSpan` declaration above for
+            // the bug class this prevents.
+            let insideSubstitute = false;
+            for (let k = 0; k < kwWords.length; k += 1) {
+              if (indexInsideSubstitutedSpan(start + k)) {
+                insideSubstitute = true;
+                break;
+              }
+            }
+            if (insideSubstitute) continue;
             return {
               index: blankIdx,
               keyword: kwLc,


### PR DESCRIPTION
## Summary

`BlankFill` looped on substituted output whose text contained a registered keyword. Canonical reproducer + symptom you reported:

```
type: nvda _ + apple _ = _
got:  Nvidia NVDA: $200.42 + apple • = •     (apple + = stuck loading forever)
```

`nvda _` substitutes to `Nvidia NVDA: $200.42`. The substituted span contains `nvidia` (one of the stocks blank's keywords). On the next text-change BlankFill scanned the new buffer, matched `nvidia` against the next `_` further along, and re-fired the substitute. Buffer kept looping; sibling blanks (`+ apple _`, `= _`) never got a stable scan to fire against, so they sat in their loading frames forever.

Event-stream evidence on the pre-fix run:

```
blank.substituted nvda → NVDA: $200.42  (ts 218140)
blank.substituted apple → AAPL: $291.58 (ts 316164)
blank.substituted nvda → NVDA: $200.42  (ts 339598)  ← repeat
blank.substituted nvda → NVDA: $200.42  (ts 415878)  ← repeat
blank.substituted nvda → NVDA: $200.42  (ts 576113)  ← still firing
```

## Fix

`BlankFill.matchKeyword` now consults `DynDefs.findSpanContaining` for each candidate keyword word index and skips matches that fall inside an already-substituted multi-word span. `findSpanContaining` only returns multi-word spans (≥2 words), so single-word substitutions stay matchable — that's the mirror of how the broader runtime treats single-word DynDefs as the original-keyword-is-unchanged case.

## Test plan

Two regression tests pinned in `blank-fill.test.ts`:

- `skips keyword match inside an already-substituted multi-word span` — simulates the post-`nvda _` substitute state (DynDef span 0-2 with `Nvidia NVDA: $200.42`); scans `Nvidia NVDA: $200.42 + apple _`; expects only the apple slot to match.
- `still matches keyword OUTSIDE substituted spans` — belt-and-braces; DynDefs has a single-word substitute elsewhere, the apple keyword outside any span still matches.

All 1642 runtime tests pass.

## Known follow-up (separate PR)

After this fix, the harness still shows `apple •` and `= •` stuck. Event-stream evidence:

```
blank.invoked apple   (ts 910189)
blank.substituted nvda  (ts 910371)
```

apple's invoke fires but its substitute never lands. This is a SEPARATE bug — concurrent invokes coordinating with span writes — and is being tracked as a follow-up. This PR ships the loop fix because (1) it eliminates the most visible symptom, (2) the fix is structurally tight + well-tested, and (3) the concurrent-invoke bug is harder to reproduce reliably and needs its own focused investigation.

## Version

`@opencues/runtime` 0.3.2 → 0.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)