### PR TITLE
perf(runtime): parallelise BlankContextCache refresh; cold transform-blank 2.3× faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Perf — Parallelise blank-context cache refresh; cold transform-blank/fluid-blank 2.3× faster
+
+`BlankContextCache.snapshot()` refreshed catalog slots via a **sequential** `for ... await blank.get(slot)` loop. Every stale slot stalled on a real HTTP call — stocks → Finnhub, weather → OpenWeather, crypto → CoinGecko, hackernews → HN API, etc. On the default catalog (5 stocks from `context-slots` + N from `context-bind: portfolio` + 2 crypto + 1 weather + 1 HN + 1 claude-status) that's 10+ sequential round-trips firing on every cold transform-blank / fluid-blank call.
+
+User bench 2026-06-13, `draft an email _` on cerebras gpt-oss-120b:
+
+| Trial | Sequential (pre-fix) | Parallel (post-fix) | Saved |
+|---|---|---|---|
+| Cold 1 (fresh runtime) | 1810ms | **785ms** | 1025ms (57%) |
+| Cold 2 (post-65s TTL expiry) | 1953ms | **811ms** | 1142ms (58%) |
+| Warm (cache valid, no HTTP) | 926ms | 692ms | within noise — expected unchanged |
+
+Direct HTTP probe confirmed the mechanism: 5 sequential Finnhub stock calls = 877ms; parallel = max(209ms) ≈ 210ms. The fanout is independent per slot — no cross-slot dependency — so the runtime can launch every refresh concurrently.
+
+Fix: replace the sequential loop with `Promise.all(plan.map(async slot => ...))`. Per-slot `try/catch` preserved so a single network failure still produces `[STALE]` for that one slot without poisoning the rest of the snapshot. Cache eviction (`_evictIfOver`) moved to fire once after the fan-out lands, instead of inside the loop. Otherwise zero behaviour change — same TTL semantics, same `[STALE]` fallback, same cache shape.
+
+The other obvious optimisation — skipping catalog injection entirely when the buffer text doesn't plausibly reference any token — is tracked as a follow-up (would cut another ~500ms on prose-only buffers by eliminating the LLM-side prompt + reasoning tax). This fix alone is a structurally tight one-file, ~30-line change with no behaviour difference visible to the user beyond "transform-blank substitutes feel snappier on cold runs."
+
+`@opencues/runtime` 0.3.7 → 0.3.8.
+
 ### Fix — Blank keywords no longer dim until `_` is in proximity
 
 `DimRender` painted dim ranges for every word in `configLoader.navigableWords` — which includes every shipped blank's `blankKeywords` list (91 distinct keywords across `volume`, `brightness`, `weather`, `forecast`, all stock tickers, all crypto symbols, lookup triggers like `what is`, `define`, country phrasings, etc.). The result was phantom dimming on bare prose: "the volume in this room was low" painted `volume`, "Apple announced earnings" painted `apple`, "i love bitcoin lately" painted `bitcoin`. The dim implied interactivity but the action only fires when `_` lands adjacent — so the user saw a hint with no payoff.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/blank-context-cache.ts
