### PR TITLE
docs(transform-blank): user-facing examples use natural typing order (body first, instruction last)

### DIFF
--- a/docs/architecture/transform-blank.md
+++ b/docs/architecture/transform-blank.md
@@ -36,7 +36,7 @@ substitutes an answer at `_`. But people often want the opposite:
 instruction.
 
 ```
-You type:   change boy to girl _ the boy ran fast
+You type:   the boy ran fast change boy to girl _
 You see:    the girl ran fast
 ```
 
@@ -77,22 +77,23 @@ match any obvious imperative verb). The cost of one EXTRACT call per
 non-transform `_` is ~400ms, which is acceptable for the cleanliness
 gain.
 
-### Two layouts the user can type
-
-Both work — the EXTRACT prompt is trained on both:
+### The shape — body first, instruction last
 
 ```
-(a) <INSTRUCTION> _ <TARGET>
-    e.g.  change boy to girl _ the boy ran fast
-
-(b) <TARGET> <INSTRUCTION> _
-    e.g.  the boy ran fast change boy to girl _
+<TARGET> <INSTRUCTION> _
+e.g.  the boy ran fast change boy to girl _
 ```
 
-Real users mostly do (b) — they type their text first, then realize
-they want to transform it, and add the imperative at the end. (a) is
-more common when a user is dictating an imperative they've already
-formulated.
+This is the only shape live typing can produce: `_` triggers the
+moment you press it, so anything you'd type *after* `_` would never
+reach the source. The body has to be in the buffer before `_` lands.
+
+The inverted shape `<INSTRUCTION> _ <TARGET>` exists as a parser
+target — the EXTRACT prompt is trained on both layouts so a pasted
+snippet, a synthetic bench case, or text you constructed by editing
+*back* into the middle of the buffer all still classify correctly.
+But that's a paste-or-edit path, not a typing path. Examples in
+user-facing docs should use `<TARGET> <INSTRUCTION> _` exclusively.
 
 ---
 
@@ -836,7 +837,7 @@ TransformBlank P2 APPLY: 1 step(s) — ["change boy to girl"]
 TransformBlank P2 APPLY step 1/1 (227ms, max_tokens=812): "the girl ran fast"
 TransformBlank P3 VERIFY: SKIPPED (low-stakes instruction + faithful draft)
 TransformBlank: pipeline done (578ms total) — final="the girl ran fast"
-TransformBlank: substituting "change boy to girl _ the boy ran fast" → "the girl ran fast" (origLen=42, rewriteLen=18, defAt=0)
+TransformBlank: substituting "the boy ran fast change boy to girl _" → "the girl ran fast" (origLen=42, rewriteLen=18, defAt=0)
 ```
 
 Each log line maps to a code location in `transform-blank-source.ts`

--- a/docs/features/agent-task.md
+++ b/docs/features/agent-task.md
@@ -6,7 +6,7 @@ on every debounce. Edits appear as dimmed words you can navigate to and
 revert with cycle Down.
 
 ```
