### PR TITLE
docs(cc): align stale 2.1.110/2.1.150 literals with the canonical 2.1.170 pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ host and the runtime.
 
 
 **Current Integrations**:
-- **Claude Code** (`integrations/claude-code/`) — patches Claude Code 2.1.x (tested 2.1.110 cli.js + 2.1.150 native binary) via tweakcc 4.0.13+
+- **Claude Code** (`integrations/claude-code/`) — patches Claude Code 2.1.x (current pin 2.1.170 native binary; tested versions in `integrations/claude-code/compat.json`) via tweakcc 4.0.13+
 - **OpenCode** (`integrations/opencode/`) — patches OpenCode 1.4.x; runtime loaded inline
 - **Chrome** (`integrations/chrome/`) — MV3 extension; CSS Custom Highlight API for in-page rendering
 - **Gemini CLI** (`integrations/gemini-cli/`) — patches Gemini CLI 0.41.x; React/Ink host with a render-kick + ZWS-toggle pull model. See its CLAUDE.md for the React quirks (it's the first React/Ink host so the integration was non-trivial).
@@ -46,15 +46,13 @@ Two Claude Code installs exist on this machine. **OpenCues work targets `claude-
 
 | Command | Location | Version | Purpose |
 |---|---|---|---|
-| `claude-cues` | `~/claude-code-cues` (local npm) | 2.1.110 (cli.js, pegged) | OpenCues patches applied here — npm cli.js shape |
-| `claude-cues-150` | `~/claude-code-cues-150` (local npm) | 2.1.150 (native bun-binary) | OpenCues patches applied here — native-binary shape (post-2.1.113 cutover) |
-| `claude-cues-158` | `~/claude-code-cues-158` (local npm) | 2.1.158 (native bun-binary) | OpenCues patches applied here — same v2.1 adapter band as 150 (all 4 seams S1/S2/S3/S7 still hit) |
-| `claude-cues-170` | `~/claude-code-cues-170` (local npm) | 2.1.170 (native bun-binary) | OpenCues patches applied here — **latest tested** (June 2026), same v2.1 adapter band; S6 still missing (gone since 2.1.150, statusline polls); S1/S2/S3/S7 all hit; agentic core suite (01/02/03/07/14) green |
+| `claude-cues` | `~/claude-code-cues` (local npm) | 2.1.170 (native bun-binary, pegged via `compat.json:current-pin`) | OpenCues patches applied here |
 | `claude` | `~/.local/bin/claude` (native) | latest | Clean/unpatched — development use |
 
-- Both `claude-cues` and `claude-cues-150` are patched instances. `setup.sh` targets the cli.js fork; the native-binary fork is patched via tweakcc 4.0.13+'s `.bun` ELF section extract/repack.
+- `claude-cues` is the only patched instance. The 2.1.113+ native bun-binary shape is patched via tweakcc 4.0.13+'s `.bun` ELF section extract/repack (the pre-2.1.113 cli.js shape used a direct minified-JS patch — same `setup.sh` auto-detects which shape is present).
 - `claude` is never patched. Use it for unaffected Claude Code sessions during development.
 - Each patched fork is pegged to its declared version — do not upgrade without re-running the [UPGRADING runbook](integrations/claude-code/UPGRADING.md) to verify the five seam anchors (S1/S2/S3 required, S6/S7 optional).
+- Multi-version dev forks (`~/claude-code-cues-150/`, `-158/`, `-170/`) were retired June 2026. Re-spawn one for a targeted version test, but don't keep them around as ambient drift surfaces — `opencues install claude-code` fans out across every `~/claude-code-cues*` dir it finds and stale forks rebuild silently, which is more cost than they're worth when no active test work is using them.
 
 > **Self-healing on `opencues run <host>` (shipped June 2026).** Every
 > `opencues run <host>` invocation now reads the fork's `version.json`
@@ -249,7 +247,8 @@ export GROQ_API_KEY="your-key"
    library-script sync + 0-byte OPENCUES.md self-heal + colocated `.cs`
    compile (WSL only).
 2. **`integrations/claude-code/patches/setup.sh`** — strictly CC-specific.
-   Default behavior: nuke + rebuild from scratch. Pinned `@anthropic-ai/claude-code@2.1.110`
+   Default behavior: nuke + rebuild from scratch. Pinned `@anthropic-ai/claude-code`
+   (version from `integrations/claude-code/compat.json:current-pin`, today 2.1.170)
    reinstalled + cloned tweakcc inside `<CC_FORK>/.cues/tweakcc/` +
    `@opencues/{core,runtime}` built and installed into `<CC_FORK>/node_modules/@opencues/`
    + statusline.sh into `<CC_FORK>/.cues/` + tweakcc patched (only

--- a/integrations/claude-code/UPGRADING.md
+++ b/integrations/claude-code/UPGRADING.md
@@ -58,7 +58,7 @@ text-level patch surface is identical; only the install pipeline differs.
 The compat manifest at `integrations/claude-code/compat.json` is the source of
 truth for what we've tested.
 
-## The seam inventory (current as of 2.1.150)
+## The seam inventory (current as of 2.1.170)
 
 The patch is **anchored on five seams** in cli.js. Same-patch and same-minor
 bumps usually leave all five intact; cross-minor refactors can move any of

--- a/integrations/claude-code/bin/install.cjs
+++ b/integrations/claude-code/bin/install.cjs
@@ -293,7 +293,7 @@ function ensureCanonicalForkExists(forkRoot) {
   const pkgPath = path.join(forkRoot, 'package.json');
   if (!fs.existsSync(pkgPath)) {
     const compat = JSON.parse(fs.readFileSync(path.join(PKG_DIR, 'compat.json'), 'utf8'));
-    const pin = compat['current-pin'] || '2.1.150';
+    const pin = compat['current-pin'] || '2.1.170';
     fs.writeFileSync(pkgPath, JSON.stringify({
       private: true,
       dependencies: { '@anthropic-ai/claude-code': pin },
@@ -586,17 +586,19 @@ function tryAutoDetectCli() {
 // install target. Returns [{root, target, shape: 'cli.js' | 'native'}].
 //
 // Why this matters: prior to today, install.cjs only patched whichever
-// single fork tryAutoDetectCli() returned first. Users with both the
-// 2.1.110 cli.js fork AND the 2.1.150 native-binary fork would re-run
-// install thinking it'd update both — silently the 150 fork stayed
-// unpatched. (Documented in CLAUDE.md root § Claude Installs.) Now
-// install enumerates every fork + patches each in turn.
+// single fork tryAutoDetectCli() returned first. Users running both the
+// canonical fork AND a versioned dev fork (e.g. `~/claude-code-cues-150/`)
+// would re-run install thinking it'd update both — silently the dev fork
+// stayed unpatched. (Documented in CLAUDE.md root § Claude Installs.)
+// Now install enumerates every fork + patches each in turn.
 //
 // Lookup order:
 //   1. Standard `~/.claude/node_modules/...` (rare — pre-fork-era layout)
-//   2. `~/claude-code-cues/` (default cli.js fork, CC ≤ 2.1.111)
-//   3. `~/claude-code-cues-150/` (default native-binary fork, CC ≥ 2.1.113)
-//   4. Any other `~/claude-code-cues-*/` (user-named forks)
+//   2. `~/claude-code-cues/` (canonical fork; shape auto-detected — today's
+//      pin in compat.json:current-pin is 2.1.170 native bun-binary, older
+//      pins fell on the cli.js shape)
+//   3. Any other `~/claude-code-cues-*/` (user-named version-test forks
+//      — see CLAUDE.md § Claude Installs for the dev-fork retirement note)
 //
 // An explicit --target overrides the auto-detection — single-fork mode.
 function detectAllForks() {

--- a/integrations/claude-code/patches/setup.sh
+++ b/integrations/claude-code/patches/setup.sh
@@ -2,12 +2,17 @@
 #
 # setup.sh — install OpenCues into Claude Code (claude-cues fork).
 #
-# Scope: handles the **npm cli.js** install shape (Claude Code 2.1.111 and
-# earlier — default fork `~/claude-code-cues/`, pinned to 2.1.110). For
-# the **native bun-binary** shape (2.1.113+, including 2.1.150 — default
-# fork `~/claude-code-cues-150/`), see `integrations/claude-code/UPGRADING.md`
-# § "Reinstall" — tweakcc 4.0.13+ patches the binary directly; the install
-# pipeline differs at the npm-install step but the patch source is identical.
+# Scope: handles BOTH install shapes structurally — the npm **cli.js**
+# shape (Claude Code 2.1.111 and earlier) and the **native bun-binary**
+# shape (2.1.113+, including today's pinned 2.1.170). Same script,
+# same patch source; `setup.sh` auto-detects which artifact is present
+# under the fork's `node_modules/@anthropic-ai/claude-code/` and hands
+# the right path to tweakcc — tweakcc 4.0.13+ patches cli.js directly,
+# or for native binaries extracts cli.js from the `.bun` ELF section,
+# patches the text, and repacks. The version pin lives in
+# `integrations/claude-code/compat.json:current-pin` (today 2.1.170);
+# see `integrations/claude-code/UPGRADING.md` for the version-bump
+# runbook.
 #
 # Always-from-scratch by default: every install nukes prior state and
 # rebuilds deterministically. The ONLY way to drift is to opt in via
@@ -19,7 +24,7 @@
 # State that gets nuked + rebuilt every install (default):
 #   ~/claude-code-cues/.cues/                            recreated (incl. tweakcc clone)
 #   ~/claude-code-cues/node_modules/@opencues/{core,runtime}/  rebuilt + recopied
-#   ~/claude-code-cues/node_modules/@anthropic-ai/       reinstalled (pinned 2.1.110, cli.js shape)
+#   ~/claude-code-cues/node_modules/@anthropic-ai/       reinstalled (pin from compat.json:current-pin, today 2.1.170 native bun-binary)
 #
 # State that survives every install:
 #   ~/.cues/  (incl. OPENCUES.md)                        user content (your CUE.md / BLANK.md edits etc.)
@@ -156,11 +161,18 @@ if [ -n "${OPENCUES_CC_TARGET:-}" ]; then
 else
   CC_FORK_DIR="$HOME/claude-code-cues"
 fi
+# Resolve the canonical CC pin from compat.json (single source of truth).
+# Falls back gracefully if compat.json is unreadable so a one-off setup.sh
+# invocation against a side fork doesn't hard-fail.
+COMPAT_JSON="$(dirname "$0")/../compat.json"
+CC_PIN=$(node -e "try{process.stdout.write(JSON.parse(require('fs').readFileSync('$COMPAT_JSON','utf8'))['current-pin']||'')}catch{}" 2>/dev/null || true)
+[ -z "$CC_PIN" ] && CC_PIN="2.1.170"
+
 if [ ! -f "$CC_FORK_DIR/package.json" ]; then
   echo "Error: $CC_FORK_DIR/package.json missing." >&4
   echo "Create the fork dir first with a package.json that pins claude-code:" >&4
   echo "  mkdir -p $CC_FORK_DIR" >&4
-  echo "  echo '{\"dependencies\":{\"@anthropic-ai/claude-code\":\"2.1.110\"}}' > $CC_FORK_DIR/package.json" >&4
+  echo "  echo '{\"dependencies\":{\"@anthropic-ai/claude-code\":\"$CC_PIN\"}}' > $CC_FORK_DIR/package.json" >&4
   exit 1
 fi
 # Sanity-check the pin is exact (no caret / tilde — those allow drift).
@@ -168,7 +180,7 @@ PINNED_VERSION=$(node -e "process.stdout.write(JSON.parse(require('fs').readFile
 if [[ "$PINNED_VERSION" =~ ^(\^|~) ]]; then
   echo "Warning: $CC_FORK_DIR/package.json pins @anthropic-ai/claude-code with a range ($PINNED_VERSION)." >&4
   echo "  Caret/tilde ranges allow npm install to drift to incompatible versions." >&4
-  echo "  Edit package.json to pin an EXACT version (e.g. \"2.1.110\")." >&4
+  echo "  Edit package.json to pin an EXACT version (e.g. \"$CC_PIN\")." >&4
 fi
 
 OC_INSTALL_ROOT="$CC_FORK_DIR/.cues"


### PR DESCRIPTION
## Summary

- `compat.json:current-pin` is `2.1.170` (native bun-binary) and the canonical fork at `~/claude-code-cues/` is on 2.1.170 in practice, but several docs + the install help text still pointed users at older versions (cli.js 2.1.110 / native 2.1.150).
- A fresh first-time installer reading CLAUDE.md was being told the canonical fork is "2.1.110 cli.js, pegged", and the `setup.sh` "package.json missing" help-text instructed them to write `2.1.110` into their fork's package.json — they'd land on the wrong CC version.
- Doc-only PR. No behaviour change in any code path that reads compat.json's pin; only the fallback literals + help text move forward.

## What changed

| File | Change |
|---|---|
| `CLAUDE.md` (root) | "Claude Installs" canonical row → 2.1.170 native bun-binary; dev-fork narrative tightened. "Quick Install" pin reference reads `compat.json:current-pin` instead of hard-coded 2.1.110. |
| `integrations/claude-code/patches/setup.sh` | Header reframed (single-shape → "handles both shapes structurally"). Help text + exact-pin warning now read pin from `compat.json` with a 2.1.170 fallback. |
| `integrations/claude-code/bin/install.cjs` | `compat['current-pin'] \|\| '2.1.150'` fallback bumped to `'2.1.170'`. `detectAllForks` comment block reframed: lookup #2 is "the canonical fork; shape auto-detected" rather than "default cli.js fork, CC ≤ 2.1.111". |
| `integrations/claude-code/UPGRADING.md` | Seam-inventory heading bumped from "current as of 2.1.150" → "current as of 2.1.170" (same seams still hit per CLAUDE.md; the heading was last bumped a minor behind reality). Other 2.1.150 / 2.1.110 references in UPGRADING.md are historical narrative (anchor refactors) and stay. |

## Why now

Doctor showed clean post-install but a quick check of `~/claude-code-cues/node_modules/@anthropic-ai/claude-code/package.json` revealed it was at 2.1.170 while CLAUDE.md still said 2.1.110. The 158/170 dev forks were retired in the same session, surfacing the docs drift on the canonical row.

## Test plan

- [x] `grep -rn "2\.1\.110\|2\.1\.150" CLAUDE.md integrations/claude-code/` — remaining hits are intentional historical narrative in UPGRADING.md (anchor-refactor notes, version-transition examples), not stale state claims.
- [x] `setup.sh` syntax check: `bash -n integrations/claude-code/patches/setup.sh`.
- [x] `node -e "require('./integrations/claude-code/bin/install.cjs')"` loads cleanly.
- [x] The canonical fork's `~/claude-code-cues/package.json` already at 2.1.170 — no install state changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)