### PR TITLE
fix(chrome): LinkedIn Quill caret stays put across agent-rewrite ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — LinkedIn Quill share composer: caret stays put across agent-rewrite ticks
+
+`agentically <task> _` on LinkedIn's share composer caused the caret to jump to end-of-buffer on every debounce tick (~1500ms). The runtime's `pushText(text, cursor)` was already feeding chrome's boot a correctly-translated caret position via `AgentRewrite.translateCursor`, and chrome's handler did re-apply via `writeCursorOffset(cursor, true)` + one `requestAnimationFrame`. But LinkedIn's Quill SelectionObserver reconciles ONE frame after our first RAF and snaps the browser selection to Quill's internal model position (end of the last `execCommand('insertText')` in `replaceAllText`'s Quill fallback path). One RAF wasn't enough to outlast the reconcile.
+
+Fix: extracted the cursor re-apply into a `reapplyCursor` helper that schedules sync + RAF + nested-RAF + `setTimeout(0)`. The nested-RAF lands after Quill's reconcile microtask; the `setTimeout(0)` tail catches the rare case where the reconcile slips past two frames. Idempotent on editors that don't fight (LinkedIn messaging composer, ProseMirror/Lexical) — the extra calls are no-ops there. `pushText` and `setCursorOffset` both route through the helper for consistency.
+
+Chrome 0.2.5 → 0.2.6 (manifest.json + package.json lockstep).
+
 ### Fix — Multi-fork CC install fan-out + boot-smoke gate + per-fork drift advisory
 
 PR #117 (Claude Fable 5) added `packages/opencues-core/src/providers/claude-cli-daemon.ts`. `integrations/claude-code/patches/setup.sh` hard-coded the dist subdirs it copied into each fork (`sources` only), so the new `providers/` subdir was silently dropped at install time. The installed bundle's `@opencues/core/model-aliases.js` then `require('./providers/claude-cli-daemon')` blew up at boot, the CC patch's outer try/catch swallowed the error, and every CC session came up with `__oc.failed=true` — no cues, no blanks, no log line, no install error. The install reported `✓ installed + validated`.

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -738,6 +738,30 @@ function writeCursorOffset(offset: number, force: boolean = false): void {
   sel.addRange(range);
 }
 
+/** Re-apply the caret across multiple frames + a tail timeout so it
+ *  sticks past managed editors' selection reconcile. LinkedIn's Quill
+ *  share composer is the load-bearing case: its SelectionObserver
+ *  normalizes the browser selection to its internal model position one
+ *  frame after our first RAF, snapping the caret back to end-of-buffer.
+ *  A 2-frame + setTimeout(0) tail catches the reconcile and lands the
+ *  caret at the runtime-translated position. Idempotent on editors that
+ *  don't fight — the extra calls are no-ops.
+ *
+ *  If the user moves the caret between calls (e.g. clicks elsewhere
+ *  during the ~16ms window), the later calls will re-snap to our
+ *  target — accepted trade-off: agent-rewrite ticks are debounced
+ *  ~1500ms apart, so the re-snap window is short relative to typing
+ *  cadence and overwhelmingly the user benefit is cursor-stays-where-
+ *  it-was-typed rather than cursor-jumps-to-end. */
+function reapplyCursor(offset: number): void {
+  writeCursorOffset(offset, true);
+  requestAnimationFrame(() => {
+    writeCursorOffset(offset, true);
+    requestAnimationFrame(() => writeCursorOffset(offset, true));
+  });
+  setTimeout(() => writeCursorOffset(offset, true), 0);
+}
+
 /** Apply newText to the target by mutating existing text nodes in
  *  place — common-prefix/common-suffix diff, splice the difference
  *  into whichever node(s) the change falls in.
@@ -2380,8 +2404,7 @@ export function startOpenCues(opts: RuntimeStartOptions = {}): BootResult {
     // We also re-apply after a frame so the managed editor's
     // post-reconcile cursor snap doesn't override us.
     setCursorOffset: (offset) => {
-      writeCursorOffset(offset, true);
-      requestAnimationFrame(() => writeCursorOffset(offset, true));
+      reapplyCursor(offset);
     },
     pushText: (text, cursor) => {
       // diffWriteText already calls sourceReclassifier.markRuntimeWrite.
@@ -2390,12 +2413,14 @@ export function startOpenCues(opts: RuntimeStartOptions = {}): BootResult {
       diffWriteText(text);
       // pushText cursor came from the runtime (substitution landing
       // position) — force the move even on managed editors, and
-      // re-apply after a frame so the editor's reconcile doesn't
-      // snap the caret back to its model's idea of "natural" position.
-      if (cursor !== undefined) {
-        writeCursorOffset(cursor, true);
-        requestAnimationFrame(() => writeCursorOffset(cursor, true));
-      }
+      // re-apply across multiple frames so the editor's reconcile
+      // doesn't snap the caret back to its model's idea of "natural"
+      // position. LinkedIn's Quill share composer specifically reconciles
+      // its SelectionObserver one frame AFTER our first RAF — a single
+      // RAF re-apply isn't enough; the agent-rewrite tick would land the
+      // caret at end-of-buffer on every ~1500ms tick instead of the
+      // translated position. See reapplyCursor for the schedule.
+      if (cursor !== undefined) reapplyCursor(cursor);
     },
     forceRender: () => {
       runtimeRender();


### PR DESCRIPTION
## Summary

- `agentically <task> _` on LinkedIn's share composer (Quill) caused the caret to jump to end-of-buffer on every ~1500ms agent-rewrite tick. The runtime's `pushText(text, cursor)` already passed a correctly-translated caret position, and chrome's handler did re-apply via `writeCursorOffset(cursor, true)` + one `requestAnimationFrame` — but Quill's `SelectionObserver` reconciles ONE frame later and snaps the browser selection to its internal model position (end of last `execCommand('insertText')` in `replaceAllText`'s Quill fallback).
- Extracted the re-apply into `reapplyCursor`: sync + RAF + nested-RAF + `setTimeout(0)`. The nested-RAF lands after Quill's reconcile microtask; `setTimeout(0)` is a belt-and-braces tail for the rare case the reconcile slips past two frames.
- Idempotent on editors that don't fight (LinkedIn messaging composer, Lexical, ProseMirror) — the extra calls are no-ops there.
- Chrome 0.2.5 → 0.2.6 (manifest.json + package.json lockstep).

## Diagnosis trail

Verified the runtime side is correct on a non-chrome host first: spun up opencode via the agentic harness, armed `agentically correct spelling _`, typed `I beleive the recieved report was incorect about the seperate issues` → all four words corrected, four `agent-task` DynDefs placed, caret stayed at the translated logical position. So the issue lives in chrome's pushText handler, not the runtime's `AgentRewrite.translateCursor`.

User confirmed scope: only Quill boxes (LinkedIn share composer); LinkedIn messaging composer (PR #93) and other managed editors are fine. That isolates the bug to a host that has a SelectionObserver that fights against browser-level selection sets — Quill is the only one in our matrix that does this.

## Test plan

- [ ] Load chrome 0.2.6 on linkedin.com, open share composer
- [ ] Arm `agentically correct spelling _`
- [ ] Type a multi-line message with misspellings (`I beleve we shuld try this approch.`)
- [ ] After each ~1500ms rewrite tick, caret should remain where the user is typing, not jump to end of buffer
- [ ] Existing flows still work:
  - [ ] LinkedIn share composer: `draft an email _` substitutes paragraphs correctly (smoke from PR #91)
  - [ ] LinkedIn messaging composer: Send button enables after substitute (smoke from PR #93)
  - [ ] Lexical/Reddit, ProseMirror/Claude.ai, generic CE — no regressions
- [ ] Pre-PR gates: `bash scripts/pre-pr.sh` green except the pre-existing local-env doctor warnings (stale CC forks etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)