### PR TITLE
fix(runtime): blank keywords no longer dim until `_` is in proximity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — Blank keywords no longer dim until `_` is in proximity
+
+`DimRender` painted dim ranges for every word in `configLoader.navigableWords` — which includes every shipped blank's `blankKeywords` list (91 distinct keywords across `volume`, `brightness`, `weather`, `forecast`, all stock tickers, all crypto symbols, lookup triggers like `what is`, `define`, country phrasings, etc.). The result was phantom dimming on bare prose: "the volume in this room was low" painted `volume`, "Apple announced earnings" painted `apple`, "i love bitcoin lately" painted `bitcoin`. The dim implied interactivity but the action only fires when `_` lands adjacent — so the user saw a hint with no payoff.
+
+User report 2026-06-13: "should we make it that they don't turn gray... only 'Cues' or aspects which have been changed should turn gray."
+
+Fix: new gate `DimRender.shouldGateBlankKeywordDim()` runs after the existing `navigable.has(lc)` check. A word that is:
+- in `blanksByWord` (a blank keyword), AND
+- NOT in `cueMap` (i.e. not also a word-cue or tip entry — those still dim because their dim IS the affordance of cyclable prose alternatives)
+
+…is treated as a pure action trigger. It dims only when `_` is within `blankProximity` words of the keyword (matches the same proximity window that gates the action firing in `BlankFill`). Bare-prose mentions stay plain text.
+
+Behaviour matrix (verified on CC harness with debug-mode dim trace):
+
+| Phrase | Before | After |
+|---|---|---|
+| `the volume in this room` | `volume` dimmed | nothing dims ✓ |
+| `Apple announced earnings` | `Apple` dimmed | nothing dims ✓ |
+| `i love bitcoin lately` | `bitcoin` dimmed | nothing dims ✓ |
+| `volume _` | `volume` + `_` dim | same — gate passes because `_` is within proximity 3 |
+| `volume is _` | `volume` + `_` dim | same |
+| `i have a contract` | dimmed via `legal` word-cue (host-gated) | same — word-cue arm is unaffected |
+| Substituted span (post-`volume _` resolve to `volume 50%`) | dim covers keyword + `50%` | same — DynDef arm is unaffected |
+
+Word-cues with real prose alternatives (legal, medical, financial, spelling, more-formal) keep the unconditional dim because their dim IS the offer. Tips-folder static entries (`tips-claude-code`, `tips-gemini-cli`, etc.) also keep the dim — they're informational hints without action.
+
+Pinned by two new tests in `dim-render.test.ts`:
+- `blank keyword without _ adjacent does NOT dim`
+- `blank keyword WITH _ within proximity DOES dim`
+
+`@opencues/runtime` 0.3.6 → 0.3.7.
+
 ### Fix — Substitute never auto-selects; user must manually navigate onto the span
 
 `statusline.ts:buildPayload` used to elevate any live `spanFillState` to `active: true` even when `hlState` was inactive — the rationale was that BlankFill scenarios polled `active === true` to assert "the substitute completed." Those scenarios moved to `waitForEvent` on the `blank.substituted` event (the canonical completion signal); the one remaining poller now sits under `tests/agentic/scenarios/_flaky/`.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/dim-render.test.ts
+++ b/packages/opencues-runtime/src/modules/dim-render.test.ts
@@ -101,6 +101,65 @@ describe('DimRender + render pipeline (integration)', () => {
     expect(out?.dimRanges).toEqual([]);
   });
 