-You type:   agentically correct spelling _ I rite some text witth typos
+You type:   I rite some text witth typos agentically correct spelling _
 You see:    I write some text with typos
             (with "write" and "with" dimmed — the agent's edits)
 
@@ -18,9 +18,9 @@ You type:   stop task _
             agent cleared. Existing dimmed edits stay.
 ```
 
-Where **transform-blank** is one-shot ("change boy to girl _ ..." fires
-once), agent-task is **persistent** — the instruction stays armed and
-fires on every typing pause until you stop it.
+Where **transform-blank** is one-shot ("the boy ran change boy to girl _"
+fires once), agent-task is **persistent** — the instruction stays armed
+and fires on every typing pause until you stop it.
 
 ---
 

--- a/docs/features/transform-blank.md
+++ b/docs/features/transform-blank.md
@@ -5,14 +5,14 @@ runtime rewrites the surrounding text per the instruction (or generates
 new content from scratch when no surrounding text is given).
 
 ```
-You type:   change boy to girl _ the boy ran fast
+You type:   the boy ran fast change boy to girl _
 You see:    the girl ran fast
-Press ↓ :   change boy to girl _ the boy ran fast   (revert)
+Press ↓ :   the boy ran fast change boy to girl _   (revert)
 Press ↑ :   the girl ran fast                        (apply)
 ```
 
 Where **fluid-blank** answers questions at `_` ("capital of france _" → Paris),
-**transform-blank** edits text around `_` ("change boy to girl _ the boy ran"
+**transform-blank** edits text around `_` ("the boy ran change boy to girl _"
 → "the girl ran") OR generates new content ("write a poem _" → a poem).
 
 ---
@@ -37,20 +37,19 @@ fluid-blank-mode: on  # both blank handlers can coexist; instructions go to
 
 ---
 
-## Two layouts
-
-The instruction can sit either side of `_`:
+## The shape — body first, instruction at the end
 
 ```
-(a) <INSTRUCTION> _ <TARGET>
-    e.g.  change boy to girl _ the boy ran fast
-
-(b) <TARGET> <INSTRUCTION> _
-    e.g.  the boy ran fast change boy to girl _
+<TARGET> <INSTRUCTION> _
+e.g.  the boy ran fast change boy to girl _
 ```
 
-Both work. Most people end up using (b) — they type the text first,
-realize they want to transform it, then add the imperative at the end.
+Body first, instruction last, `_` triggers the rewrite. This is the
+only shape that works for live typing because `_` resolves the moment
+you type it — anything you'd type *after* `_` would never reach the
+source. (The EXTRACT prompt is also trained on the inverted layout
+`<INSTRUCTION> _ <TARGET>` so a pasted snippet shaped that way still
+parses, but you can't get there by typing.)
 
 ---
 
@@ -105,35 +104,34 @@ rate ~83%, ~1.4s per case end-to-end on Groq gpt-oss-120b.
 
 | Category | Example |
 |---|---|
-| literal swap | `change boy to girl _ the boy ran` |
-| multi-span | `replace USD with EUR _ price is 10 USD plus 2 USD` |
-| concept | `he/she swap _ he gave the book to John` |
-| transform | `make past tense _ I run to the store` |
-| math | `add 10% _ original price 100, final price 100` |
-| linked-concepts | `change pet from dog to cat _ the dog wagged its tail and barked` |
-| targeted scope | `capitalize the names _ john and sarah went to lunch` |
-| composed (X and Y) | `make past tense and remove pronouns _ I run to the store` |
-| trailing-instruction | `the boy ran fast change boy to girl _` |
-| code-transform | `convert var to const _ var name = "alice"; var age = 30;` |
-| adversarial | `change the word change to modify _ I want to change my approach` |
+| literal swap | `the boy ran change boy to girl _` |
+| multi-span | `price is 10 USD plus 2 USD replace USD with EUR _` |
+| concept | `he gave the book to John he/she swap _` |
+| transform | `I run to the store make past tense _` |
+| math | `original price 100, final price 100 add 10% _` |
+| linked-concepts | `the dog wagged its tail and barked change pet from dog to cat _` |
+| targeted scope | `john and sarah went to lunch capitalize the names _` |
+| composed (X and Y) | `I run to the store make past tense and remove pronouns _` |
+| code-transform | `var name = "alice"; var age = 30; convert var to const _` |
+| adversarial | `I want to change my approach change the word change to modify _` |
 | negative (correctly bails) | `capital of france _` |
 
 ### Mid categories (70-90%)
 
 | Category | Example |
 |---|---|
-| long-text (40 cases, 4 sub-buckets) | `make past tense _ <multi-paragraph input>` |
-| creative-rewrite | `translate to pirate speak _ Hello, where is the bathroom?` |
-| format-transform | `convert to bullet points _ I need eggs, milk, bread, cheese` |
-| multi-paragraph | `change protagonist to wizard _ <2-3 paragraph story>` |
-| conditional | `change boy to girl but not in the second sentence _ The boy ran. ...` |
+| long-text (40 cases, 4 sub-buckets) | `<multi-paragraph input> make past tense _` |
+| creative-rewrite | `Hello, where is the bathroom? translate to pirate speak _` |
+| format-transform | `I need eggs, milk, bread, cheese convert to bullet points _` |
+| multi-paragraph | `<2-3 paragraph story> change protagonist to wizard _` |
+| conditional | `The boy ran. ... change boy to girl but not in the second sentence _` |
 
 ### Weak categories (50-70%)
 
 | Category | Example |
 |---|---|
-| context-referring | `match the style of the first sentence _ ...` |
-| tone-shift | `make it more confident _ I think maybe we should perhaps consider` |
+| context-referring | `... match the style of the first sentence _` |
+| tone-shift | `I think maybe we should perhaps consider make it more confident _` |
 
 The persistent floor (~17%) is mostly upstream model variance + judge
 calibration on open-ended cases ("make it casual", "match the style of
@@ -172,7 +170,7 @@ TransformBlank P2 APPLY: 1 step(s) — ["change boy to girl"]
 TransformBlank P2 APPLY step 1/1 (227ms, max_tokens=812): "the girl ran fast"
 TransformBlank P3 VERIFY: SKIPPED (low-stakes instruction + faithful draft)
 TransformBlank: pipeline done (578ms total) — final="the girl ran fast"
-TransformBlank: substituting "change boy to girl _ the boy ran fast" → "the girl ran fast" (origLen=42, rewriteLen=18, defAt=0)
+TransformBlank: substituting "the boy ran fast change boy to girl _" → "the girl ran fast" (origLen=42, rewriteLen=18, defAt=0)
 ```
 
 Composed instructions show one APPLY line per step:

--- a/integrations/gemini-cli/CLAUDE.md
+++ b/integrations/gemini-cli/CLAUDE.md
@@ -381,6 +381,6 @@ re-applying). If you ever see weird patch state, just re-run setup.
 | `volume _` | Cue-blank script | `_` auto-populates to e.g. `25%`; up/down on it adjusts system volume |
 | `weather _` | Cue-blank HTTP | `_` auto-populates with current temp |
 | `atomic number of oxygen _` | Fluid blank | LLM substitutes `8` |
