### PR TITLE
perf(core): cerebras reasoning_format=hidden on gpt-oss-120b; p95 tail drops 26-40% on short-output sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Perf — Cerebras `reasoning_format: "hidden"` on gpt-oss-120b; p95 tail drops 26-40% on short-output sources
+
+Cerebras's `gpt-oss-120b` accepts a `reasoning_format` parameter ([docs](https://inference-docs.cerebras.ai/capabilities/reasoning)) that controls whether the reasoning trace appears in the response. Default is `"text_parsed"` (reasoning appears as a separate field); `"hidden"` suppresses the reasoning text while still generating + counting the tokens internally.
+
+This PR sets `reasoning_format: "hidden"` for every cerebras dispatch to a gpt-oss-* model. Conditional in `buildOpenAIBody`: `opts.provider === 'cerebras'` AND `req.model` starts with `gpt-oss`. The bench harnesses (`tests/benchmarks/fluid-blank/cerebras.ts`) were updated to mirror so future benches measure what production runs.
+
+**Effect** (N=20 trials per cell, June 2026):
+
+| Source | default p95 | hidden p95 | Δ |
+|---|---|---|---|
+| FluidBlank | 579ms | 348ms | **−231ms (−40%)** |
+| ConfigIntent | 603ms | 446ms | **−157ms (−26%)** |
+| TransformBlank | 461ms | 470ms | +9ms (noise) |
+
+The pattern is clean: hidden mode tightens p95 for **short-output sources** (FluidBlank, ConfigIntent — ~50-90 completion tokens) but is neutral for **long-output sources** (TransformBlank fused — ~240 completion tokens). Hypothesis: when content is small but the reasoning trace is heavy, transmission of the trace inflates worst-case latency; hidden mode skips that.
+
+**Accuracy preserved** — bench-validated on both:
+- `tests/benchmarks/fluid-blank-ambient/fused-bench.ts`: **175/176** (matches target).
+- `tests/benchmarks/transform-blank/prod-fused.ts`: **187/231** (within master's variance band 186-193).
+- 1656/1656 runtime tests pass.
+
+Cost unchanged: reasoning tokens are still computed and counted in `usage.completion_tokens_details.reasoning_tokens`. Hidden mode only suppresses the **text** of the reasoning trace from the response payload.
+
+Why no runtime toggle: the behavior change is semantic-neutral and the bench data is clear, so this is always-on for cerebras gpt-oss-120b. Documented in [`docs/architecture/cerebras.md` § Hidden reasoning format](docs/architecture/cerebras.md#hidden-reasoning-format-on-gpt-oss-120b).
+
+Bumps:
+- `@opencues/core` 0.3.18 → 0.3.19 (one conditional in `buildOpenAIBody` + bench harness mirror + cerebras.md extension).
+- `@opencues/chrome` 0.2.18 → 0.2.19 (bundle bytes change; manifest + package.json in lockstep).
+
 ### Fix — `cerebras-model: zai-glm-4.7` now forwards `reasoning_effort: none` correctly; opt-in users get fast + accurate output instead of slow + 60% accuracy
 
 Cerebras's `zai-glm-4.7` ([their docs](https://inference-docs.cerebras.ai/capabilities/reasoning)) has a **binary** reasoning knob in practice: `'none'` cleanly disables thinking (0 reasoning tokens, ~280ms median); any other value (`low` / `medium` / `high`) burns 500-700 reasoning tokens for no quality gain (~1000ms median).

--- a/docs/architecture/cerebras.md
+++ b/docs/architecture/cerebras.md
@@ -162,6 +162,34 @@ A `pred-accepted=0` line on a long input is a regression signal — something ab
 
 (Future-proofing: every new Cerebras feature OpenCues adopts gets a section here. Today the list is short.)
 
+### Hidden reasoning format on gpt-oss-120b
+
+Cerebras's `gpt-oss-120b` accepts a `reasoning_format` parameter ([docs](https://inference-docs.cerebras.ai/capabilities/reasoning)) that controls how the model's internal reasoning trace appears in the response:
+
+- **`text_parsed`** (default for gpt-oss): reasoning appears as a separate field in the response message.
+- **`hidden`**: reasoning tokens are still **computed and counted**, but the response contains only the final answer in `message.content`. No `reasoning` field is returned.
+
+**OpenCues passes `reasoning_format: "hidden"` for every cerebras dispatch to gpt-oss-120b.** This is conditional in `buildOpenAIBody`: gated on `provider === 'cerebras'` AND `req.model` starts with `gpt-oss`.
+
+Why hidden:
+- **Same accuracy**: same internal generation, identical content bytes. Bench-validated at 175/176 on `tests/benchmarks/fluid-blank-ambient/fused-bench.ts` and 187/231 on `transform-blank/prod-fused.ts` (both within master's variance band).
+- **Same cost**: reasoning tokens still counted (no change in per-call billing).
+- **Same median latency** (within ±10ms noise).
+- **Significant p95 tail reduction** on short-output sources:
+
+  | Source | default p95 | hidden p95 | Δ |
+  |---|---|---|---|
+  | FluidBlank | 579ms | 348ms | **−231ms (−40%)** |
+  | ConfigIntent | 603ms | 446ms | **−157ms (−26%)** |
+  | TransformBlank | 461ms | 470ms | +9ms (noise) |
+
+  N=20 trials per cell, June 2026. Long-output sources (TransformBlank's fused rewrite) are neutral because the output content dominates the response payload — the reasoning trace doesn't materially change the transmission cost. Short-output sources have a small content payload, so the reasoning trace was disproportionately inflating worst-case responses; hidden strips that overhead.
+
+Why gated to gpt-oss-120b:
+- Cerebras docs scope `reasoning_format` to gpt-oss-120b and zai-glm-4.7. zai-glm-4.7 already runs at `reasoning_effort: 'none'` for us (no reasoning text to hide); the parameter is a no-op there but we still gate it tight to avoid sending an unknown field to other providers' models.
+
+Why NOT a runtime toggle: the behavior change is semantic-neutral and the bench data is clear, so we don't expose a config scalar for it. It's always on for cerebras gpt-oss-120b.
+
 ### Reasoning effort `medium` for transform-blank / fluid-blank dispatches
 
 Cerebras's `gpt-oss-120b` exposes a `reasoning_effort` parameter. Our default is `medium` for transform-blank and `low` for fluid-blank, tuned by the [thinking-budget bench](../../tests/benchmarks/thinking-budget/). The `max-thinking: off` scalar dials this down further (see [max-thinking.md](max-thinking.md)).

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/llm-provider.ts
+++ b/packages/opencues-core/src/llm-provider.ts
@@ -355,6 +355,29 @@ function buildOpenAIBody(req: ChatRequest, opts?: { includeReasoningEffort?: boo
   if (reasoning !== undefined && !providerRejectsReasoning) {
     body.reasoning_effort = reasoning;
   }
+  // Cerebras gpt-oss-120b only — request `reasoning_format: "hidden"`
+  // so the model's reasoning trace is suppressed from the response.
+  // Reasoning tokens are still generated and counted (no cost change,
+  // no accuracy change), but the JSON response carries only the final
+  // answer in `message.content` with NO separate `reasoning` field.
+  //
+  // Why hidden on gpt-oss-120b: bench-measured at N=20 trials it
+  // tightens p95 by ~150-230ms on short-output calls (fluid-blank,
+  // config-intent) — the small content + heavy reasoning trace ratio
+  // amplifies the relative cost of transmitting the trace. Long-
+  // output calls (transform-blank fused) are neutral. Median latency
+  // is unchanged either way.
+  //
+  // Why gated to gpt-oss-120b: cerebras docs scope `reasoning_format`
+  // to gpt-oss-120b and zai-glm-4.7. zai-glm-4.7 already runs at
+  // reasoning_effort: 'none' for us (model-thinking.ts) so it
+  // produces no reasoning text; hidden is a no-op there. Other
+  // providers may reject the unknown field; safest to scope tight.
+  //
+  // See docs/architecture/cerebras.md § "Hidden reasoning format".
+  if (opts?.provider === 'cerebras' && /^gpt-oss/i.test(req.model)) {
+    body.reasoning_format = 'hidden';
+  }
   // Structured outputs. Groq's gpt-oss-{20b,120b} support `strict: true`
   // with constrained decoding (guarantee). Other OpenAI-compatible
   // providers accept best-effort (strict: false). The schema must

--- a/tests/benchmarks/fluid-blank/cerebras.ts
+++ b/tests/benchmarks/fluid-blank/cerebras.ts
@@ -38,14 +38,23 @@ export async function chat(
   messages: ChatMessage[],
   opts: { temperature?: number; maxTokens?: number; seed?: number; reasoning?: 'none' | 'low' | 'medium' | 'high' } = {},
 ): Promise<ChatResult> {
-  const body = JSON.stringify({
+  // Mirror production: cerebras gpt-oss-120b uses reasoning_format:
+  // "hidden" to suppress the reasoning trace from the response
+  // (bench-validated tail reduction; see llm-provider.ts § hidden
+  // reasoning). zai-glm-4.7 runs at reasoning_effort: 'none' so it
+  // produces no reasoning text either way.
+  const reqBody: Record<string, unknown> = {
     model: MODEL,
     messages,
     temperature: opts.temperature ?? 0,
     max_tokens: opts.maxTokens ?? 512,
     seed: opts.seed ?? 42,
     reasoning_effort: opts.reasoning ?? defaultReasoningFor(MODEL),
-  });
+  };
+  if (/^gpt-oss/i.test(MODEL)) {
+    reqBody.reasoning_format = 'hidden';
+  }
+  const body = JSON.stringify(reqBody);
 
   const t0 = Date.now();
   const data = await new Promise<string>((resolve, reject) => {


### PR DESCRIPTION
## Summary

Cerebras's `gpt-oss-120b` accepts a [`reasoning_format` parameter](https://inference-docs.cerebras.ai/capabilities/reasoning):
- **`text_parsed`** (default): reasoning appears as a separate field in the response.
- **`hidden`**: reasoning tokens still computed + counted, but the text is suppressed from the response payload.

This PR sets `reasoning_format: "hidden"` for every cerebras dispatch to a gpt-oss-* model. One conditional in `buildOpenAIBody`. The bench harness mirrors so future benches measure what production runs.

## Effect (N=20 trials per cell)

| Source | default median | hidden median | default p95 | hidden p95 |
|---|---|---|---|---|
| FluidBlank | 232ms | 233ms | 579ms | **348ms (−40%)** |
| ConfigIntent | 219ms | 223ms | 603ms | **446ms (−26%)** |
| TransformBlank | 293ms | 301ms | 461ms | 470ms (noise) |

Pattern: tightens p95 for **short-output sources** (50-90 completion tokens) — the relative cost of transmitting a heavy reasoning trace alongside a small content payload was inflating worst-case latency. Neutral for long-output sources where content dominates the payload.

## Accuracy validation

- `tests/benchmarks/fluid-blank-ambient/fused-bench.ts`: **175/176** (matches target).
- `tests/benchmarks/transform-blank/prod-fused.ts`: **187/231** (within master variance band 186-193).
- 1656/1656 runtime tests pass.

Cost unchanged — reasoning tokens still computed and counted in `usage.completion_tokens_details.reasoning_tokens`.

## Why gated to gpt-oss-120b

Cerebras docs scope `reasoning_format` to gpt-oss-120b and zai-glm-4.7. zai already runs at `reasoning_effort: none` (no reasoning text to hide); the parameter is a no-op there. Tight gating avoids sending an unknown field to other providers.

## Why no runtime toggle

Semantic-neutral change (same internal generation, identical content bytes). Bench data is clear. Always-on for cerebras gpt-oss-120b. Documented in [`docs/architecture/cerebras.md` § Hidden reasoning format](docs/architecture/cerebras.md#hidden-reasoning-format-on-gpt-oss-120b).

## Version bumps

- `@opencues/core` 0.3.18 → 0.3.19.
- `@opencues/chrome` 0.2.18 → 0.2.19 (bundle bytes change; manifest + package.json in lockstep).
- `@opencues/runtime` unchanged.

## Upgrade path after merge

1. `git pull`
2. `opencues install claude-code` / `opencode` / `gemini-cli` / `chrome` for each host you use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)