+++ b/packages/opencues-runtime/src/modules/blank-context-cache.ts
@@ -61,14 +61,28 @@ export class BlankContextCache {
     blanks: ReadonlyMap<string, Blank>,
     perBlankTtlMs: ReadonlyMap<string, number>,
   ): Promise<BlankContextSnapshot> {
-    const fields: ResolvedBlankContextField[] = [];
-    const catalog = new Map<string, string>();
-
-    for (const slot of plan) {
+    // Parallelise the refresh fan-out. Pre-June-2026 this was a
+    // sequential `for ... await blank.get(slot.slot)` which stalled on
+    // every HTTP call (stocks → Finnhub, weather → OpenWeather, crypto
+    // → CoinGecko, hackernews → HN API). On a default catalog
+    // (5 stocks + portfolio stocks + 2 crypto + weather + HN) that's
+    // 10+ sequential round-trips before the TransformBlank /
+    // FluidBlank call could even start. Bench showed ~1000ms added to
+    // every cold transform-blank substitute purely from blocking on
+    // these HTTP calls in series.
+    //
+    // The fetches are independent — each blank's get(slot) reads its
+    // own data source with no cross-slot dependency — so `Promise.all`
+    // is safe and reduces the cold-cache cost to roughly the SLOWEST
+    // single fetch (~200-300ms) instead of their sum.
+    //
+    // Each fetch keeps its own try/catch so a single network failure
+    // still produces `[STALE]` for that one slot without poisoning
+    // the rest of the snapshot.
+    const resolutions = await Promise.all(plan.map(async (slot) => {
       const ttl = perBlankTtlMs.get(slot.blankName) ?? 60_000;
       let entry = this._cache.get(slot.token);
       if (!entry || this._now() - entry.fetchedAt > ttl || entry.value === null) {
-        // Stale or absent — re-fetch.
         const blank = blanks.get(slot.blankName);
         let value: string | null = null;
         if (blank) {
@@ -86,13 +100,20 @@ export class BlankContextCache {
           ttlMs: ttl,
         };
         this._cache.set(slot.token, entry);
-        this._evictIfOver();
       }
+      return { slot, entry };
+    }));
+
+    // Evict once after all fetches land (was: per-slot inside the loop).
+    this._evictIfOver();
+
+    const fields: ResolvedBlankContextField[] = [];
+    const catalog = new Map<string, string>();
+    for (const { slot, entry } of resolutions) {
       const resolved = entry.value ?? '[STALE]';
       fields.push({ token: slot.token, description: slot.description, value: resolved });
       catalog.set(slot.token, resolved);
     }
-
     return { fields, catalog };
   }
 


### PR DESCRIPTION
## Summary

User bench 2026-06-13: `draft an email _` on cerebras gpt-oss-120b took ~1810ms cold, only ~926ms warm. Tracing the cold-path overhead landed on `BlankContextCache.snapshot()` — it refreshed every stale catalog slot via a **sequential** `for ... await blank.get(slot)` loop. Each slot's `get(slot)` is a real HTTP call (stocks → Finnhub, weather → OpenWeather, crypto → CoinGecko, hackernews → HN API, etc.). On the user's default catalog (5 stocks from `context-slots` + N from `context-bind: portfolio` + 2 crypto + 1 weather + 1 HN + 1 claude-status) that's 10+ sequential HTTP round-trips firing on every cold transform-blank / fluid-blank call.

Direct HTTP probe confirmed:

```
Finnhub NVDA: 0.209s    Finnhub AAPL: 0.161s    Finnhub TSLA: 0.194s
Finnhub MSFT: 0.189s    Finnhub GOOGL: 0.124s   (5 stocks: 877ms sequential)
CoinGecko BTC: 0.061s   HN top: 0.275s
```

Five stocks ALONE = 877ms of pure HTTP wall-clock. Parallel: `max(209ms) ≈ 210ms`. Savings ≈ 670ms on stocks alone, then crypto/HN/weather/status pile additional saves on top.

## Fix

Replace the sequential loop with `Promise.all(plan.map(async slot => ...))`. The fan-out is structurally safe:

- Each `blank.get(slot)` reads its own data source with no cross-slot dependency.
- Per-slot `try/catch` preserved so a single network failure still produces `[STALE]` for that one slot without poisoning the rest of the snapshot.
- `_evictIfOver` moved to fire once after the fan-out lands instead of per-slot (necessary now that all writes complete before any eviction check would be meaningful).

Behaviour unchanged: same TTL semantics, same `[STALE]` fallback, same cache shape, same eviction policy.

## Bench (end-to-end on CC canonical fork, new code deployed)

| Trial | Sequential (pre-fix) | Parallel (post-fix) | Saved |
|---|---|---|---|
| Cold 1 (fresh runtime, cold cache) | 1810ms | **785ms** | 1025ms (57%) |
| Cold 2 (post-65s TTL expiry) | 1953ms | **811ms** | 1142ms (58%) |
| Warm (cache valid, no HTTP) | 926ms | 692ms | within noise |

Warm path tracks baseline — expected, since the cache hits bypass HTTP entirely.

## Tests

`pnpm --filter @opencues/runtime test` → **1648 / 1648 pass**. No test changes needed — the parallelisation is observable only via wall-clock, not state shape. The existing `blank-context-cache.test.ts` exercises cache hits / misses / TTL expiry / `[STALE]` fallback and continues to cover those.

## Version

`@opencues/runtime` 0.3.7 → 0.3.8.

## Follow-up (separate PR)

Skipping catalog injection entirely when the buffer text doesn't plausibly reference any token would cut another ~500ms on prose-only buffers (by eliminating the LLM-side prompt tokens + reasoning tax). Tracked separately — this PR is the structurally tightest single-file change with the biggest immediate win.

## Re-sync path

After merge: `pnpm --filter @opencues/runtime build` then either `opencues install <host>` for native hosts or rebuild + sync chrome bundle. The change ships inside the runtime; no host-side update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)