-| `fix typos _ this is bad righting` | Transform blank | Rewrites to `this is bad writing` |
+| `this is bad righting fix typos _` | Transform blank | Rewrites to `this is bad writing` |
 | `opencues settings _` | Selector blank | Shows e.g. `voice-mode active`; up/down toggles |
 | Any active cycle | Footer | Shows `attorney (2/5) - …` while cycling |


### PR DESCRIPTION
## Summary

\`_\` triggers the moment you press it, so any text typed AFTER \`_\` never reaches the source. Several user-facing docs taught the inverted layout \`<INSTRUCTION> _ <TARGET>\` (e.g. \`change boy to girl _ the boy ran\`) as if it were a typing pattern. It isn't — it's a parser target only.

This PR scrubs the inverted layout from every example a user encounters and reframes the architecture doc so future examples don't reintroduce it.

## What changed

| File | Change |
|---|---|
| \`docs/features/transform-blank.md\` | Headline + inline example flipped to body-first. \"Two layouts\" section replaced with \"The shape — body first, instruction at the end\" + a one-paragraph explanation of why the inverted layout is paste-only. All 15 strong/mid/weak table examples flipped. Dropped now-redundant \`trailing-instruction\` row from the strong table. Substitute log example reflects the buffer at trigger time. |
| \`docs/features/agent-task.md\` | Headline example + transform-blank cross-reference flipped. |
| \`integrations/gemini-cli/CLAUDE.md\` | \"Test prompts\" table row for transform blank flipped. |
| \`docs/architecture/transform-blank.md\` | Headline example flipped. \"Two layouts the user can type\" section reframed: still documents that EXTRACT is trained on both layouts (structural fact behind why paste still works), but reframes the inverted layout as a paste/edit path with the explicit rule *\"Examples in user-facing docs should use \`<TARGET> <INSTRUCTION> _\` exclusively\"*. Substitute log example reflects buffer at trigger time. |

## What stayed

- \`tests/benchmarks/transform-blank/cases.ts\` and friends — synthetic inputs submitted to the source, not user-typing illustrations. The EXTRACT prompt still handles both layouts in production, so the bench cases are valid as-is.
- The architecture doc's note that EXTRACT trains on both layouts — kept, because that's why paste/edit-after-typing still works. It's just no longer presented as a co-equal typing option.

## Why this matters

Future docs (and AI-generated examples) were anchoring on the inverted layout because the architecture doc presented both as equally valid. The user-facing rule is now explicit: body first, instruction last, \`_\` triggers.

## Test plan

- [x] \`grep -rnE \"(change [a-z]+ to|make past tense|translate to|...) _ [A-Za-z<]\" docs/ CLAUDE.md README.md concept.md spec/ integrations/*/CLAUDE.md integrations/*/docs/\` → no remaining hits.
- [x] \`grep -n \"_ \" docs/features/transform-blank.md\` → every remaining \`_\` is at the natural end-of-input position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)