+  // Blank-keyword arm gating — June 2026 UX change.
+  // A blank keyword on its own is an *action trigger* that requires `_`
+  // adjacency to fire. Without `_`, dimming the keyword is noise — it
+  // implies interactivity when nothing will happen. The gate suppresses
+  // the dim until `_` lands within `blankProximity`. Word-cue entries
+  // (legal/medical/financial/spelling, any CUES.md ## Tips) bypass the
+  // gate because their dim IS the offer of prose alternatives.
+  it('blank keyword without `_` adjacent does NOT dim', async () => {
+    const { ConfigLoader } = await import('./config-loader');
+    const VOLUME_BLANK = `---
+name: volume
+type: blank
+blankKeywords: volume
+blankProximity: 3
+tip: system volume
+blankScript: ./vol.sh
+---`;
+    const TIPS = JSON.stringify({ domain: 't', version: 1, concepts: [] });
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: { '/tips.json': TIPS, '/proj/blanks/volume/BLANK.md': VOLUME_BLANK },
+    });
+    adapter.pushText('the volume in this room was low');
+    const loader = new ConfigLoader(adapter);
+    await loader.load();
+    const hlState = new HighlightState();
+    const dynDefs = new DynDefs();
+    const dim = new DimRender(adapter, hlState, dynDefs, loader);
+    const out = dim.compute({ text: 'the volume in this room was low', cursor: 0, externalHighlights: [] });
+    // "volume" is in blanksByWord (navigable) but no `_` is adjacent → suppress.
+    expect(out?.dimRanges ?? []).toEqual([]);
+  });
+
+  it('blank keyword WITH `_` within proximity DOES dim', async () => {
+    const { ConfigLoader } = await import('./config-loader');
+    const VOLUME_BLANK = `---
+name: volume
+type: blank
+blankKeywords: volume
+blankProximity: 3
+tip: system volume
+blankScript: ./vol.sh
+---`;
+    const TIPS = JSON.stringify({ domain: 't', version: 1, concepts: [] });
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: { '/tips.json': TIPS, '/proj/blanks/volume/BLANK.md': VOLUME_BLANK },
+    });
+    adapter.pushText('volume is _');
+    const loader = new ConfigLoader(adapter);
+    await loader.load();
+    const hlState = new HighlightState();
+    const dynDefs = new DynDefs();
+    const dim = new DimRender(adapter, hlState, dynDefs, loader);
+    const out = dim.compute({ text: 'volume is _', cursor: 0, externalHighlights: [] });
+    // _ is at word 2, volume is at word 0; proximity 3 covers it → dim fires.
+    expect(out?.dimRanges?.some(r => r.start === 0 && r.end === 6)).toBe(true);
+  });
+
   it('dims words that are only navigable via DynDefs (LLM-resolved)', async () => {
     const { ConfigLoader } = await import('./config-loader');
     const adapter = new MockAdapter({

--- a/packages/opencues-runtime/src/modules/dim-render.ts
+++ b/packages/opencues-runtime/src/modules/dim-render.ts
@@ -104,6 +104,18 @@ export class DimRender {
           navigable.has(lc) ||
           this.dynDefs.get(w.index)
         ) {
+          // Blank-keyword arm: a word that is ONLY a blank keyword
+          // (not a word-cue match, not a registered tip in cueMap)
+          // shouldn't dim until a `_` is in proximity. Without the
+          // gate, every prose mention of `volume` / `bitcoin` /
+          // `apple` / `weather` etc. paints a phantom dim that
+          // suggests "I'm interactive" \u2014 but the action only fires
+          // when `_` lands adjacent. Words that are ALSO word-cue
+          // entries (legal/medical/financial when host-enabled, any
+          // CUES.md ## Tips entry) keep the unconditional dim
+          // because those genuinely offer prose alternatives the
+          // user can cycle \u2014 the dim is the affordance.
+          if (this.shouldGateBlankKeywordDim(lc, w.index, words)) continue;
           dimRanges.push({ start: w.start, end: w.end });
         }
       }
@@ -171,5 +183,44 @@ export class DimRender {
 
     if (!highlight && dimRanges.length === 0) return null;
     return { highlight, dimRanges };
+  }
+
+  /**
+   * Returns true when the dim for this word should be SUPPRESSED because
+   * it's a pure blank keyword (an action trigger that needs `_` to fire)
+   * and no `_` is in proximity. Words that are ALSO word-cue entries
+   * (live in `configLoader.cueMap`) bypass the gate and dim
+   * unconditionally — those offer real prose alternatives.
+   *
+   * See `docs/architecture/spans-and-cycling.md` § "Dim contract" for
+   * the rationale.
+   */
+  private shouldGateBlankKeywordDim(
+    lc: string,
+    wordIdx: number,
+    words: readonly { word: string }[],
+  ): boolean {
+    if (!this.configLoader) return false;
+    // Word-cue entries (CUES.md ## Tips, folder cues, spelling) keep
+    // the unconditional dim — their dim IS the offer that the user
+    // can cycle them.
+    if (this.configLoader.cueMap.has(lc)) return false;
+    const entry = this.configLoader.blanksByWord.get(lc);
+    if (!entry) return false;
+    // The word resolved to a blank keyword. Check if any `_` is within
+    // proximity. blankProximity defaults to 0 (keyword must be
+    // directly adjacent to `_`); blanks with looser phrasing set it
+    // explicitly (e.g. volume = 3, dictionary = 20).
+    const proximity = entry.blank.blankProximity ?? 0;
+    const lower = wordIdx - proximity - 1;
+    const upper = wordIdx + proximity + 1;
+    const start = Math.max(0, lower);
+    const end = Math.min(words.length - 1, upper);
+    for (let i = start; i <= end; i++) {
+      if (i === wordIdx) continue;
+      const w = words[i]?.word;
+      if (w === '_' || w?.replace(/[​‌]/g, '') === '_') return false;
+    }
+    return true;
   }
 }


### PR DESCRIPTION
## Summary

User report 2026-06-13: *"should we make it that they don't turn gray... only Cues or aspects which have been changed should turn gray."*

`DimRender` painted dim ranges for **every** word in `configLoader.navigableWords` — which includes every shipped blank's `blankKeywords` list (91 distinct keywords across `volume`, `brightness`, `weather`, all stock tickers, all crypto symbols, lookup triggers like `what is` / `define` / `capital of`, etc.). Result: phantom dimming on bare prose:

```
"the volume in this room was low"   →  dimmed `volume`
"Apple announced earnings"           →  dimmed `apple`
"i love bitcoin lately"              →  dimmed `bitcoin`
```

The dim implied interactivity, but the action only fires when `_` lands adjacent. So users saw a hint with no payoff — exactly the wrong UX contract.

## Fix

New gate `DimRender.shouldGateBlankKeywordDim()` runs after the existing `navigable.has(lc)` check. A word that is:

- in `blanksByWord` (= a blank keyword), AND
- NOT in `cueMap` (= not also a word-cue or tip entry)

is treated as a pure action trigger. It dims **only** when `_` is within the blank's `blankProximity` of the keyword — the same window that gates the action firing in `BlankFill`. Bare-prose mentions stay plain text.

## What still dims (unchanged)

- **Word-cues with real prose alternatives** — `legal` (contract, agreement, ...), `medical` (diagnosis, prognosis, ...), `financial` (equity, dividend, ...), `spelling`, `more-formal`. Their dim IS the offer of cyclable alternatives.
- **Tips-folder static entries** — `tips-claude-code`, `tips-gemini-cli`, `tips-opencode`, `tips-shell`. Informational hints without action; dim surfaces the tip.
- **Substituted spans** — anything post-`_` resolve (volume 50%, BITCOIN: $63,930.00, NVDA: $205.21, ...). Indicates a cyclable region.
- **DynDef-attributed words** (LLM-resolved alternatives). Same affordance.
- **Selector/satellite spans**.

## What stops dimming (91 keywords across 16 blanks)

- **Stocks** (15 base + "X stock" variants): `nvda`, `apple`, `aapl`, `tesla`, `tsla`, `meta`, `microsoft`, `msft`, `amazon`, `amzn`, `google`, `googl`, `reddit`, `rddt`, `nvidia`
- **Crypto** (30): `bitcoin`, `btc`, `ethereum`, `eth`, `solana`, `sol`, `cardano`, `ada`, `ripple`, `xrp`, `dogecoin`, `doge`, ...
- **System actions** (4): `volume`, `brightness`, `time`, `clock`
- **Lookups** (~12): `weather`, `forecast`, `temp`, `temperature`, `define`, `definition of`, `meaning of`, `what does`, `what is`, `what is the word for`, `how to say`, ...
- **Country data** (8): `population of`, `capital of`, `currency of`, `region of`, `language of`, ...
- **Multi-word actions** (10): `improve prompt`, `enhance prompt`, `refine prompt`, `is claude down`, `claude status`, ...
- **Misc**: `hn`, `hackernews`, `gh-issues`, `affirmation`, `affirmations`

All keep dimming the moment `_` is in proximity.

## Verification

### Unit tests

Pinned by two new tests in `dim-render.test.ts`:
- `blank keyword without _ adjacent does NOT dim`
- `blank keyword WITH _ within proximity DOES dim`

Runtime suite: **1648 / 1648 pass** (+2 new).

### Live (CC harness, debug-mode dim trace)

| Phrase | Before | After |
|---|---|---|
| `the volume in this room` | `dimRanges: [{start:4,end:10}]` (volume) | `dimRanges: []` ✓ |
| `i love bitcoin lately` | `[{start:7,end:14}]` (bitcoin) | `[]` ✓ |
| `apple announced earnings` | `[{start:0,end:5}]` (apple) | `[]` ✓ |
| `volume _` | `[{start:0,end:6}]` | `[{start:0,end:6}]` (unchanged) |
| `volume is _` | `[{start:0,end:6}]` | `[{start:0,end:6}]` (unchanged, _ within proximity 3) |

### Chrome

Bundle rebuilt + synced. After reload, the floating dim painter follows the same gate.

## Version

`@opencues/runtime` 0.3.6 → 0.3.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)