### PR TITLE
fix(runtime): substitute never auto-selects; user must manually navigate onto span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — Substitute never auto-selects; user must manually navigate onto the span
+
+`statusline.ts:buildPayload` used to elevate any live `spanFillState` to `active: true` even when `hlState` was inactive — the rationale was that BlankFill scenarios polled `active === true` to assert "the substitute completed." Those scenarios moved to `waitForEvent` on the `blank.substituted` event (the canonical completion signal); the one remaining poller now sits under `tests/agentic/scenarios/_flaky/`.
+
+The lingering elevation conflicted with OpenCues' core UX rule: a region is only `active` once the user has *manually navigated onto it*. Without that, fluid-blank / transform-blank / agent-rewrite substitutes appeared "auto-selected" the moment they landed — statusline emitted the span's `blankTip` and chrome's floating statusbar showed it, even though the user hadn't moved onto the span. The elevation also returned BEFORE the `tipsMode === 'off'` check, so even `tips-mode: off` didn't suppress it.
+
+Fix: remove the spanActive-without-hlState branch. When `hlState.active` is false, `buildPayload` now returns `{ active: false, agentTask }` unconditionally regardless of the spanFillState. Cycling (`Cycling.ts:181`) reads `spanFillState` directly so Up/Down cycling after manual navigation works exactly as before — only the *unactivated* "selected on substitute" signal is removed.
+
+Behavioural matrix (verified end-to-end on CC harness, transform-blank substitute):
+
+| State | `active` | `cueTip` | `cueBlank` | Visible? |
+|---|---|---|---|---|
+| Right after substitute (no nav) | `false` | `null` | `null` | Nothing — empty statusbar/statusline |
+| After Ctrl+Alt+arrow onto span | `true` | `null` | `true` | Span highlighted; chrome statusbar hides per PR #128 |
+
+Rules pinned by a new unit test (`statusline.test.ts`): `spanFillState set but hlState inactive → active=false`. Runtime suite: 1646 / 1646 pass.
+
+`@opencues/runtime` 0.3.5 → 0.3.6.
+
 ### Fix — Statusline shows nothing for any word inside a fluid/transform/agent-rewrite substitute
 
 `statusline.ts:buildPayload` used `this.dynDefs.get(wordIndex)` to find the DynDef at the highlighted word, then suppressed the tip when `def.blankName` was set (fluid-blank / transform-blank / agent-rewrite substitutes shouldn't surface tips because the substituted text was emitted by the LLM, not authored by the user). But `dynDefs.get(wordIndex)` only matches the **origin** word index of a multi-word span. When the highlight landed on word N>origin INSIDE a multi-word substitute, `def` came back undefined and the function fell through to the word-cue lookup at the bottom, which surfaced a tip for the individual LLM-emitted word.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/statusline.test.ts
+++ b/packages/opencues-runtime/src/modules/statusline.test.ts
@@ -268,6 +268,40 @@ describe('Statusline write behaviour', () => {
     expect(p.currentAltIndex).toBe(0);
   });
 
+  // Pinning the manual-select-only rule (June 2026 user request): a
+  // live spanFillState (BlankFill / fluid-blank / transform-blank /
+  // agent-rewrite just substituted) MUST NOT make the statusline
+  // active until the user explicitly navigates onto the span. The
+  // payload stays { active: false } so chrome's runtime-statusbar
+  // hides entirely and CC's status line consumer renders nothing.
+  it('spanFillState set but hlState inactive → active=false (no auto-select after substitute)', async () => {
+    const { SpanFillState } = await import('../state/span-fill');
+    const adapter = new MockAdapter();
+    adapter.pushText('affirm I am strong');
+    const hlState = new HighlightState();
+    const dynDefs = new DynDefs();
+    const span = new SpanFillState();
+    // Mimic the post-substitute state: BlankFill just filled a span.
+    // The user has NOT navigated onto it yet.
+    span.set({
+      index: 1,
+      alternatives: ['I am strong', 'I am brave', '_'],
+      currentAltIndex: 0,
+      spanLength: 3,
+      blankTip: 'Daily affirmations',
+    }, 'affirm I am strong');
+    const sl = new Statusline(adapter, hlState, dynDefs, {
+      exportPath: '/tmp/x.json',
+    }, undefined, span);
+    // hlState intentionally not activated — represents the moment
+    // immediately after BlankFill landed.
+    const p = sl.buildPayload({ text: 'affirm I am strong', cursor: 0, externalHighlights: [] });
+    expect(p.active).toBe(false);
+    expect(p.cueTip).toBeUndefined();
+    expect(p.cueBlank).toBeUndefined();
+    expect(p.alts).toBeUndefined();
+  });
+
   it('selector word emits setting-level tip', async () => {
     const { SelectorSatelliteState } = await import('../state/selector-satellite');
     const OPENCUES_MD = `---

--- a/packages/opencues-runtime/src/modules/statusline.ts
+++ b/packages/opencues-runtime/src/modules/statusline.ts
@@ -156,26 +156,25 @@ export class Statusline {
   /** Exposed for testing — build the payload from current state + render ctx. */
   buildPayload(ctx: RenderContext): StatuslinePayload {
     const agentTask = this.formatAgentTask();
-    // `active` means "OpenCues has an interactive region the user can
-    // act on". Highlight active is the obvious case. Span fill (e.g.
-    // a weather/stocks blank that just substituted) is also active —
-    // the user can cycle Up/Down through alternatives. Without
-    // including spanFill here, BlankFill scenarios that wait for
-    // active=true after a substitution time out even though the
-    // substituted span is fully cyclable.
-    const spanActive = this.spanFillState?.current ?? null;
+    // `active` means "OpenCues has an interactive region the user
+    // navigated onto and is acting on right now." A substituted span
+    // (BlankFill / fluid-blank / transform-blank / agent-rewrite)
+    // becomes cyclable as soon as it lands, but ONLY hlState.active
+    // marks the user-acknowledged target.
+    //
+    // History: this branch used to elevate any live spanFillState to
+    // active=true even when hlState was inactive — the rationale was
+    // that BlankFill scenarios polled `active === true` after a
+    // substitute to assert "the run completed." Those scenarios moved
+    // to `waitForEvent` on `blank.substituted` (the canonical
+    // completion signal) and the one remaining waiter sits under
+    // tests/agentic/scenarios/_flaky/. Removing the elevation gives
+    // the no-tip-no-highlight UX every host needs: the user must
+    // navigate onto the span (Tab / Ctrl+Alt+arrow) before the
+    // statusline emits ANY tip or selection signal. Cycling continues
+    // to work — Cycling.ts reads spanFillState directly and is not
+    // gated on the statusline's active flag.
     if (!this.hlState.active || this.hlState.wordIndex === null) {
-      if (spanActive) {
-        return {
-          active: true, timestamp: Date.now(), agentTask,
-          highlightedWordIndex: spanActive.index,
-          highlightedWord: spanActive.alternatives[spanActive.currentAltIndex] ?? '',
-          cueTip: spanActive.blankTip ?? null,
-          alts: spanActive.alternatives,
-          currentAltIndex: spanActive.currentAltIndex,
-          cueBlank: true,
-        };
-      }
       return { active: false, timestamp: Date.now(), agentTask };
     }
     // tips-mode: off → still expose word + alts but suppress tip text.


### PR DESCRIPTION
## Summary

User-reported regression 2026-06-13:
> The moment a fluid/transform/agent blank substitutes text, that span is treated as selected: it shows the blank's tip in the statusline (and gets highlighted) even though I never navigated to it. In OpenCues you should always *manually* select something before it's the active/cyclable region.

## Root cause

`statusline.ts:buildPayload` had a branch (~lines 166–178) that returned `active: true` + `cueTip: spanActive.blankTip` + `cueBlank: true` whenever `spanFillState.current` was set AND `hlState.active` was false. The historical rationale was that BlankFill scenarios polled `active === true` after a substitute to assert "the run completed" — but those scenarios moved to `waitForEvent` on `blank.substituted` (the canonical signal) and the one remaining poller now sits under `tests/agentic/scenarios/_flaky/`. The branch was load-bearing for nothing in the main suite and conflicted with the manual-select-only UX rule. It also returned BEFORE the `tipsMode === 'off'` check, so `tips-mode: off` couldn't suppress it.

## Fix

Remove the spanActive-without-hlState branch. When `hlState.active` is false, `buildPayload` returns `{ active: false, agentTask }` unconditionally regardless of `spanFillState`. Cycling still works — `Cycling.ts:181` reads `spanFillState` directly and is not gated on the statusline's `active` flag, so Up/Down cycling after manual navigation behaves exactly as before.

## Behaviour matrix (verified live)

End-to-end on CC harness — transform-blank `draft an email to alice _` substitute (391-char body):

| State | `active` | `cueTip` | `cueBlank` | UI |
|---|---|---|---|---|
| Right after substitute (no nav) | `false` | `null` | `null` | Empty statusbar / blank status line |
| After Ctrl+Alt+Left onto span | `true` | `null` | `true` | Span highlighted; chrome statusbar hides per PR #128 |

Single-alt vs multi-alt fills behave identically — neither auto-selects.

## Tests

- New unit test `statusline.test.ts: spanFillState set but hlState inactive → active=false`.
- Full runtime suite: **1646 / 1646 pass** (+1 new test).

## Version

`@opencues/runtime` 0.3.5 → 0.3.6.

## Re-sync path for the recording rig

After this merges, run `pnpm --filter @opencues/runtime build` (workspaces depending on the runtime auto-pick it up), then re-bundle chrome (`cd integrations/chrome && npm run build && cp -r dist/* /mnt/c/...`). The statusline payload shape didn't change — only the value of `active` for the unnavigated-span case — so no `main.ts:onStatusSnapshot` mapping update is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)