### PR TITLE
fix(runtime): statusline hides for any word inside fluid/transform/agent substitute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — Statusline shows nothing for any word inside a fluid/transform/agent-rewrite substitute
+
+`statusline.ts:buildPayload` used `this.dynDefs.get(wordIndex)` to find the DynDef at the highlighted word, then suppressed the tip when `def.blankName` was set (fluid-blank / transform-blank / agent-rewrite substitutes shouldn't surface tips because the substituted text was emitted by the LLM, not authored by the user). But `dynDefs.get(wordIndex)` only matches the **origin** word index of a multi-word span. When the highlight landed on word N>origin INSIDE a multi-word substitute, `def` came back undefined and the function fell through to the word-cue lookup at the bottom, which surfaced a tip for the individual LLM-emitted word.
+
+User report 2026-06-13 (chrome): "tips when we highlight the modified text. It should not have any tips for now." → in chrome's floating statusbar this surfaced as `word (N/M) - tip` for a word the LLM picked, not the user.
+
+Fix: when `dynDefs.get(wordIndex)` misses, fall back to `dynDefs.findSpanContaining(wordIndex)` so the origin def of any multi-word span containing this word is picked up. The existing `if (def?.blankName)` branch then suppresses the tip + sets `cueBlank: true` for the whole span uniformly. Chrome's runtime-statusbar handles `cueBlank: true && cueTip: null` → `combined === null` → `hide()`, so the floating div fully disappears for any navigation into a substitute (no word, no `(N/M)`, no tip).
+
+CC behaviour unchanged in practice (cursor-navigate lands on origin word indices for multi-word DynDefs, so the original `dynDefs.get` already matched there) — the fix is structurally defensive for any host whose cursor model walks inside multi-word spans.
+
+`@opencues/runtime` 0.3.4 → 0.3.5.
+
 ### Fix — Chrome narrows `supportsAgentRewrite: false` to LinkedIn share composer only
 
 PR #125 disabled `supportsAgentRewrite` for **every** `.ql-editor` on the page, intending to scope to LinkedIn's share composer (where Delta+MutationObserver fights cause caret snap-back). But LinkedIn comment boxes are also Quill instances, so they got swept up — `agentically X _` in a LinkedIn comment was silently wiped instead of running. Symptom reported 2026-06-12.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/statusline.ts
+++ b/packages/opencues-runtime/src/modules/statusline.ts
@@ -181,7 +181,23 @@ export class Statusline {
     // tips-mode: off → still expose word + alts but suppress tip text.
     const tipsHidden = this.configLoader?.opencuesState.tipsMode === 'off';
     const wordIndex = this.hlState.wordIndex;
-    const def = this.dynDefs.get(wordIndex);
+    // Direct lookup matches multi-word substitute DefAt the origin word
+    // only. If the highlight is on word N>origin inside a multi-word span
+    // (fluid/transform blank substitutes are always multi-word — the
+    // LLM emits 2+ word answers), `dynDefs.get(wordIndex)` returns
+    // undefined and the code falls through to the word-cue lookup at
+    // the bottom of this function. That surfaces a word-cue tip for an
+    // individual word in the LLM-substituted body (e.g. "email" inside a
+    // draft) — confusing because the user didn't write that word, the
+    // LLM did. Use `findSpanContaining` so any word inside a
+    // blankName-attributed span (`fluid-blank`, `transform-blank`,
+    // `agent-rewrite`) resolves to the originating def and goes through
+    // the suppression branch below.
+    let def = this.dynDefs.get(wordIndex);
+    if (!def) {
+      const span = this.dynDefs.findSpanContaining(wordIndex);
+      if (span) def = span.def;
+    }
     const words = splitWords(ctx.text);
     let highlightedWord: string;
     if (def) {


### PR DESCRIPTION
## Summary

User report 2026-06-13 (chrome): "tips when we highlight the modified text. It should not have any tips for now."

`statusline.ts:buildPayload` used `dynDefs.get(wordIndex)` which only matches the **origin** word index of a multi-word span. When the highlight landed on word N>origin INSIDE a multi-word LLM substitute, `def` came back undefined and the function fell through to the word-cue lookup at the bottom — surfacing a `word (N/M) - tip` line for a word the LLM picked (e.g. "email" inside a draft).

## Fix

Fall back to `dynDefs.findSpanContaining(wordIndex)` when `dynDefs.get()` misses. The existing `if (def?.blankName)` branch then suppresses the tip + sets `cueBlank: true` uniformly across the span. Chrome's `runtime-statusbar.ts:applyStatuslinePayload` handles `cueBlank: true && cueTip: null` as `combined === null` → `hide()`, so the floating div **fully disappears** for any navigation into a substitute — no word, no `(N/M)`, no tip.

CC behaviour unchanged in practice (cursor-navigate already lands on origin word indices for multi-word DynDefs); the fix is structurally defensive for any host whose cursor model walks character-by-character through spans.

## Verification

- `pnpm --filter @opencues/runtime test` → 1645 / 1645 pass.
- Agentic harness on CC + canonical fork: typed `text:draft an email to alice _`, waited for transform-blank substitute (391-char body), then `key:left:ctrl+alt` to navigate onto the substitute. `statusline.snapshot` event in `/tmp/opencues-events-<pid>.jsonl` shows `cueTip: null, cueBlank: true`. CC's status line consumer then renders nothing.
- Chrome bundle synced to `/mnt/c/Users/wilfred/AppData/Local/opencues-chrome/dist/` with 10 `findSpanContaining` references in `content.js`. Awaiting your reload-and-test confirmation.

## Version

`@opencues/runtime` 0.3.4 → 0.3.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)