### PR TITLE
fix(core): word-cue in-progress gate no longer drops every word when cursor is unknown (regression from #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — Word-cue dispatch: in-progress-word gate no longer fires on unknown cursor (regression from #136)
+
+PR #136 (`perf(core): skip in-progress trailing word from word-cue dispatch`) introduced a `findInProgressTrailingWord` gate that drops the trailing word from word-cue dispatch when the user is actively typing at end-of-buffer. The gate's three checks: (1) buffer non-empty, (2) buffer doesn't end in whitespace, (3) cursor is at end-of-buffer.
+
+The original implementation got the third check wrong: it treated `cursor === undefined` as "assume end-of-buffer typing" — i.e. fired the gate when cursor was unknown. This silently dropped the only word in every CueContext that omitted `cursor`, which included almost every pre-existing core test (`output.test.ts` `ctx(text)` helper, `build-sources.providers.test.ts` literal contexts, etc.).
+
+The CI billing block from 2026-06-13 22:33Z hid the breakage for ~5h across PRs #135–#140. With billing resolved, `build · typecheck · test` started failing in 28 places — every single one was the same root cause.
+
+Fix: flip the unknown-cursor default to "don't skip". The gate now requires `cursor` to be **known AND at end-of-buffer**. Production hosts (CC v2.1, OC v1.14, gemini-cli, chrome, shell) always pass `cursor`, so the perf optimisation still fires on every real typing surface — only headless tests, agentic bare-injection, and any future host that doesn't expose cursor stop being silently penalised. `mkContextTyping` test helper updated to set `cursor: text.length` explicitly so PR #136's own gate-firing tests still exercise the optimisation.
+
+Net: 870/879 core tests pass (was 842/879), 1656/1656 runtime tests pass, no behaviour change for production hosts.
+
+Bumps:
+- `@opencues/core` 0.3.20 → 0.3.21.
+
 ### Perf — Cerebras gzip request compression; FUSED_SYSTEM payloads shrink 68%, TransformBlank median −100ms / p95 −179ms
 
 Cerebras's inference API accepts gzip-compressed request bodies via standard HTTP `Content-Encoding: gzip` ([docs](https://inference-docs.cerebras.ai/capabilities/payload-optimization)). `NodeHttpAdapter` now gzips every outbound request to `api.cerebras.ai` and adds the header. Gating lives in a single `GZIP_REQUEST_HOSTS` set; other providers stay on plain JSON.

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/routed-word-source-group.test.ts
+++ b/packages/opencues-core/src/sources/routed-word-source-group.test.ts
@@ -43,8 +43,13 @@ function mkContext(words: string[]): CueContext {
 }
 
 function mkContextTyping(words: string[]): CueContext {
-  // No trailing space — last word is "in-progress" per the gate.
-  return { text: words.join(' '), words };
+  // No trailing space + cursor at end-of-buffer — the two conditions
+  // the in-progress-word gate (June 2026) requires before it fires.
+  // Cursor is explicit because the gate's unknown-cursor default is
+  // "don't skip" (the production-safe choice; only known-end-cursor
+  // skips the trailing word).
+  const text = words.join(' ');
+  return { text, words, cursor: text.length };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/opencues-core/src/sources/routed-word-source-group.ts
+++ b/packages/opencues-core/src/sources/routed-word-source-group.ts
@@ -52,21 +52,28 @@ interface RouteEntry {
  * word-cue dispatch so the LLM doesn't burn round-trips on partial
  * words it would correctly ignore anyway.
  *
- * Returns the trailing word's index (in `context.words`) when:
+ * Returns the trailing word's index (in `context.words`) when ALL of:
  *   - The buffer is non-empty AND
  *   - The buffer doesn't end in whitespace (so the last word hasn't
  *     been "closed" with a space/newline) AND
- *   - The cursor (if known) sits at the end of the buffer (the user
- *     is actively typing there, not editing mid-text).
+ *   - The cursor is **known** AND sits at the end of the buffer (the
+ *     user is actively typing there, not editing mid-text).
  *
- * Returns null otherwise — including the common case of cursor in
- * the middle of the buffer (mid-edit), where skipping the trailing
- * word would silently regress mid-text spelling/cue surfacing.
+ * Returns null otherwise — including:
+ *   - Cursor in the middle of the buffer (mid-edit) — skipping the
+ *     trailing word would silently regress mid-text spelling cues.
+ *   - Cursor undefined (headless tests, agentic bare-injection,
+ *     hosts that don't expose cursor) — we can't tell typing from
+ *     pasted/edit-after, so we let everything through. The perf gate
+ *     is a production optimisation, not a correctness guarantee;
+ *     defaulting to "include" when we don't know is the structurally
+ *     safer choice (June 2026 — the earlier "assume end-of-buffer"
+ *     default silently dropped single-word inputs in every test that
+ *     omits `cursor`, masking real cue regressions).
  *
- * When `context.cursor` is undefined (headless tests, agentic
- * harness bare-injection mode), we conservatively assume the cursor
- * is at end-of-buffer — matches the default behaviour of every
- * shipped host and keeps the optimisation firing where it matters.
+ * Production hosts (CC v2.1, OC v1.14, gemini-cli, chrome, shell)
+ * always pass `cursor`, so the optimisation still fires on every
+ * real typing surface.
  */
 function findInProgressTrailingWord(context: CueContext): number | null {
   const text = context.text;
@@ -74,9 +81,9 @@ function findInProgressTrailingWord(context: CueContext): number | null {
   // Buffer ends with whitespace → last word is complete (user typed
   // space after finishing it).
   if (/\s$/.test(text)) return null;
-  // Cursor explicitly mid-text → user is editing somewhere other than
-  // the trailing word; don't skip it.
-  if (context.cursor !== undefined && context.cursor >= 0 && context.cursor < text.length) {
+  // Cursor must be known AND at end-of-buffer for the gate to fire.
+  // Anything else (undefined cursor, cursor mid-text) → don't skip.
+  if (context.cursor === undefined || context.cursor < text.length) {
     return null;
   }
   // Trailing word is in-progress: return its index in `context.words`.


### PR DESCRIPTION
## Summary

- PR #136's \`findInProgressTrailingWord\` gate treated \`cursor === undefined\` as \"assume end-of-buffer typing\" — i.e. **fired the gate when cursor was unknown**. That silently dropped the only word in every CueContext that omitted \`cursor\`.
- The CI billing block from 2026-06-13 22:33Z onward hid the breakage for ~5h across PRs #135–#140. With billing resolved, \`build · typecheck · test\` started failing in 28 places — every single one rooted in this default.
- Fix: the gate now requires \`cursor\` to be **known AND at end-of-buffer**. Production hosts (CC v2.1, OC v1.14, gemini-cli, chrome, shell) all pass cursor, so the perf optimisation still fires on every real typing surface — only headless / dev-tooling paths stop being silently penalised.

## What changed

| File | Change |
|---|---|
| \`packages/opencues-core/src/sources/routed-word-source-group.ts\` | Flipped the unknown-cursor default in \`findInProgressTrailingWord\`. Now: \`if (context.cursor === undefined \|\| context.cursor < text.length) return null;\` JSDoc rewritten to call out why unknown-cursor falls through. |
| \`packages/opencues-core/src/sources/routed-word-source-group.test.ts\` | \`mkContextTyping\` helper now sets \`cursor: text.length\` explicitly so PR #136's own gate-firing tests (sole-word-in-progress, partial-word-skipped, etc.) still exercise the optimisation. |
| \`packages/opencues-core/package.json\` | \`@opencues/core\` 0.3.20 → 0.3.21 |
| \`CHANGELOG.md\` | Entry under Unreleased |

## Results

- **\`@opencues/core\`**: 842/879 pass → **870/879 pass** (9 skipped, 0 fail). All 28 failures cleared.
- **\`@opencues/runtime\`**: 1656/1656 pass (unchanged — not affected by the gate; the regression was purely on the core dispatch layer).

## Why this was hard to spot

The 28 failures all decoded to the same root cause but presented as unrelated test-name failures (\`word output: basic sentences\`, \`sentences: simple grammar\`, \`buildSourcesFromConfig — per-feature provider routing\`, etc.). Each test reads \`r.results.length === 1\` and sees \`0\` — which looks like a different bug per test until you notice they all use a CueContext helper that omits \`cursor\`.

The optimisation's win in production is unchanged: real hosts always pass cursor, so the gate keeps firing on every typing pause. Only the \"cursor unknown\" path moved from \"fail closed for perf\" to \"fail open for correctness\".

## Test plan

- [x] \`pnpm -C packages/opencues-core test\` → 870/879 pass (was 842/879).
- [x] \`pnpm -C packages/opencues-runtime test\` → 1656/1656 pass (unchanged).
- [x] The 6 PR #136 gate-firing tests in \`routed-word-source-group.test.ts\` still exercise the gate (via updated \`mkContextTyping\` helper that sets cursor at end-of-buffer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)