### PR TITLE
fix(chrome): narrow agent-rewrite Quill exclusion to LinkedIn share composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — Chrome narrows `supportsAgentRewrite: false` to LinkedIn share composer only
+
+PR #125 disabled `supportsAgentRewrite` for **every** `.ql-editor` on the page, intending to scope to LinkedIn's share composer (where Delta+MutationObserver fights cause caret snap-back). But LinkedIn comment boxes are also Quill instances, so they got swept up — `agentically X _` in a LinkedIn comment was silently wiped instead of running. Symptom reported 2026-06-12.
+
+The original caret-snap bug is specific to the share composer's lifecycle (post-creation modal + inline "Start a post" surface + legacy share-box widget). Comment boxes, messaging compose, and the article editor are also Quill but don't exhibit the same multi-tick storm. Narrowed the detection with a new `isLinkedInShareComposerQuill` predicate that requires both `.ql-editor` AND an ancestor matching one of:
+
+- `.share-creation-state` — modal share composer wrapper
+- `.share-box-feed-entry__form` — inline "Start a post" surface
+- `.share-box` — broadest legacy class; covers older variants
+
+If another Quill site reproduces the same caret-snap class of bug, add its detection marker to the predicate. Default-deny stays on the share composer where the structural problem is verified; everything else gets the feature back.
+
+Chrome 0.2.7 → 0.2.8 (manifest + package lockstep).
+
 ### Feature — Per-target `supportsAgentRewrite` capability; chrome opts Quill out
 
 After PR #122 (0.2.5 → 0.2.6) — the first attempt to fix LinkedIn's "cursor jumps on agent-rewrite tick" symptom by reapplying caret across more frames — failed in production, we walked through a sequence of further attempts each landing on a different theory: caret-color cosmetic hide, paragraph-level in-place mutation, line-level in-place mutation, hunk-level in-place mutation via the runtime's `wordDiff`, and a `pushText` flag to suppress an explicit cursor restore after a successful in-place write. Each was a structural improvement on its own — chrome ships them — but none fully fixed the user-visible bug. The remaining root cause: Quill's Delta-model selection doesn't sync from browser-set selections after a write. Even when we got the right characters into the right text nodes, Quill's internal cursor was still anchored at the wrong place, so every subsequent keystroke landed in the wrong location and broke the feature.

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -649,6 +649,40 @@ function isQuillEditor(el: HTMLElement): boolean {
   return !!el.closest('.ql-editor');
 }
 
+/**
+ * Narrower variant: the SPECIFIC Quill instance LinkedIn ships in its
+ * share composer (the post-creation modal at the top of the feed).
+ * That's the surface PR #125 disabled agent-rewrite on — Delta-model
+ * + MutationObserver fighting the multi-tick replaceAllText path.
+ *
+ * Comment boxes ARE Quill too but they live in a different DOM context
+ * (`.comments-comment-box`, `.comments-comment-texteditor`, …) with a
+ * different lifecycle and don't show the same caret-snap bug at agent
+ * cadence. Without the narrowing, "agentically X _" in a LinkedIn
+ * comment was silently wiped instead of running — symptom reported
+ * 2026-06-12.
+ *
+ * Detection markers (any one is sufficient — LinkedIn ships multiple
+ * variants of the share composer DOM across A/B rollouts):
+ *   - `.share-creation-state`         — modal share composer wrapper
+ *   - `.share-box-feed-entry__form`   — inline "Start a post" surface
+ *   - `.share-box`                    — broadest historical class; covers
+ *                                       the legacy widget shape too.
+ *
+ * Any `.ql-editor` outside one of those ancestors (today: comment boxes,
+ * messaging compose, article editor) is treated as agent-rewrite-eligible.
+ * If a different Quill site later reproduces the same caret-snap class
+ * of bug, add its detection marker here.
+ */
+function isLinkedInShareComposerQuill(el: HTMLElement): boolean {
+  if (!el.closest('.ql-editor')) return false;
+  return !!(
+    el.closest('.share-creation-state') ||
+    el.closest('.share-box-feed-entry__form') ||
+    el.closest('.share-box')
+  );
+}
+
 /** Walk up from a `.ql-editor` to find the Quill editor instance. Quill
  *  stashes itself on the container element (`.ql-container`) as
  *  `__quill`. Falls back to checking the immediate root + walking
@@ -2689,7 +2723,7 @@ export function startOpenCues(opts: RuntimeStartOptions = {}): BootResult {
     // Delta-model selection-shift handles correctly. The runtime gate
     // wipes the `agentically X _` trigger phrase cleanly but doesn't
     // arm an AgentTask on Quill. See adapter.ts § supportsAgentRewrite.
-    supportsAgentRewrite: () => !(currentTarget && isQuillEditor(currentTarget)),
+    supportsAgentRewrite: () => !(currentTarget && isLinkedInShareComposerQuill(currentTarget)),
     // Ambient-context gatherer — gated by the `ambient-context-mode`
     // scalar on the runtime side. Returns null for sensitive fields
     // and when no usable metadata is present. See gatherAmbientContext


### PR DESCRIPTION
## Summary

PR #125 disabled `supportsAgentRewrite` for **every** `.ql-editor` on the page, intending to scope to LinkedIn's share composer (where Delta+MutationObserver fights cause caret snap-back during agent-rewrite ticks). But LinkedIn comment boxes are also Quill instances. Result: `agentically X _` typed in a LinkedIn comment was **silently wiped** instead of running — Resolver rewrote TASK_ARM/TASK_ADD to a no-op that trimmed the trigger phrase but didn't arm anything. User report 2026-06-12.

The original caret-snap class of bug is specific to the **share composer** (post-creation modal + inline "Start a post" surface + legacy `.share-box` widget). Comment boxes, messaging compose, and the article editor are Quill too but use different lifecycle hooks and don't exhibit the same multi-tick storm.

## Fix

New predicate `isLinkedInShareComposerQuill` requires both `.ql-editor` AND an ancestor matching one of:

- `.share-creation-state` — modal share composer wrapper
- `.share-box-feed-entry__form` — inline "Start a post" surface
- `.share-box` — broadest legacy class; covers older A/B variants

If a future Quill site reproduces the same caret-snap class of bug, append its detection marker to the predicate. Default-deny stays on the share composer where the structural problem is verified; everything else gets agent-rewrite back.

## Version

`@opencues/chrome` 0.2.7 → 0.2.8 (manifest.json + package.json lockstep per CLAUDE.md "bump both" rule).

## Test plan

- [x] `pnpm --filter @opencues/chrome test` → 186 / 186 pass.
- [ ] Manual: in a LinkedIn **comment box**, type `agentically make it more formal _`. Verify the buffer rewrites + task arms (was silently wiped before).
- [ ] Manual: in the LinkedIn **share composer**, type `agentically X _`. Verify the trigger phrase still wipes without arming (no regression on PR #125's caret fix).
- [ ] Manual: outside LinkedIn (any other Quill site), verify agent-rewrite works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)