### PR TITLE
feat(runtime): shape-driven blanks — three-axis model + four migrations (volume / brightness / weather / stocks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,8 @@ Every runtime change gates on `blankShapes:` being present on the blank. Shape-l
 - Manual UX validation in a real opencode session: volume + brightness selector-satellite + cycling; weather + stocks one-span emission; prose misfire reject across all four; OPENCUES settings dual-axis preserved; backspace wipes the whole substitution for both shapes.
 
 Bumps:
-- `@opencues/core` 0.3.21 → 0.3.22.
-- `@opencues/runtime` 0.3.10 → 0.3.11.
+- `@opencues/core` 0.3.21 → 0.3.23.
+- `@opencues/runtime` 0.3.10 → 0.3.12.
 
 ### Fix — Word-cue dispatch: in-progress-word gate no longer fires on unknown cursor (regression from #136)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,61 @@ Bumps:
 - `@opencues/shell` 0.2.0 → 0.2.1.
 - `@opencues/chrome` 0.2.19 → 0.2.20 (manifest.json bumped in lockstep).
 
+### Feat — Shape-driven blanks: three-axis model (`blankShapes:` + `set <value>` script contract + cycle vocab) + atomic-pair navigation + four migrations (volume, brightness, weather, stocks)
+
+Replaces the coarse `blankProximity:` gate with declarative shape patterns for script-backed blanks. Adds the `<script> set <value>` echo contract that lets natural-language setters land (`volume 70 _` / `set volume to 70 _` / `set brightness to 80 _` actually adjust the system). Two emission shapes — selector-satellite for cyclable blanks, one-span for read-only — with the appropriate render + navigation semantics for each.
+
+Full design + reasoning: `docs/architecture/shape-driven-blanks.md` (new, canonical reference).
+
+**Schema + runtime additions**
+
+- `blankShapes:` field on `BlankConfig` — array of `{pattern, action, valueGroup?}` parsed from inline JSON, mirroring the `stepValues:` pattern.
+- `BlankSlot.action` + `BlankSlot.value` carry the shape match through the runtime to the script invocation.
+- `matchKeyword` (BlankFill) bypasses the proximity gate when shapes are declared; walks shapes against the input, first match wins, declines the slot if no shape matches.
+- `maybeRunScripts` dispatches `<script> set <value>` when the matched shape's action is `set`; cache key includes action+value so SET-70 and SET-30 don't collide.
+- `applySatelliteFill` uses line-scoped wipe for shape-driven matches (the whole shape-matched input gets replaced with the satellite pair, surrounding paragraphs preserved).
+- `cycleSelectorSatellite` gained two dispatchers BEFORE the FEATURES-registry path: numeric-step (`blankStep:`) and categorical (`stepValues:`). Selector-forwards-to-satellite rule for shape-driven blanks. Defence-in-depth bail in the FEATURES selector dispatcher when the selector isn't a known registry setting.
+- `Navigation.computeTargets` carves out shape-driven selectors: Ctrl+Alt+→/← treats the pair as one navigation unit. FEATURES-pairs keep both stops navigable.
+- `DimRender.applyRender` follows the same predicate: selector renders as plain text for shape-driven blanks; satellite stays gray. FEATURES-pairs keep both sides gray.
+- `stepValues` + `blankScript` now compose (was previously short-circuited to list-only). The script owns get/set; stepValues becomes the categorical cycle vocab.
+
+**Two emission shapes by cycle-vocab presence**
+
+- Cyclable shape-driven blank (`blankStep:` or `stepValues:` declared) — selector-satellite pair. Script outputs `<selector>\t<satellite>`. Selector plain text, satellite gray. Ctrl+Alt+↑/↓ steps the satellite. Used by **volume** + **brightness**.
+- Read-only shape-driven blank (no cycle vocab) — one uniform gray span. Script outputs a plain string (no tab). Whole substitution dims, Backspace wipes the whole thing, edit-anywhere triggers `clearOnEdit`. Used by **weather** + **stocks**.
+
+**Migrations shipped in this PR**
+
+- `volume` — shapes for bare GET / `volume N _` / `set volume to N _`. Script handles dual arg shape (shape-driven `set <value>` and cycler `set <setting> <value>`). Ctrl+Alt+↑/↓ steps by `blankStep: 6`. Natural-language SET is the new capability — previously the numeric was silently ignored.
+- `brightness` — mirror of volume at `blankStep: 10`.
+- `weather` — shapes for bare lookup / `weather <city> _` / `forecast <city> _` etc. One-span emission. Default location preserved (`defaultLocation: London`).
+- `stocks` — shapes for the 21 keywords (nvda / nvidia / nvidia stock / aapl / apple / apple stock / …). One-span emission. Original output format preserved (`AAPL: $230.50`).
+
+**Behaviour deltas users will notice**
+
+- `volume 70 _` / `set volume to 70 _` actually set the volume now (was a silent no-op before).
+- Prose mentions of migrated keywords no longer hijack the slot. `the volume was great _` / `the weather was nice _` / `i love apple pie _` decline cleanly; fluid-blank takes them.
+- Copula forms (`volume is _` / `weather is _`) decline the blank claim and route through fluid-blank, which produces a contextually relevant answer.
+- One-Backspace wipes the entire substitution for both emission shapes (was two backspaces for the slot-splice path).
+
+**`blankProximity:` deprecation (Phase 2)**
+
+`ConfigLoader` now logs a one-shot per-blank warning at load time when a blank declares `blankProximity:` without `blankShapes:`. Hard removal is queued for Phase 5 after all shipped blanks migrate. Until then: warn loudly, keep the gate working for back-compat.
+
+**Back-compat surface (no breakage for non-migrated blanks)**
+
+Every runtime change gates on `blankShapes:` being present on the blank. Shape-less blanks (hackernews, dictionary, crypto, countries, claude-status, opencues-settings) continue to use the legacy proximity gate and slot-splice emission unchanged. The FEATURES-registry blank (`opencues settings _`) and ConfigIntent's natural-language flip (`turn debug mode on _`) keep their dual-axis selector-satellite behaviour. ConfigIntent's codomain stays bounded to FEATURES-registry scalars; user blanks remain off-limits to LLM routing (security model unchanged). User BLANK.md files at `~/.cues/blanks/<name>/` are preserved across upgrades via the existing "user-only fields" mechanism. `SPEC_VERSION` not bumped in this PR — spec PR queued separately after more migrations land.
+
+**Tests + validation**
+
+- `pnpm -C packages/opencues-core test` — 870/879 pass (9 skipped, 0 fail; unchanged baseline).
+- `pnpm -C packages/opencues-runtime test` — 1658/1658 pass (added brightness SET-clamp + brightness selector-satellite tests).
+- Manual UX validation in a real opencode session: volume + brightness selector-satellite + cycling; weather + stocks one-span emission; prose misfire reject across all four; OPENCUES settings dual-axis preserved; backspace wipes the whole substitution for both shapes.
+
+Bumps:
+- `@opencues/core` 0.3.21 → 0.3.22.
+- `@opencues/runtime` 0.3.10 → 0.3.11.
+
 ### Fix — Word-cue dispatch: in-progress-word gate no longer fires on unknown cursor (regression from #136)
 
 PR #136 (`perf(core): skip in-progress trailing word from word-cue dispatch`) introduced a `findInProgressTrailingWord` gate that drops the trailing word from word-cue dispatch when the user is actively typing at end-of-buffer. The gate's three checks: (1) buffer non-empty, (2) buffer doesn't end in whitespace, (3) cursor is at end-of-buffer.

--- a/defaults/blanks/answer/BLANK.md
+++ b/defaults/blanks/answer/BLANK.md
@@ -2,13 +2,22 @@
 name: answer
 type: blank
 blankKeywords: what is the word for, how to say
-# wipe: replaces the full query phrase with the answer word.
-# "what is the word for surprise _" → "astonishment"
-blankReplace: wipe
+# blankShapes: precision gate (June 2026). Multi-word trigger phrases
+# anchored at the start with the query captured at the end. Drops
+# prose like "she explained what is the word for in french _" from
+# claiming. Shape-less prose with the keyword embedded mid-sentence
+# routes to fluid-blank.
+blankShapes: [{"pattern":"^what\\s+is\\s+the\\s+word\\s+for\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^how\\s+to\\s+say\\s+(.+?)\\s*_$","action":"get","valueGroup":1}]
 blankAutoPopulate: true
 blankFormat: string
 blankTip: Answer
-blankProximity: 20
+# One-span emission — single-answer LLM lookup, no cycle vocab.
+# NO blankClearOnEdit — the answer is a word/phrase the user
+# typically wants to keep and write around (e.g. "what is the word
+# for surprise _" → "astonishment", then user types "astonishment was
+# exactly the right word"). clearOnEdit would wipe their in-progress
+# sentence the moment they typed a character.
+blankConsumeContext: true
 # Blank-as-context: deliberately OFF. AnswerBlank is a per-query LLM
 # lookup with no fixed "current value" to surface — every invocation
 # produces a different answer from the user's phrasing.

--- a/defaults/blanks/brightness/BLANK.md
+++ b/defaults/blanks/brightness/BLANK.md
@@ -4,12 +4,17 @@ type: blank
 tip: screen brightness
 speak: true
 blankKeywords: brightness
+# blankShapes: declarative intent gate (mirrors volume). Drops prose
+# mentions of "brightness" from claiming the slot.
+#   Shape 1 — bare GET:                brightness _
+#   Shape 2 — direct SET:              brightness 70 _    /  brightness 70% _
+#   Shape 3 — verb-prefixed SET:       set brightness to 70 _    /  set brightness 70 _
+blankShapes: [{"pattern":"^brightness\\s*_$","action":"get"},{"pattern":"^brightness\\s+(\\d+)\\s*%?\\s*_$","action":"set","valueGroup":1},{"pattern":"^set\\s+brightness\\s+(?:to\\s+)?(\\d+)\\s*%?\\s*_$","action":"set","valueGroup":1}]
 blankStep: 10
 blankAutoPopulate: true
-blankSuffix: %
-# Raw "70%" is context-free; keep the "brightness" prefix so readers
-# can tell volume / battery / brightness apart.
-blankReplace: keep
+blankSatellite: true
+blankClearOnEdit: true
+blankConsumeContext: true
 blankScript: ./brightness-blank.sh
 # Sandbox: declared OFF — script calls system brightness controls
 # (xrandr / Win32 / macOS via /mnt/c on WSL) that need filesystem

--- a/defaults/blanks/brightness/brightness-blank.sh
+++ b/defaults/blanks/brightness/brightness-blank.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-# Brightness blank — backs `brightness _` blanks (e.g. "brightness ___")
+# Brightness blank — backs `brightness _`, `brightness 70 _`,
+# `set brightness to 70 _`.
 # Usage: brightness-blank.sh <get|set> [value]
+#
+# Selector-satellite emission (June 2026):
+#   get → echoes `brightness\t<value>%` (TAB-separated). The runtime's
+#         blankSatellite path splices this as a one-span pair the
+#         user can wipe in a single Backspace.
+#   set → applies the new value (clamped to 0..100), then echoes
+#         `brightness\t<clamped>%` so the buffer reflects the FINAL
+#         post-clamp state.
 #
 # Per-platform priority:
 #   1. BrightCtl.exe (colocated, WSL only — see BrightCtl.cs)
@@ -10,15 +19,22 @@
 #   4. WSL legacy: powershell.exe + brightness-set.ps1.
 #
 # get-with-no-backend echoes 50 so the runtime always has a value to
-# splice. set-with-no-backend exits 0 — the cycle is recorded in the
-# DynDef regardless.
+# splice. set-with-no-backend echoes the clamped value so the buffer
+# still updates even when the platform-side apply silently no-ops.
 #
 # POSIX-portable: uses #!/usr/bin/env bash + plain test brackets so it
 # runs under macOS bash 3.2.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIRECTION="$1"
-VALUE="${2:-50}"
+# The runtime calls `set` two ways:
+#   shape-driven SET: `set <value>`               ($2 = numeric value)
+#   satellite cycle:  `set <setting> <value>`     ($2 = "brightness", $3 = numeric)
+# Pick the value field regardless: take $2 if numeric, otherwise $3.
+case "$2" in
+  ''|*[!0-9]*) VALUE="${3:-50}" ;;
+  *) VALUE="$2" ;;
+esac
 
 BRIGHT_CTL="${SCRIPT_DIR}/BrightCtl.exe"
 BRIGHT_SET_PS1="${SCRIPT_DIR}/brightness-set.ps1"
@@ -30,88 +46,73 @@ clamp() {
   echo "$v"
 }
 
+# Emit the selector\tsatellite pair the runtime expects.
+emit() {
+  printf 'brightness\t%s%%\n' "$1"
+}
+
+# Reusable GET — used by both `get` (echo current) and the SET
+# branches' fallback when the backend's read-back fails.
+read_current() {
+  if [ -f "$BRIGHT_CTL" ]; then
+    local v
+    v=$("$BRIGHT_CTL" get 2>/dev/null | tr -dc '0-9')
+    if [ "$v" = "0" ] || [ -z "$v" ]; then
+      sleep 0.1
+      v=$("$BRIGHT_CTL" get 2>/dev/null | tr -dc '0-9')
+    fi
+    [ -n "$v" ] && [ "$v" != "0" ] && echo "$v" && return 0
+  fi
+  if command -v brightnessctl >/dev/null 2>&1; then
+    local raw max
+    raw=$(brightnessctl get 2>/dev/null)
+    max=$(brightnessctl max 2>/dev/null)
+    [ -n "$raw" ] && [ -n "$max" ] && [ "$max" -gt 0 ] && echo $((raw * 100 / max)) && return 0
+  fi
+  if command -v brightness >/dev/null 2>&1; then
+    local raw v
+    raw=$(brightness -l 2>/dev/null | awk '/brightness/ {print $NF; exit}')
+    if [ -n "$raw" ]; then
+      v=$(awk "BEGIN{printf \"%d\", $raw * 100}")
+      [ -n "$v" ] && echo "$v" && return 0
+    fi
+  fi
+  if command -v ddcutil >/dev/null 2>&1; then
+    local v
+    v=$(ddcutil getvcp 10 2>/dev/null \
+      | awk -F'current value =' '{print $2}' \
+      | awk -F',' '{gsub(/ /, "", $1); print $1}')
+    [ -n "$v" ] && echo "$v" && return 0
+  fi
+  if [ -f /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe ]; then
+    local v
+    v=$(powershell.exe -NoProfile -Command "(Get-CimInstance -Namespace root/WMI -ClassName WmiMonitorBrightness).CurrentBrightness" 2>/dev/null | tr -dc '0-9')
+    [ -n "$v" ] && echo "$v" && return 0
+  fi
+  echo "50"
+}
+
 case "$DIRECTION" in
   get)
-    # WSL: colocated BrightCtl.exe.
-    if [ -f "$BRIGHT_CTL" ]; then
-      ACTUAL=$("$BRIGHT_CTL" get 2>/dev/null | tr -dc '0-9')
-      if [ "$ACTUAL" = "0" ] || [ -z "$ACTUAL" ]; then
-        sleep 0.1
-        ACTUAL=$("$BRIGHT_CTL" get 2>/dev/null | tr -dc '0-9')
-      fi
-      [ -n "$ACTUAL" ] && [ "$ACTUAL" != "0" ] && echo "$ACTUAL" && exit 0
-    fi
-
-    # Linux: brightnessctl (laptop backlight via /sys/class/backlight).
-    if command -v brightnessctl >/dev/null 2>&1; then
-      RAW=$(brightnessctl get 2>/dev/null)
-      MAX=$(brightnessctl max 2>/dev/null)
-      [ -n "$RAW" ] && [ -n "$MAX" ] && [ "$MAX" -gt 0 ] && echo $((RAW * 100 / MAX)) && exit 0
-    fi
-
-    # macOS: `brightness` cli (brew install brightness). First display only.
-    if command -v brightness >/dev/null 2>&1; then
-      # `brightness -l` prints "display N: brightness 0.752734" lines.
-      RAW=$(brightness -l 2>/dev/null | awk '/brightness/ {print $NF; exit}')
-      if [ -n "$RAW" ]; then
-        # 0.752734 → 75
-        ACTUAL=$(awk "BEGIN{printf \"%d\", $RAW * 100}")
-        [ -n "$ACTUAL" ] && echo "$ACTUAL" && exit 0
-      fi
-    fi
-
-    # Linux/macOS: ddcutil for external DDC/CI displays.
-    if command -v ddcutil >/dev/null 2>&1; then
-      # `ddcutil getvcp 10` → "VCP code 0x10 (Brightness): current value =    65, max value =   100"
-      ACTUAL=$(ddcutil getvcp 10 2>/dev/null \
-        | awk -F'current value =' '{print $2}' \
-        | awk -F',' '{gsub(/ /, "", $1); print $1}')
-      [ -n "$ACTUAL" ] && echo "$ACTUAL" && exit 0
-    fi
-
-    # WSL: powershell WMI query.
-    if [ -f /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe ]; then
-      ACTUAL=$(powershell.exe -NoProfile -Command "(Get-CimInstance -Namespace root/WMI -ClassName WmiMonitorBrightness).CurrentBrightness" 2>/dev/null | tr -dc '0-9')
-      [ -n "$ACTUAL" ] && echo "$ACTUAL" && exit 0
-    fi
-
-    echo "50"
+    emit "$(read_current)"
     ;;
 
   set)
-    VALUE=$(clamp "$VALUE")
-
-    # WSL: BrightCtl.exe.
+    V=$(clamp "$VALUE")
     if [ -f "$BRIGHT_CTL" ]; then
-      "$BRIGHT_CTL" set "$VALUE"
-      exit 0
+      "$BRIGHT_CTL" set "$V" >/dev/null 2>&1
+    elif command -v brightnessctl >/dev/null 2>&1; then
+      brightnessctl set "${V}%" >/dev/null 2>&1
+    elif command -v brightness >/dev/null 2>&1; then
+      brightness "$(awk "BEGIN{printf \"%.2f\", $V / 100}")" >/dev/null 2>&1
+    elif command -v ddcutil >/dev/null 2>&1; then
+      ddcutil setvcp 10 "$V" >/dev/null 2>&1
+    elif [ -f /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe ] && [ -f "$BRIGHT_SET_PS1" ]; then
+      powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$BRIGHT_SET_PS1" "$V" >/dev/null 2>&1
     fi
-
-    # Linux: brightnessctl.
-    if command -v brightnessctl >/dev/null 2>&1; then
-      brightnessctl set "${VALUE}%" >/dev/null 2>&1
-      exit 0
-    fi
-
-    # macOS: brightness cli expects a 0.0-1.0 float.
-    if command -v brightness >/dev/null 2>&1; then
-      brightness "$(awk "BEGIN{printf \"%.2f\", $VALUE / 100}")" >/dev/null 2>&1
-      exit 0
-    fi
-
-    # Linux/macOS: ddcutil for external displays.
-    if command -v ddcutil >/dev/null 2>&1; then
-      ddcutil setvcp 10 "$VALUE" >/dev/null 2>&1
-      exit 0
-    fi
-
-    # WSL: powershell + brightness-set.ps1.
-    if [ -f /mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe ] && [ -f "$BRIGHT_SET_PS1" ]; then
-      powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$BRIGHT_SET_PS1" "$VALUE"
-      exit 0
-    fi
-
-    exit 0
+    # Echo the post-clamp value regardless of backend success — see
+    # volume-blank.sh for the rationale.
+    emit "$V"
     ;;
 
   *)

--- a/defaults/blanks/claude-status/BLANK.md
+++ b/defaults/blanks/claude-status/BLANK.md
@@ -2,16 +2,25 @@
 name: claude-status
 type: blank
 blankKeywords: is claude down, claude status, claude api status
+# blankShapes: precision gate (June 2026). Anchored multi-word
+# triggers — drops prose like "claude was so down on me _" or
+# "the claude api was annoying _" from claiming.
+blankShapes: [{"pattern":"^is\\s+claude\\s+down\\s*_$","action":"get"},{"pattern":"^claude\\s+(?:api\\s+)?status\\s*_$","action":"get"}]
 blankAutoPopulate: true
 blankFormat: string
 blankTip: Claude / Anthropic service status
+# Multi-alt cycle vocab: the script synthesises 4 alts from one
+# Statuspage fetch:
+#   1. Yes/No — <reason>           (default — answers the literal question)
+#   2. <indicator>                  (one-word verdict)
+#   3. Per-component breakdown
+#   4. Active or last incident
+# blankDismissible lets the user cycle through them with Ctrl+Alt+↑/↓
+# and dismiss back to `_`. One-span emission — the cyclable thing IS
+# the whole substitution.
 blankDismissible: true
-# Auto: bare "is claude down _" / "claude status _" → wipe → just the
-# Yes/No + reason ("No — all systems operational"). Copula phrasings
-# ("the claude api is _") → keep → preserves the lead-in.
-# The Yes/No answer reads naturally on its own — no get() reformat needed.
-blankReplace: auto
 blankClearOnEdit: true
+blankConsumeContext: true
 # Blank-as-context: when blank-context-mode is on, expose Anthropic
 # API status as [CLAUDE-STATUS API] so casual phrasings ("is claude
 # working _", "anything broken _", "should i wait to retry _") route
@@ -23,14 +32,5 @@ context-slots: api
 Implementation: built-in `ClaudeStatusBlank` in `@opencues/runtime`
 (`packages/opencues-runtime/src/blanks/claude-status.ts`). Hits the
 public Statuspage API at `https://status.claude.com/api/v2/summary.json` and
-synthesises four cycling alts from one fetch:
-
-1. `Yes/No — <reason>` (default — answers the literal question)
-2. `<indicator>` (one-word verdict: `none` / `minor` / `major` / …)
-3. Per-component breakdown
-4. Active or last incident with relative timestamp
-
-30-second cache (status pivots quickly during incidents — the longer
-TTL we use for weather would be too stale here). Read-only; no API
-key required. Works on every host that mounts `@opencues/runtime`
-with a fetch implementation (native + Chrome).
+synthesises four cycling alts from one fetch. 30-second cache.
+Read-only; no API key required.

--- a/defaults/blanks/countries/BLANK.md
+++ b/defaults/blanks/countries/BLANK.md
@@ -2,14 +2,18 @@
 name: countries
 type: blank
 blankKeywords: population of, capital of, currency of, region of, language of, languages of, area of, size of
+# blankShapes: precision gate (June 2026). Each fact-keyword phrase
+# anchored at the start, with the country name captured at the end.
+# Drops prose like "the population of the city was huge _" (city not
+# country) or "I love the capital of culture _".
+blankShapes: [{"pattern":"^population\\s+of\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^capital\\s+of\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^currency\\s+of\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^region\\s+of\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^languages?\\s+of\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^(?:area|size)\\s+of\\s+(.+?)\\s*_$","action":"get","valueGroup":1}]
 blankAutoPopulate: true
 blankFormat: string
 blankTip: Country fact
 blankReadOnly: true
-blankProximity: 3
-# Auto: bare "population of france _" → wipe → "France population: 66.4M"
-# (country + fact embedded). Copula phrasing → keep.
-blankReplace: auto
+# One-span emission — no cycle vocab.
+blankClearOnEdit: true
+blankConsumeContext: true
 ---
 
 Implementation: built-in `CountriesBlank` in `@opencues/runtime`
@@ -18,13 +22,6 @@ facts: the keyword phrase tells the runtime which field to extract
 from REST Countries (https://restcountries.com — no auth, no signup).
 24h cache per country.
 
-Examples:
-- `population of France _` → `67.7M`
-- `capital of Japan _` → `Tokyo`
-- `currency of Brazil _` → `Brazilian real (BRL)`
-- `area of Russia _` → `17,098,242 km²`
-- `languages of India _` → `Hindi, English`
-
 Multi-word country names work (`united states`, `south africa`) — the
 runtime joins all non-trigger words and lets REST Countries' search
-endpoint fuzzy-match. ReadOnly: cycling is no-op.
+endpoint fuzzy-match.

--- a/defaults/blanks/crypto/BLANK.md
+++ b/defaults/blanks/crypto/BLANK.md
@@ -2,11 +2,19 @@
 name: crypto
 type: blank
 blankKeywords: bitcoin, btc, ethereum, eth, solana, sol, cardano, ada, ripple, xrp, dogecoin, doge, polygon, matic, polkadot, dot, avalanche, avax, chainlink, link, uniswap, uni, litecoin, ltc, binance, bnb, tron, trx, shiba, shib
+# blankShapes: precision gate (June 2026). Each keyword anchored at
+# the start of the input — drops prose like "she said bitcoin would
+# moon _" or "tron the movie _" from claiming the slot. The 30-coin
+# alternation is verbose but explicit; mirrors the stocks blank.
+blankShapes: [{"pattern":"^(bitcoin|btc|ethereum|eth|solana|sol|cardano|ada|ripple|xrp|dogecoin|doge|polygon|matic|polkadot|dot|avalanche|avax|chainlink|link|uniswap|uni|litecoin|ltc|binance|bnb|tron|trx|shiba|shib)\\s*_$","action":"get","valueGroup":1}]
 blankAutoPopulate: true
 blankFormat: string
 blankTip: Crypto price (USD)
 blankReadOnly: true
-blankProximity: 1
+# One-span emission — no cycle vocab. Whole substituted result
+# dims, Backspace wipes, edit-anywhere triggers clearOnEdit.
+blankClearOnEdit: true
+blankConsumeContext: true
 blankKeywordExpansions.btc: Bitcoin
 blankKeywordExpansions.eth: Ethereum
 blankKeywordExpansions.sol: Solana
@@ -22,9 +30,6 @@ blankKeywordExpansions.ltc: Litecoin
 blankKeywordExpansions.bnb: Binance Coin
 blankKeywordExpansions.trx: TRON
 blankKeywordExpansions.shib: Shiba Inu
-# Auto: bare "btc _" → wipe → "BTC: $78,542.00" (ticker embedded).
-# Copula phrasing → keep.
-blankReplace: auto
 # Blank-as-context: when blank-context-mode is on, expose BTC + ETH
 # as ambient tokens ([CRYPTO BTC], [CRYPTO ETH]) so casual phrasings
 # ("how is bitcoin doing _", "crypto check _", "digital currency _")
@@ -37,12 +42,3 @@ Implementation: built-in `CryptoBlank` in `@opencues/runtime`
 (`packages/opencues-runtime/src/blanks/crypto.ts`). Hits CoinGecko's
 free public API (no key, no signup) for live USD prices. 60-second
 cache per coin.
-
-Examples:
-- `bitcoin _` → `Bitcoin $68,432.50`
-- `eth _` → `Ethereum $3,521.40`
-- `doge _` → `Dogecoin $0.1245`
-
-Mirrors the StocksBlank pattern — keyword expansions render the
-short ticker as the friendly display name. ReadOnly: cycling is no-op
-(refresh by typing a new `_`).

--- a/defaults/blanks/dictionary/BLANK.md
+++ b/defaults/blanks/dictionary/BLANK.md
@@ -2,14 +2,19 @@
 name: dictionary
 type: blank
 blankKeywords: define, definition of, meaning of, what does, what is
+# blankShapes: precision gate (June 2026). Each trigger phrase
+# anchored at the start, with the word being defined captured at
+# the end. Drops prose like "let me define what I mean _" or "the
+# meaning of life _" (the latter is a fluid-blank query, not a
+# dictionary lookup).
+blankShapes: [{"pattern":"^define\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^definition\\s+of\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^meaning\\s+of\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^what\\s+does\\s+(.+?)\\s+mean\\s*_$","action":"get","valueGroup":1},{"pattern":"^what\\s+is\\s+(.+?)\\s*_$","action":"get","valueGroup":1}]
 blankAutoPopulate: true
 blankFormat: string
 blankTip: Dictionary definition
 blankReadOnly: true
-blankProximity: 3
-# Auto: bare "define ephemeral _" → wipe → "ephemeral: lasting for a very short time"
-# (word embedded). Copula phrasing → keep.
-blankReplace: auto
+# One-span emission — no cycle vocab.
+blankClearOnEdit: true
+blankConsumeContext: true
 # Blank-as-context: deliberately OFF. The "ambient" set for dictionary
 # would be "every word the user looks up" — a surveillance shape that
 # also has no fixed slot list. Keep this as a keyword-triggered lookup.
@@ -20,12 +25,4 @@ Implementation: built-in `DictionaryBlank` in `@opencues/runtime`
 (`packages/opencues-runtime/src/blanks/dictionary.ts`). Looks up
 the highlighted/contextual word at https://api.dictionaryapi.dev/
 (no API key, no signup), returns the first definition truncated to
-~100 chars.
-
-Examples:
-- `define ephemeral _` → `lasting for a very short time`
-- `meaning of catalyst _` → `a substance that accelerates a chemical reaction without...`
-- `what is entropy _` → `a measure of disorder in a thermodynamic system`
-
-Cached for 24h per word — definitions don't churn. ReadOnly so cycling
-is a no-op (the definition IS the definition).
+~100 chars. Cached for 24h per word.

--- a/defaults/blanks/example/BLANK.md
+++ b/defaults/blanks/example/BLANK.md
@@ -33,15 +33,24 @@ enabled: false
 # which run on plain text). Cue sources omit this field.
 type: blank
 
-# Triggered when any of these words appears within `blankProximity`
-# words of `_`. Use comma-separated short triggers — they're
+# Triggered when any of these words appears within the shapes
+# declared below. Use comma-separated short triggers — they're
 # matched as whole words, case-insensitive.
 blankKeywords: time, clock
 
-# Max words between keyword and `_`. 0 means "directly adjacent
-# only" (`time _`). 2 lets `time is _` and `time right now _` fire.
-# Volume / brightness use 3 to handle copulas like `volume is _`.
-blankProximity: 2
+# blankShapes: the precision gate (the modern replacement for
+# blankProximity). Each shape is a regex anchored against the input
+# up to and including `_`. First match wins, declines if none match.
+# This blank's shapes cover the bare-keyword case (`time _` /
+# `clock _`). Add more shapes if you want copula forms
+# (`^the\s+time\s+is\s*_$`) or other phrasings.
+#
+# Full design: docs/architecture/shape-driven-blanks.md.
+blankShapes: [{"pattern":"^(?:the\\s+)?(?:time|clock)(?:\\s+(?:is|now|right\\s+now))?\\s*_$","action":"get"}]
+
+# One-span emission — no cycle vocab on a clock.
+blankClearOnEdit: true
+blankConsumeContext: true
 
 # Auto-populate on text-change: as soon as the keyword+`_` pattern
 # is detected, fire `get` without waiting for the user to navigate

--- a/defaults/blanks/gh-issues/BLANK.md
+++ b/defaults/blanks/gh-issues/BLANK.md
@@ -3,17 +3,18 @@ name: gh-issues
 type: blank
 tip: open issue count for a github repo
 blankKeywords: gh-issues
-# Allow `owner/repo` between the keyword and `_`. Without this,
-# `blankKeywords` must be immediately adjacent to `_` (proximity 0).
-blankProximity: 2
+# blankShapes: precision gate (June 2026). Captures owner/repo at
+# the end. Drops prose where "gh-issues" appears mid-sentence from
+# claiming.
+blankShapes: [{"pattern":"^gh-issues\\s+([\\w.-]+\\/[\\w.-]+)\\s*_$","action":"get","valueGroup":1}]
 blankAutoPopulate: true
 blankReadOnly: true
+# One-span emission — no cycle vocab.
+blankClearOnEdit: true
+blankConsumeContext: true
 impl: ./blank.js
 network: [api.github.com]
 storage: gh-issues
-# Auto: bare "gh-issues opencues/opencues _" → wipe → "opencues/opencues: 42 open"
-# (repo embedded). Copula phrasing → keep.
-blankReplace: auto
 ---
 
 User-shipped JS blank demo. Type `gh-issues owner/repo _` and the

--- a/defaults/blanks/hackernews/BLANK.md
+++ b/defaults/blanks/hackernews/BLANK.md
@@ -3,15 +3,22 @@ name: hackernews
 type: blank
 blankKeywords: hn, hackernews
 blankKeywordExpansions.hn: HackerNews
+# blankShapes: precision gate (June 2026). Anchored bare-keyword
+# patterns — drops prose like "I posted on hn yesterday _" or
+# "hackernews was buggy _" from claiming the slot.
+blankShapes: [{"pattern":"^(?:hn|hackernews)\\s*_$","action":"get"}]
 blankAutoPopulate: true
 blankFormat: string
 blankTip: Hacker News
 blankReadOnly: true
+# Multi-alt cycle vocab: the script returns multiple top-story
+# titles, one per line. blankDismissible lets the user cycle through
+# them with Ctrl+Alt+↑/↓ and dismiss back to `_`. Emission is the
+# one-span shape (no selector-satellite split) — the cyclable thing
+# IS the whole substitution.
 blankDismissible: true
-blankProximity: 3
-# Auto: bare "hn _" → wipe → "<top story title>" (self-contained).
-# Copula phrasing → keep.
-blankReplace: auto
+blankClearOnEdit: true
+blankConsumeContext: true
 # Blank-as-context: when blank-context-mode is on, expose the current
 # top story as [HACKERNEWS TOP] so casual phrasings ("anything
 # interesting on hn _", "write a quick comment about today's top hn
@@ -23,4 +30,4 @@ context-slots: top
 Implementation: built-in `HackerNewsBlank` in `@opencues/runtime`
 (`packages/opencues-runtime/src/blanks/hackernews.ts`). Every host
 wires it via `createDefaultBlanksRegistry`; the runtime dispatches
-via `blankInvoke`.
+via `blankInvoke`. Multi-line stdout: each line is one cycleable alt.

--- a/defaults/blanks/prompt/BLANK.md
+++ b/defaults/blanks/prompt/BLANK.md
@@ -2,14 +2,30 @@
 name: prompt
 type: blank
 blankKeywords: improve prompt, enhance prompt, refine prompt
+# blankShapes: precision gate (June 2026). Supports both natural
+# typing flows:
+#   (a) trigger-at-start: `improve prompt <prompt> _` (rare)
+#   (b) trigger-at-end:   `<prompt> improve prompt _` (the common
+#       flow — type what you want, then ask for improvement)
+# Both anchor with ^...$ so mid-sentence triggers ("I want to improve
+# prompt engineering skills _") don't claim. The prompt-to-improve
+# is captured in valueGroup 1 of each shape.
+blankShapes: [{"pattern":"^improve\\s+prompt\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^enhance\\s+prompt\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^refine\\s+prompt\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^(.+?)\\s+improve\\s+prompt\\s*_$","action":"get","valueGroup":1},{"pattern":"^(.+?)\\s+enhance\\s+prompt\\s*_$","action":"get","valueGroup":1},{"pattern":"^(.+?)\\s+refine\\s+prompt\\s*_$","action":"get","valueGroup":1}]
 blankAutoPopulate: true
 blankFormat: string
-# wipe-all: the user's prompt-with-trigger phrase is replaced entirely
-# by the improved prompt — there's nothing they want kept around the
-# trigger ("improve prompt"). Legacy `blankConsumeAll: true` had the
-# same effect.
-blankReplace: wipe-all
 blankTip: Prompt improver
+# Multi-alt cycle vocab — altCount: 3 produces 3 improved variants;
+# includeOriginal adds the original as alt 4. Ctrl+Alt+↑/↓ on the
+# substituted span walks through them. blankDismissible adds `_`
+# as the final alt so the user can dismiss back to the placeholder.
+blankDismissible: true
+# NO blankClearOnEdit — the improved prompt is meant to be refined
+# by the user before they send it. clearOnEdit would wipe their
+# in-progress edits the moment they typed a character. Cycling still
+# works (Ctrl+Alt+↑/↓ before any edit); after the first edit the
+# text becomes free-form and cycling stops, which is the right UX
+# for "I picked variant 2 and now I'm tweaking it."
+blankConsumeContext: true
 # model: openai/gpt-oss-120b   (Groq — fast, requires GROQ_API_KEY)
 # model: claude-sonnet-4-6     (Claude CLI — smarter, uses existing Claude Code auth)
 model: openai/gpt-oss-120b

--- a/defaults/blanks/sentinel/BLANK.md
+++ b/defaults/blanks/sentinel/BLANK.md
@@ -2,20 +2,19 @@
 name: sentinel
 type: blank
 blankKeywords: set sentinel, remove sentinel
-# Allow up to 16 words between the keyword and `_` so multi-word
-# values land correctly (e.g. `set sentinel signOff Best from sunny
-# London _`). 16 covers any realistic sentinel value (~80 chars of
-# prose) while keeping false-positive matches narrow — without it,
-# the proximity-0 default makes the blank silently miss every
-# non-single-word value (TransformBlank wins the slot instead). A
-# user with an unusually long value (>16 words / ~80 chars) falls
-# back to `opencues identity set` from the CLI, which has no
-# proximity limit. The 256-char value cap (validateSentinelWrite)
-# still gates the actual content of any matched write.
-blankProximity: 16
+# blankShapes: precision gate (June 2026). Two shapes — set captures
+# the full "<key> <value>" payload; remove captures just the key.
+# The proximity-16 hack (needed under the legacy gate to allow
+# multi-word values) retires — shapes anchor at start of input and
+# accept arbitrary content for the value, no false-positive surface
+# at all. The SentinelBlank class continues to split the captured
+# payload into key + value and validate via validateSentinelWrite
+# (security chokepoint unchanged).
+blankShapes: [{"pattern":"^set\\s+sentinel\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^remove\\s+sentinel\\s+(\\w+)\\s*_$","action":"get","valueGroup":1}]
 blankFormat: string
 blankClearKeywords: true
 blankClearOnEdit: true
+blankConsumeContext: true
 # Runtime-only blank — served by SentinelBlank in @opencues/runtime on
 # every host (chrome.storage on chrome; injected readFile/writeFile
 # against ~/.cues/IDENTITY.md on every native host). The resolver tries

--- a/defaults/blanks/stocks/BLANK.md
+++ b/defaults/blanks/stocks/BLANK.md
@@ -1,22 +1,26 @@
 ---
 name: stocks
 type: blank
+# Every keyword the TypeScript blank accepts. Listed here so the
+# runtime BlankFill scanner sees them all as candidate triggers
+# before the shape gate runs. The shape pattern below filters
+# them to "actually a stock invocation" (prose declines).
 blankKeywords: reddit stock, reddit, rddt, nvidia stock, nvidia, nvda, apple stock, apple, aapl, google stock, google, googl, microsoft stock, microsoft, msft, amazon stock, amazon, amzn, tesla stock, tesla, tsla, meta stock, meta
+# blankShapes: declarative precision gate (June 2026). Each keyword
+# alternation explicitly listed — the alternation IS the precision.
+# Bare prose like "she nvda her presentation _" or "they apple-pick
+# in autumn _" doesn't match (the keyword must be the leading word
+# in the input). The companies + tickers are deliberately the same
+# set as blankKeywords above.
+blankShapes: [{"pattern":"^(reddit\\s+stock|reddit|rddt|nvidia\\s+stock|nvidia|nvda|apple\\s+stock|apple|aapl|google\\s+stock|google|googl|microsoft\\s+stock|microsoft|msft|amazon\\s+stock|amazon|amzn|tesla\\s+stock|tesla|tsla|meta\\s+stock|meta)\\s*_$","action":"get","valueGroup":1}]
 blankAutoPopulate: true
 blankFormat: string
 blankTip: Stock price
 blankReadOnly: true
-blankProximity: 1
-blankKeywordExpansions.rddt: Reddit
-blankKeywordExpansions.nvda: Nvidia
-blankKeywordExpansions.aapl: Apple
-blankKeywordExpansions.googl: Alphabet
-blankKeywordExpansions.msft: Microsoft
-blankKeywordExpansions.amzn: Amazon
-blankKeywordExpansions.tsla: Tesla
-# Auto: bare "nvda _" → wipe → "NVDA: $198.47" (ticker embedded).
-# "nvda is _" or copula phrasings → keep → "nvda is NVDA: $198.47".
-blankReplace: auto
+# No blankSatellite: stocks has no cycle vocab. One uniform gray span
+# emission — see shape-driven-blanks.md.
+blankClearOnEdit: true
+blankConsumeContext: true
 # Blank-as-context: when blank-context-mode is on, expose 5 popular
 # tickers as ambient tokens ([STOCKS NVDA], [STOCKS AAPL], …) so
 # fluid-blank + transform-blank can route casual prose ("how are

--- a/defaults/blanks/volume/BLANK.md
+++ b/defaults/blanks/volume/BLANK.md
@@ -4,19 +4,48 @@ type: blank
 tip: system volume
 speak: true
 blankKeywords: volume
-# Allow up to 3 words between the keyword and `_` — so natural
-# phrasings like `volume is _`, `volume was _`, `volume right now _`
-# all fire the blank. Matches the proximity set on the network
-# blanks (weather, countries, hackernews). Default proximity is 0
-# (keyword must be directly adjacent to `_`), which would miss
-# every copula form.
-blankProximity: 3
+# blankShapes: declarative intent gate (June 2026 — replaces the coarse
+# blankProximity gate for this blank). The runtime walks each shape's
+# pattern against the input up to and including `_`; first match wins.
+# Anything not matching a shape drops the claim — fluid-blank takes the
+# slot. Authors must order narrowest-first.
+#
+# Patterns are matched case-insensitively (`i` flag) with dotall (`s`).
+# The literal `_` anchors the trigger position.
+#
+#   Shape 1 — bare GET:                volume _
+#   Shape 2 — direct SET:              volume 70 _    /  volume 70% _
+#   Shape 3 — verb-prefixed SET:       set volume to 70 _    /  set volume 70 _
+#   Shape 4 — step direction:          volume up _    /  volume down _
+#
+# Anything else (prose like "the volume was great _", "the volume
+# button is broken _", "please increase the volume _") matches no
+# shape and the blank declines — fluid-blank takes the slot for a
+# free-form lookup. That's the misfire-reduction win.
+blankShapes: [{"pattern":"^volume\\s*_$","action":"get"},{"pattern":"^volume\\s+(\\d+)\\s*%?\\s*_$","action":"set","valueGroup":1},{"pattern":"^set\\s+volume\\s+(?:to\\s+)?(\\d+)\\s*%?\\s*_$","action":"set","valueGroup":1}]
+# `volume up _` / `volume down _` step shapes deferred — needs script
+# step branch that knows about blankStep. Cycling via Ctrl+Alt+↑/↓ on
+# the substituted satellite still works the existing way.
+# blankProximity retired in favour of blankShapes — the shape patterns
+# define their own distance and intent. Kept here at 3 as a comment so
+# pre-shape readers know the legacy behaviour.
+# blankProximity: 3
 blankStep: 6
 blankAutoPopulate: true
-blankSuffix: %
-# Raw numeric answer ("70%") is context-free; keep the "volume" prefix
-# in the buffer so readers know what 70% is measuring.
-blankReplace: keep
+# Tab-separated emission: the script now outputs `volume\t70%` so the
+# runtime's existing blankSatellite path (blank-fill.ts:611) splices it
+# as a single one-click-wipeable span (clearOnEdit). Replaces the prior
+# raw-numeric + blankSuffix path.
+blankSatellite: true
+blankClearOnEdit: true
+# blankConsumeContext: wipe the full summon (keyword + words between
+# keyword and `_`) when the substitute fires. Combined with shapes,
+# this gives `set volume to 70 _` → `volume 70%` (the "set" and "to"
+# verbs vanish along with `70` and `_`).
+blankConsumeContext: true
+# blankReplace / blankSuffix retired — the selector-satellite emission
+# carries the label + value as one wipeable unit; no in-buffer suffix
+# to append separately.
 blankScript: ./volume-blank.sh
 # Sandbox: declared OFF because volume-blank.sh needs:
 #   - /mnt/c/ access (WSL) to reach VolCtl.exe (Windows Core Audio)

--- a/defaults/blanks/volume/volume-blank.sh
+++ b/defaults/blanks/volume/volume-blank.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-# Volume blank — backs `volume _` (e.g. "volume ___")
+# Volume blank — backs `volume _`, `volume 70 _`, `set volume to 70 _`.
 # Usage: volume-blank.sh <get|set> [value]
+#
+# Selector-satellite emission (June 2026):
+#   get → echoes `volume\t<value>%` (TAB-separated).  The runtime's
+#         blankSatellite path splices this as a one-span pair the user
+#         can wipe in a single Backspace.
+#   set → applies the new value (clamped to 0..100), then echoes
+#         `volume\t<clamped>%` so the buffer reflects the FINAL
+#         post-clamp state (200 → clamps to 100 → buffer shows 100%,
+#         not 200%).
 #
 # Per-platform priority:
 #   1. VolCtl.exe (colocated, WSL only — ~10ms, see VolCtl.cs)
@@ -8,16 +17,25 @@
 #   3. macOS: osascript (built-in, always available)
 #   4. Linux: wpctl (PipeWire) → pactl (PulseAudio) → amixer (ALSA)
 #
-# Exits 0 + prints "50" on get-with-no-backend so the runtime still has
-# a value to splice. set-with-no-backend exits 0 silently (the cycle
-# step is recorded in OPENCUES.md anyway).
+# Exits 0 + echoes a sentinel "50" on get-with-no-backend so the
+# runtime still has a value to splice. set-with-no-backend echoes the
+# clamped value too — the runtime substitutes it even if the OS-side
+# apply was a no-op; the cycle step is recorded in OPENCUES.md anyway.
 #
 # POSIX-portable: uses #!/usr/bin/env bash + plain test brackets so it
 # runs under macOS bash 3.2.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DIRECTION="$1"
-VALUE="${2:-50}"
+# The runtime calls `set` two ways:
+#   shape-driven SET: `set <value>`               ($2 = numeric value)
+#   satellite cycle:  `set <setting> <value>`     ($2 = "volume", $3 = numeric)
+# Pick the value field regardless: take $2 if numeric, otherwise $3.
+# POSIX `case` is the portable shape-test (bash 3.2 lacks `[[ =~ ]]`).
+case "$2" in
+  ''|*[!0-9]*) VALUE="${3:-50}" ;;
+  *) VALUE="$2" ;;
+esac
 
 VOL_CTL="${SCRIPT_DIR}/VolCtl.exe"
 
@@ -29,108 +47,77 @@ clamp() {
   echo "$v"
 }
 
+# Emit the selector\tsatellite pair the runtime expects.
+emit() {
+  printf 'volume\t%s%%\n' "$1"
+}
+
+# Reusable GET — used by both `get` (echo current) and the SET branches'
+# fallback (echo the requested value if the backend's read-back fails).
+read_current() {
+  if [ -f "$VOL_CTL" ]; then
+    local v
+    v=$("$VOL_CTL" get 2>/dev/null | tr -dc '0-9')
+    if [ "$v" = "0" ] || [ -z "$v" ]; then
+      sleep 0.1
+      v=$("$VOL_CTL" get 2>/dev/null | tr -dc '0-9')
+    fi
+    [ -n "$v" ] && [ "$v" != "0" ] && echo "$v" && return 0
+  fi
+  if command -v osascript >/dev/null 2>&1; then
+    local v
+    v=$(osascript -e 'output volume of (get volume settings)' 2>/dev/null)
+    if [ -n "$v" ] && [ "$v" != "missing value" ]; then
+      echo "$v" && return 0
+    fi
+  fi
+  if command -v wpctl >/dev/null 2>&1; then
+    local raw v
+    raw=$(wpctl get-volume @DEFAULT_AUDIO_SINK@ 2>/dev/null | awk '{print $2}')
+    if [ -n "$raw" ]; then
+      v=$(awk "BEGIN{printf \"%d\", $raw * 100}")
+      [ -n "$v" ] && echo "$v" && return 0
+    fi
+  fi
+  if command -v pactl >/dev/null 2>&1; then
+    local v
+    v=$(pactl get-sink-volume @DEFAULT_SINK@ 2>/dev/null \
+      | grep -oE '[0-9]+%' | head -1 | tr -d '%')
+    [ -n "$v" ] && echo "$v" && return 0
+  fi
+  if command -v amixer >/dev/null 2>&1; then
+    local v
+    v=$(amixer get Master 2>/dev/null \
+      | grep -oE '[0-9]+%' | head -1 | tr -d '%')
+    [ -n "$v" ] && echo "$v" && return 0
+  fi
+  echo "50"
+}
+
 case "$DIRECTION" in
   get)
-    # WSL: prefer colocated VolCtl.exe (zero-dep, fastest).
-    if [ -f "$VOL_CTL" ]; then
-      ACTUAL=$("$VOL_CTL" get 2>/dev/null | tr -dc '0-9')
-      if [ "$ACTUAL" = "0" ] || [ -z "$ACTUAL" ]; then
-        sleep 0.1
-        ACTUAL=$("$VOL_CTL" get 2>/dev/null | tr -dc '0-9')
-      fi
-      [ -n "$ACTUAL" ] && [ "$ACTUAL" != "0" ] && echo "$ACTUAL" && exit 0
-    fi
-
-    # macOS native.
-    if command -v osascript >/dev/null 2>&1; then
-      ACTUAL=$(osascript -e 'output volume of (get volume settings)' 2>/dev/null)
-      if [ -n "$ACTUAL" ] && [ "$ACTUAL" != "missing value" ]; then
-        echo "$ACTUAL"
-        exit 0
-      fi
-    fi
-
-    # Linux PipeWire (default on modern distros).
-    if command -v wpctl >/dev/null 2>&1; then
-      # `wpctl get-volume @DEFAULT_AUDIO_SINK@` → "Volume: 0.65 [MUTED]"
-      RAW=$(wpctl get-volume @DEFAULT_AUDIO_SINK@ 2>/dev/null | awk '{print $2}')
-      if [ -n "$RAW" ]; then
-        # 0.65 → 65 (multiply by 100, strip decimal).
-        ACTUAL=$(awk "BEGIN{printf \"%d\", $RAW * 100}")
-        [ -n "$ACTUAL" ] && echo "$ACTUAL" && exit 0
-      fi
-    fi
-
-    # Linux PulseAudio.
-    if command -v pactl >/dev/null 2>&1; then
-      # `pactl get-sink-volume @DEFAULT_SINK@` → "Volume: front-left: 42598 / 65%  / ..."
-      ACTUAL=$(pactl get-sink-volume @DEFAULT_SINK@ 2>/dev/null \
-        | grep -oE '[0-9]+%' | head -1 | tr -d '%')
-      [ -n "$ACTUAL" ] && echo "$ACTUAL" && exit 0
-    fi
-
-    # Linux ALSA.
-    if command -v amixer >/dev/null 2>&1; then
-      ACTUAL=$(amixer get Master 2>/dev/null \
-        | grep -oE '[0-9]+%' | head -1 | tr -d '%')
-      [ -n "$ACTUAL" ] && echo "$ACTUAL" && exit 0
-    fi
-
-    # WSL last-resort fallback.
-    if [ -f /mnt/c/Windows/nircmd.exe ]; then
-      # nircmd has no get — just echo the cycle's running value.
-      echo "50"
-      exit 0
-    fi
-
-    # No backend — keep the runtime happy with a plausible default.
-    echo "50"
+    emit "$(read_current)"
     ;;
 
   set)
-    VALUE=$(clamp "$VALUE")
-
-    # WSL: VolCtl.exe.
+    V=$(clamp "$VALUE")
     if [ -f "$VOL_CTL" ]; then
-      "$VOL_CTL" set "$VALUE"
-      exit 0
+      "$VOL_CTL" set "$V" >/dev/null 2>&1
+    elif command -v osascript >/dev/null 2>&1; then
+      osascript -e "set volume output volume $V" >/dev/null 2>&1
+    elif command -v wpctl >/dev/null 2>&1; then
+      wpctl set-volume @DEFAULT_AUDIO_SINK@ "$(awk "BEGIN{printf \"%.2f\", $V / 100}")" >/dev/null 2>&1
+    elif command -v pactl >/dev/null 2>&1; then
+      pactl set-sink-volume @DEFAULT_SINK@ "${V}%" >/dev/null 2>&1
+    elif command -v amixer >/dev/null 2>&1; then
+      amixer set Master "${V}%" >/dev/null 2>&1
+    elif [ -f /mnt/c/Windows/nircmd.exe ]; then
+      /mnt/c/Windows/nircmd.exe setsysvolume $((V * 655))
     fi
-
-    # macOS.
-    if command -v osascript >/dev/null 2>&1; then
-      osascript -e "set volume output volume $VALUE" >/dev/null 2>&1
-      exit 0
-    fi
-
-    # Linux PipeWire.
-    if command -v wpctl >/dev/null 2>&1; then
-      # wpctl expects a float (0.0–1.0+).
-      wpctl set-volume @DEFAULT_AUDIO_SINK@ "$(awk "BEGIN{printf \"%.2f\", $VALUE / 100}")" >/dev/null 2>&1
-      exit 0
-    fi
-
-    # Linux PulseAudio.
-    if command -v pactl >/dev/null 2>&1; then
-      pactl set-sink-volume @DEFAULT_SINK@ "${VALUE}%" >/dev/null 2>&1
-      exit 0
-    fi
-
-    # Linux ALSA.
-    if command -v amixer >/dev/null 2>&1; then
-      amixer set Master "${VALUE}%" >/dev/null 2>&1
-      exit 0
-    fi
-
-    # WSL legacy.
-    if [ -f /mnt/c/Windows/nircmd.exe ]; then
-      /mnt/c/Windows/nircmd.exe setsysvolume $((VALUE * 655))
-      exit 0
-    fi
-
-    # No backend. Exit 0 — the runtime has already recorded the cycle
-    # step in OPENCUES.md; failing here would surface as a user-visible
-    # error every cycle press on an unsupported platform.
-    exit 0
+    # Echo the post-clamp value regardless of backend success — the
+    # runtime needs SOMETHING to substitute; "I asked for V" is more
+    # useful than nothing when the OS-side apply silently no-op'd.
+    emit "$V"
     ;;
 
   *)

--- a/defaults/blanks/weather/BLANK.md
+++ b/defaults/blanks/weather/BLANK.md
@@ -2,14 +2,24 @@
 name: weather
 type: blank
 blankKeywords: weather, forecast, temp, temperature
+# blankShapes: declarative precision gate (June 2026). Drops prose
+# misfires like "the weather was great _" from claiming the slot.
+# Multi-keyword: weather / forecast / temp / temperature all alias to
+# the same blank, so the shape pattern accepts any of them as the
+# leading word.
+#
+#   Shape 1 — bare lookup (default location):  weather _
+#   Shape 2 — explicit location:                weather london _    /  forecast paris _
+blankShapes: [{"pattern":"^(?:weather|forecast|temp|temperature)\\s+(.+?)\\s*_$","action":"get","valueGroup":1},{"pattern":"^(?:weather|forecast|temp|temperature)\\s*_$","action":"get"}]
 blankAutoPopulate: true
 blankFormat: string
 blankTip: Weather
-blankDismissible: true
-blankProximity: 3
-# Auto: bare "weather london _" → wipe → "London: 13°C Overcast"
-# (location embedded). Copula phrasings ("weather is _") → keep.
-blankReplace: auto
+# No blankSatellite: weather has no cycle vocab (no blankStep, no
+# stepValues), so we use the "one uniform gray span" emission —
+# the regular splice path produces a single dimmed substitution the
+# user can wipe with Backspace or edit-anywhere.
+blankClearOnEdit: true
+blankConsumeContext: true
 # Blank-as-context: when blank-context-mode is on, expose current
 # weather for the user's workCity (from IDENTITY.md) as an ambient
 # token [WEATHER <CITY>] that fluid-blank can route casual phrasings
@@ -19,6 +29,5 @@ context-bind: workCity
 ---
 
 Implementation: built-in `WeatherBlank` in `@opencues/runtime`
-(`packages/opencues-runtime/src/blanks/weather.ts`). Every host wires
-it via `createDefaultBlanksRegistry`. Open-Meteo geocode + forecast
-fetch happens in pure TypeScript.
+(`packages/opencues-runtime/src/blanks/weather.ts`). Open-Meteo
+geocode + forecast fetch happens in pure TypeScript.

--- a/docs/architecture/shape-driven-blanks.md
+++ b/docs/architecture/shape-driven-blanks.md
@@ -1,0 +1,369 @@
+---
+last_updated: 2026-06-14
+---
+
+# Shape-Driven Blanks — Three-Axis Model
+
+This is the canonical reference for the **shape-driven blank** mechanic introduced June 2026. It replaces the coarse `blankProximity:` gate with declarative shape patterns, formalises the `<script> set <value>` contract, and converges every script-backed blank on a single emission shape (the selector-satellite span) with well-defined navigation and cycling semantics.
+
+Read this before:
+- Authoring a new script-backed blank (`defaults/blanks/<name>/BLANK.md` + script)
+- Touching `matchKeyword` / `applySatelliteFill` in `packages/opencues-runtime/src/modules/blank-fill.ts`
+- Touching `cycleSelectorSatellite` in `packages/opencues-runtime/src/modules/cycling.ts`
+- Touching word-by-word navigation in `packages/opencues-runtime/src/modules/navigation.ts` (when the atomic-pair carve-out lands; see [Navigation semantics](#navigation-semantics))
+- Migrating an existing script-backed blank from `blankProximity:` to `blankShapes:`
+
+Companion docs:
+- **[`blank-sources.md`](blank-sources.md)** — the family of `CueSource` classes (`BlankSource` / `FluidBlankSource` / etc.) and the substitute mechanisms. Shape-driven gating sits **above** that layer — it picks which slots `BlankSource` claims, not how the substitute is computed.
+- **[`fluid-config.md`](fluid-config.md)** — the LLM-classifier flow for natural-language settings flips. Shape-driven blanks deliberately avoid LLM classification; this doc explains why.
+- **[`blank-replace-modes.md`](blank-replace-modes.md)** — the legacy `blankReplace: keep | wipe | wipe-all | auto` mechanic. Shape-driven blanks have a fixed effective mode (line-scoped wipe) regardless of the field; this doc explains the divergence.
+- **[`spans-and-cycling.md`](spans-and-cycling.md)** — DynDef + span machinery the selector-satellite stash sits on top of.
+
+User-facing summary: `docs/features/blanks.md` (TODO — to be written as part of the shape-driven migration).
+
+---
+
+## What this mechanic is
+
+Three independent axes that compose into one blank declaration:
+
+| Axis | Frontmatter field | Controls |
+|---|---|---|
+| **Shapes** | `blankShapes:` (array of `{pattern, action, valueGroup?}`) | When the blank fires (precision gate) + which script verb runs (`get` / `set` / `step`) + what literal value gets captured |
+| **Script contract** | `blankScript:` (or `impl:` for JS user-blanks) | How state gets applied. Script accepts `<verb> <value>` and echoes `<selector>\t<satellite>` on stdout |
+| **Cycle vocab** | `blankStep:` (numeric) and/or `stepValues:` (categorical) | What Ctrl+Alt+↑/↓ does after the fill. Both optional, both compose with shapes + script |
+
+Default emission: a **selector-satellite span** (`blankSatellite: true` + `blankClearOnEdit: true` + `blankConsumeContext: true`). The result reads `volume 70%` as one wipeable unit.
+
+---
+
+## Emission shapes — cycle vocab decides
+
+A shape-driven blank picks one of two emission shapes based on **whether it declares cycle vocab** (`blankStep:` and/or `stepValues:`). The visual structure reflects whether there's an interaction to expose.
+
+### Selector-satellite emission (cyclable blanks)
+
+When a blank declares cycle vocab AND `blankSatellite: true` AND the script outputs `<selector>\t<satellite>` (tab-separated), the runtime splices the pair as a selector-satellite span:
+
+```
+INPUT:  volume 70 _
+SCRIPT: volume\t70%
+BUFFER: volume 70%
+        └─selector──┘└─satellite─┘
+        plain text   gray (cyclable)
+```
+
+The selector is a **static label** (plain text); the satellite is the **cyclable handle** (gray). The user navigates to the pair as one nav step and presses Ctrl+Alt+↑/↓ to cycle the value. Used by every shape-driven blank that has cycle vocab — today volume + brightness, future theme / lights / any blank with a tunable axis.
+
+### One-span emission (read-only blanks)
+
+When a blank has NO cycle vocab (no `blankStep`, no `stepValues`), there's no interaction to expose. We drop the selector-satellite split entirely. The script outputs a plain string (no tab), the runtime splices it via the regular `consumeContext` path, the whole substitution renders as one gray span:
+
+```
+INPUT:  weather london _
+SCRIPT: weather London 14°C Partly cloudy
+BUFFER: weather London 14°C Partly cloudy
+        └────────── one gray span ──────────┘
+        clearOnEdit + Backspace-wipe still apply
+```
+
+The user can Backspace the whole span away (one wipe) or edit anywhere inside it (triggers `blankClearOnEdit`). No selector to navigate to, no cycling key bindings — just "AI substituted text the user can remove."
+
+### Which shape to use
+
+The author decides at BLANK.md authorship time, gated by cycle vocab:
+
+| Has `blankStep:` or `stepValues:` declared? | Emission shape | Script output |
+|---|---|---|
+| Yes (cyclable) | Selector-satellite | `<selector>\t<satellite>` (tab-separated) + `blankSatellite: true` in BLANK.md |
+| No (read-only) | One uniform gray span | Plain string (no tab), no `blankSatellite:` in BLANK.md |
+
+Both shapes use `blankClearOnEdit: true` + `blankConsumeContext: true`. Both shapes wipe-line on fill. The only differences are: (a) whether the substituted region splits into selector+satellite words, (b) whether cycling keys do anything, (c) whether the runtime registers a `selectorSatelliteState` stash or a `spanFillState` stash for the substituted region.
+
+### Shipped examples
+
+| Blank | Has cycle vocab? | Emission |
+|---|---|---|
+| `volume` (`blankStep: 6`) | Yes | `volume\t70%` (selector-satellite) |
+| `brightness` (`blankStep: 10`) | Yes | `brightness\t70%` (selector-satellite) |
+| `weather` (none) | No | `weather London 14°C Partly cloudy` (one gray span) |
+| `stocks` (none) | No | `AAPL: $230.50` (one gray span) |
+| `dictionary` (none) | No | one gray span (TBD per migration) |
+| (future) `theme` (`stepValues: [dark, light, sepia]`) | Yes | `theme\tdark` (selector-satellite) |
+
+**There is one separate case** — the FEATURES-registry blank (`opencues settings _`) — where the selector is **also** a cycle axis. See [Two distinct kinds of selector-satellite pairs](#two-distinct-kinds-of-selector-satellite-pairs) below.
+
+---
+
+## Navigation semantics
+
+> **Status note:** the atomic-pair carve-out described in this section is the **agreed design** but **not yet implemented** in `navigation.ts` as of June 2026. The runtime currently treats every word as independently navigable. This section documents the intended semantics; the migration is queued in `plan.md` § Step 4.
+
+For shape-driven blank pairs, the selector + satellite together act as **one navigation unit**:
+
+```
+Hello there volume 70% world
+            ├──────────┤
+            one Ctrl+Alt+→ step
+```
+
+Concretely:
+
+- **Ctrl+Alt+→** stepping into a shape-driven pair lands on the **satellite directly**, skipping the selector. The pair is one step.
+- **Ctrl+Alt+←** stepping out of a shape-driven pair lands on the **word before the selector**, also skipping the selector. Symmetric.
+- The cursor still **passes through** selector character positions during normal text editing — the carve-out is specifically about Ctrl+Alt+→/← (word-skip navigation), not character-level cursor movement. Typing inside the span triggers `clearOnEdit` (same as today).
+
+For FEATURES-registry pairs (where the selector axis is real), navigation is unchanged — both selector and satellite are independently navigable, because the user genuinely wants to land on the selector to cycle through settings.
+
+### Rendering follows the navigation predicate
+
+The dim layer (`dim-render.ts`) and the nav layer (`navigation.ts`) share the **same predicate** for shape-driven blanks: when the active pair's blank has `blankShapes:` declared, the selector is **suppressed from `dimRanges`**. The visual gray treatment means "there's a navigable cue here" — and since the selector isn't navigable for shape-driven blanks, dimming it would be a lie. The satellite stays dimmable; the selector renders as plain text.
+
+For FEATURES-pairs, both sides stay dimmed — both ARE interactive.
+
+The two carve-outs (navigation + dimming) must move together. If you ever change one's predicate, change the other's to match — otherwise you get the visual-promise vs. interaction-reality drift that confused users in the first place.
+
+### Why atomic for shape-driven
+
+The selector for shape-driven blanks carries no independent semantic. It's a label. Making it independently navigable suggests an axis that doesn't exist: pressing Ctrl+Alt+↑ on it would either do nothing (confusing — implies action but does none), or forward to the satellite (today's behaviour — masks that they're not actually the same axis), or cycle into something else (which is exactly the bug we hit when the selector wasn't in the FEATURES registry — see [the June 2026 incident](#the-june-2026-incident) below).
+
+Atomic navigation gives the user one clear interaction model: **navigate to the pair, then cycle the value**. The label is read-only context. The two-step navigation model (selector and satellite as separate stops) was a vestige of the FEATURES-pair pattern that didn't transfer.
+
+---
+
+## Cycling semantics
+
+After the splice, `Ctrl+Alt+↑` / `Ctrl+Alt+↓` step the satellite value through the blank's declared cycle vocab. Three dispatchers in `cycleSelectorSatellite`, walked in order:
+
+| Dispatcher | Precondition | Behaviour |
+|---|---|---|
+| **Numeric-step** | `blankStep:` set + current value parses as integer | `current ± blankStep`, clamped to `[0, 100]` |
+| **Categorical** | `stepValues:` is a non-empty array | Cycle through the list with wraparound |
+| **FEATURES-registry** (legacy) | Current selector is in `opencuesState.definitions` | Selector cycles through settings, satellite cycles through values |
+
+Each dispatcher short-circuits to the next if its precondition fails. A blank can declare both `blankStep` and `stepValues` (numeric-step wins for numeric values, categorical wins for string values — useful when a control has both numeric range AND symbolic shortcuts like "max" / "mute").
+
+### Selector-press routing
+
+For shape-driven blanks, **pressing ↑/↓ on the selector forwards to the satellite**. This is implemented as a flag-flip at the top of `cycleSelectorSatellite`:
+
+```typescript
+if (isSelector && !isSatellite) {
+  const blank = configLoader.blanks.get(entry.blankName);
+  const isShapeDriven = Array.isArray(blank?.blankShapes)
+    && (blank.blankShapes.length ?? 0) > 0;
+  if (isShapeDriven) {
+    isSatellite = true;
+    isSelector = false;
+  }
+}
+```
+
+The forward only fires when the blank has `blankShapes:` declared. For FEATURES-registry blanks (`opencues settings _`) — which have no shapes — the flag stays as `isSelector`, and the existing dual-axis cycle path runs.
+
+With the atomic-pair navigation carve-out (above), selector presses become rare in practice — the user can only land on the selector via character-level cursor movement, not word-skip navigation. But the forward rule stays as defence-in-depth: even if a press lands on the selector, the right thing happens.
+
+---
+
+## Two distinct kinds of selector-satellite pairs
+
+OpenCues now has two structurally similar but semantically different uses of the selector-satellite emission. Both ship `pair as one span, clearOnEdit, satellite cycling` — but they differ on the selector axis:
+
+### Single-parameter pair (shape-driven blanks)
+
+- One parameter per blank: volume, brightness, weather, stocks
+- Selector is a **static label** echoing the keyword
+- Satellite is the only cyclable handle
+- Selector-press cycling forwards to satellite (no independent axis)
+- Navigation: pair is one Ctrl+Alt+→ step (atomic)
+
+### Multi-parameter pair (FEATURES-registry blanks)
+
+- One blank, N parameters (every OPENCUES.md scalar)
+- Selector is a **chooser** cycling through parameter names
+- Satellite cycles the chosen parameter's value vocab
+- Selector-press cycles parameters; satellite-press cycles values
+- Navigation: selector and satellite are independently navigable (each axis is meaningful)
+
+Today only `opencues-settings` (the FEATURES-registry blank) uses the multi-parameter shape. ConfigIntent's natural-language flip (`turn debug mode on _` → `debug-mode on`) lands as a FEATURES pair too — it's reusing the same emission with the same dual-axis semantics.
+
+The two patterns coexist because they answer different questions. Single-parameter answers "what's the value of this thing?" Multi-parameter answers "which thing, and what's its value?" A future `blankParameters:` field would let user blanks opt into the multi-parameter shape (see [Multi-parameter blanks (deferred)](#multi-parameter-blanks-deferred) below).
+
+---
+
+## Reasoning
+
+### Why selector is a label, not a chooser
+
+When we introduced shape-driven blanks, every shipped script-backed blank turned out to be single-parameter. Volume has one value to tune. Brightness has one. Weather reads one current condition. Stocks reads one price. There is no second axis a selector could meaningfully cycle to.
+
+We considered three options:
+
+| Option | Selector behaviour | Verdict |
+|---|---|---|
+| Selector is non-interactive (read-only label, ↑/↓ no-op) | Honest but confusing — selectable but does nothing | Rejected |
+| Selector and satellite both cycle the value (interchangeable handles) | Ergonomic but conflates model | Rejected — implies two axes when there's one |
+| Selector forwards to satellite (label that helpfully redirects presses) | Honest model + ergonomic UX | **Picked** |
+
+The third option keeps the mental model clean (selector = label, satellite = control) while giving the user a forgiving interaction (press on either word, the value cycles). The atomic-pair navigation makes the model even cleaner by removing the temptation to land on the selector independently.
+
+### Why we didn't use LLM classification
+
+ConfigIntent classifies natural-language phrases like "turn debug mode on" via an LLM call. That's appropriate because the codomain is bounded — it can only flip OPENCUES.md FEATURES-registry scalars, never a script-backed user blank.
+
+Shape-driven blanks deliberately avoid LLM classification because:
+
+1. **Codomain widens unacceptably**. A user blank declares an arbitrary script that can touch the world (system audio, brightness, HTTP fetches, file writes). Allowing an LLM to route arbitrary natural-language phrases to a user blank's `set <value>` widens the prompt-injection blast radius — a hostile page or document could craft text that the LLM classifies as a setter call.
+2. **Latency cost**. ConfigIntent already pays ~280ms per `_` for its LLM call. Doing the same for every script-backed blank multiplies the cost. PR #135's keyword pre-filter mitigates ConfigIntent's cost specifically; extending it to all blanks would lose that win.
+3. **Determinism**. Regex shapes are deterministic. Authors can reason precisely about what fires their blank. LLM classification is probabilistic — every model and every version drifts in subtle ways.
+
+Shapes give us the precision (no misfires on prose like "the volume was great _") without the security or perf cost. The trade-off: shapes are less forgiving — a phrase that doesn't literally match a declared pattern won't fire, even if the LLM would have classified it correctly.
+
+### Why proximity gate retires for shape-driven blanks
+
+`blankProximity:` is a **positive-only** gate — it says "keyword is within N words of `_`" and claims the slot if true. It can't say "the user actually intends an invocation." Three structural misfires:
+
+| User types | proximity 3 verdict | What user wanted |
+|---|---|---|
+| `the volume was great _` | Fires GET (claims slot) | Fluid-blank lookup |
+| `please increase the volume _` | Fires GET | A setter (or fluid lookup) |
+| `the volume button is broken _` | Fires GET | Fluid-blank lookup |
+
+Shapes upgrade the gate to "input matches one of these patterns." Prose strings match no shape → fluid-blank takes the slot. The misfire surface drops from "any sentence with the keyword near `_`" to "only sentences that literally look like an invocation."
+
+We didn't rip `blankProximity:` out of the codebase. Shape-less blanks (the legacy default) still use it. Shape-driven blanks bypass it. Both can coexist indefinitely.
+
+### Why we wipe the whole matched input
+
+Shape regex patterns are author-anchored: by convention `^...$` against the buffer up to and including `_`. When a shape matches, the **entire input** is the summon. Wiping just the keyword (today's `blankConsumeContext` semantic) would leave prefix/suffix words orphaned:
+
+```
+INPUT:  change theme to sepia _
+LEGACY: change theme sepia      ← "change" and "to" orphaned
+NEW:    theme sepia              ← whole shape wiped, satellite spliced
+```
+
+`applySatelliteFill` was extended with a shape-aware wipe range: when `slot.action !== undefined` (shape-driven match), wipe from the last newline boundary up to and including the `_`, then splice the pair. Surrounding paragraphs survive (line-scoped, not buffer-scoped).
+
+---
+
+## The June 2026 incident
+
+The first cut of shape-driven blanks made the selector navigable AND let selector-position ↑/↓ fall through to the FEATURES-registry cycle dispatcher. The fallthrough used `definitions.get(entry.currentSetting)` to look up the selector word in the OPENCUES.md registry; for volume that returned `undefined` and the code bumped to index 0, which is the first registry setting (`debug-mode` or similar). The visible bug: pressing Ctrl+Alt+↑ on `volume` cycled into `debug-mode something`, replacing the volume blank's selector with an unrelated setting.
+
+The structural lesson: **the FEATURES-registry selector dispatcher assumed every selector it ever saw was a registry entry.** That assumption was true before shape-driven blanks because the only selector-emitting blank was `opencues-settings`. Once a second emission path appeared (shape-driven blanks), the assumption silently failed open.
+
+Two fixes applied:
+
+1. **Bail in the FEATURES selector dispatcher** when `definitions.indexOf(entry.currentSetting) < 0`. Defence-in-depth — even if a selector press leaks past the forward rule, the registry path no longer cycles into something the user didn't want.
+2. **Forward selector-press to satellite for shape-driven blanks** (the rule documented above). Eliminates the leak path entirely for the intended case.
+
+This is documented in `cycling.ts` with the multi-paragraph comment that opens `cycleSelectorSatellite`.
+
+---
+
+## Multi-parameter blanks (deferred extension)
+
+Today every shape-driven blank is single-parameter. A future extension would let one BLANK.md group multiple controls under a single blank, with the selector cycling between them — exactly the shape `opencues-settings` already has, but exposed to user blanks.
+
+### Provisional schema
+
+```yaml
+---
+name: system
+type: blank
+blankKeywords: system
+blankShapes: [{"pattern":"^system\\s*_$","action":"get"}]
+blankParameters:
+  volume:     { step: 6,           type: numeric, clamp: [0, 100] }
+  brightness: { step: 10,          type: numeric, clamp: [0, 100] }
+  mute:       { values: [on, off], type: categorical }
+  balance:    { step: 5,           type: numeric, clamp: [-100, 100] }
+blankScript: ./system-blank.sh
+---
+```
+
+### Provisional script contract (extended)
+
+```
+$1 = get | set
+$2 = parameter name (volume / brightness / mute / balance)
+$3 = (set only) the value
+echo `<parameter>\t<final-value>` on stdout.
+```
+
+### Runtime changes when this lands
+
+- Selector cycler dispatcher learns to read `blankParameters:`. When the blank has parameters declared:
+  - Selector-position ↑/↓ cycles parameter names (`volume → brightness → mute → balance → volume`)
+  - Satellite-position ↑/↓ cycles the chosen parameter's vocab (e.g. `balance` uses `step: 5, clamp: [-100, 100]`)
+- The selector-forwards-to-satellite rule becomes **conditional on `!blankParameters`** — single-parameter blanks still forward, multi-parameter blanks expose the dual-axis.
+- Navigation atomic-pair carve-out becomes conditional too — multi-parameter pairs keep both stops navigable (selector axis is real).
+- `BlankSlot.parameter?: string` added to carry the chosen parameter through to the script call.
+- Spec adds `blankParameters:` to the blank schema. Conformance fixtures cover the two-axis cycling.
+
+### Why we're not doing this now
+
+- No real use-case in the shipped defaults. Adding it speculatively widens the schema surface.
+- Single-parameter covers ~100% of shipped script blanks.
+- The `opencues-settings` blank already serves the multi-axis UX via the FEATURES registry. A user blank wanting the same shape can mirror that pattern when needed.
+
+Comments in `cycling.ts` and this doc flag the exact extension points so future-us knows where to plug in.
+
+---
+
+## Where this lives in code
+
+| Concern | File | Key symbols |
+|---|---|---|
+| `blankShapes:` schema + parser | `packages/opencues-core/src/cues-md.ts` | `BlankFrontmatter.blankShapes`, parser `case 'blankShapes':` |
+| Shape-walk gate + slot fields | `packages/opencues-runtime/src/modules/blank-fill.ts` | `matchBlankShape`, `BlankSlot.action`, `BlankSlot.value`, hasShapes proximity bypass |
+| SET path script invocation | Same file | `scriptAction`/`actionArgs` in `maybeRunScripts`, cacheKey includes action+value |
+| stepValues + script composition | Same file | `maybeRunScripts` short-circuit predicate, `onUnderscoreKey` hasBackingImpl check |
+| Shape-aware wipe range | Same file | `applySatelliteFill` `if (slot.action !== undefined)` branch |
+| Numeric satellite cycle | `packages/opencues-runtime/src/modules/cycling.ts` | First dispatcher in `cycleSelectorSatellite` |
+| Categorical satellite cycle | Same file | Second dispatcher |
+| Selector-forwards-to-satellite | Same file | The `if (isSelector && !isSatellite)` flag-flip |
+| FEATURES-registry dual-axis (preserved) | Same file | The `if (isSelector)` block further down |
+| FEATURES selector defence-in-depth | Same file | The `if (curIdx < 0) return false;` bail |
+| Atomic-pair navigation carve-out | `packages/opencues-runtime/src/modules/navigation.ts` | **Not yet implemented** — see `plan.md` |
+| Volume migration reference | `defaults/blanks/volume/BLANK.md` + `volume-blank.sh` | Canonical shape-driven blank |
+| Brightness migration reference | `defaults/blanks/brightness/BLANK.md` + `brightness-blank.sh` | Mirror of volume |
+
+---
+
+## Author checklist — migrating a script-backed blank to shape-driven
+
+For each blank you migrate (weather, stocks, hackernews, dictionary, crypto, countries, …):
+
+1. **`BLANK.md`** — add the new fields:
+   ```yaml
+   blankShapes: [{"pattern":"^<kw>\\s*_$","action":"get"}, {"pattern":"^<kw>\\s+(...)\\s*_$","action":"set","valueGroup":1}, ...]
+   blankSatellite: true
+   blankClearOnEdit: true
+   blankConsumeContext: true
+   blankStep: <N>          # if numeric
+   stepValues: [...]       # if categorical
+   ```
+   Retire `blankProximity:` (or leave commented for posterity).
+2. **Script** — `get` branch outputs `<keyword>\t<value>` (tab-separated, optional unit suffix). `set` branch applies the value, then echoes `<keyword>\t<final-value>` — the post-clamp / post-validate state. Accept both `set <value>` (shape-driven invocation) and `set <setting> <value>` (cycler invocation) via the value-picker shim used in volume + brightness.
+3. **Test** — update `packages/opencues-runtime/testing/blank-scripts.test.ts` to expect the new tab-separated output. Add a SET-clamp / SET-validate test.
+4. **Agentic scenario** — add a `tests/agentic/scenarios/<N>-<blank>-shapes.json` covering GET, direct SET, verbose SET, satellite cycle (if cyclable), and at least one prose-misfire-reject case.
+5. **Verify** — `pnpm -C packages/opencues-runtime test` + `npx tsx tests/agentic/scenario-runner.ts --pid $PID --scenario tests/agentic/scenarios/<N>-<blank>-shapes.json -v`.
+
+---
+
+## Open standard implications
+
+When this stabilises and at least 2-3 script blanks have migrated, the spec PR updates:
+
+- **`spec/blank-spec.md`** — add `blankShapes:` field definition + the `<script> set <value>` echo contract. Mark `blankProximity:` as legacy.
+- **`spec/core.md`** — document the selector-satellite emission contract (tab-separated `<selector>\t<satellite>` from script, atomic pair as one navigation unit for single-parameter blanks).
+- **`spec/conformance/`** — add fixtures covering: numeric shape SET, categorical shape SET, misfire-reject (prose declines).
+- **`SPEC_VERSION`** bump from `0.2-alpha` → `0.3-alpha` (breaking change at the gate-shape level — `blankProximity` semantics narrow).
+
+User explicitly green-lit the breaking change because few external custom blanks exist. See `plan.md` for the full spec-bump checklist.
+
+---
+
+*Migration progress + open todos: `plan.md` at the repo root.*

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/cues-md.ts
+++ b/packages/opencues-core/src/cues-md.ts
@@ -285,6 +285,41 @@ export interface BlankConfig {
   sandboxFs?: 'ro' | 'rw';
   /** Max words allowed between keyword and _ (0 = adjacent, undefined = no limit) */
   blankProximity?: number;
+  /**
+   * Declarative intent shapes. When set, REPLACES the coarse
+   * proximity gate for this blank: the runtime walks each shape's
+   * regex against the buffer text (with `_` as anchor); first match
+   * wins. The matched shape's `action` determines whether the script
+   * is called with `get` or `set <value>`. If NO shape matches, the
+   * blank declines the slot — fluid-blank takes it.
+   *
+   * Why this exists: `blankProximity` is positive-only — it claims any
+   * sentence where the keyword sits within N words of `_`, including
+   * incidental prose ("the volume was great _", "the volume button is
+   * broken _"). Shapes upgrade the gate to "must look like a real
+   * invocation", dropping misfires sharply without an LLM call.
+   *
+   * Example for volume:
+   *   blankShapes:
+   *     - pattern: '^volume\\s*_$'                          action: get
+   *     - pattern: '^volume\\s+(\\d+)\\s*%?\\s*_$'          action: set  valueGroup: 1
+   *     - pattern: '^set\\s+volume\\s+(?:to\\s+)?(\\d+)\\s*%?\\s*_$'
+   *       action: set  valueGroup: 1
+   *
+   * Patterns are matched case-insensitively against the trimmed
+   * buffer text (whitespace-normalised). `_` is literal in the
+   * pattern; the runtime substitutes its known position.
+   */
+  blankShapes?: ReadonlyArray<{
+    /** RegExp source string (no flags — runtime adds `i`). */
+    pattern: string;
+    /** What to do when this shape matches. */
+    action: 'get' | 'set' | 'step';
+    /** 1-based capture-group index whose match is passed to `set <value>`
+     *  or used as the step direction (`up` / `down`). Required for
+     *  action: 'set' and action: 'step'. */
+    valueGroup?: number;
+  }>;
   /** If true, cycling (Up/Down) is disabled — display-only blank */
   blankReadOnly?: boolean;
   /** If true, `_` is appended as the last cycling option so the user can dismiss the value */
@@ -922,6 +957,11 @@ export interface SingleCueFrontmatter extends CuesMdFrontmatter {
   blankTip?: string;
   blankScript?: string;
   blankProximity?: number;
+  blankShapes?: ReadonlyArray<{
+    pattern: string;
+    action: 'get' | 'set' | 'step';
+    valueGroup?: number;
+  }>;
   blankReadOnly?: boolean;
   blankDismissible?: boolean;
   blankSuffix?: string;
@@ -1049,6 +1089,31 @@ function parseExtendedFrontmatter(content: string): { frontmatter: SingleCueFron
       case 'blankTip': fm.blankTip = value; break;
       case 'blankScript': fm.blankScript = value; break;
       case 'blankProximity': fm.blankProximity = parseInt(value, 10); break;
+      case 'blankShapes': {
+        // Inline-JSON like stepValues (the homegrown parser is line-per-key;
+        // a real YAML pass for blankShapes is a follow-up). Silently drop
+        // malformed entries so a partial syntax error doesn't kill the blank.
+        try {
+          const arr = JSON.parse(value) as Array<{ pattern?: unknown; action?: unknown; valueGroup?: unknown }>;
+          if (Array.isArray(arr)) {
+            const valid: Array<{ pattern: string; action: 'get' | 'set' | 'step'; valueGroup?: number }> = [];
+            for (const s of arr) {
+              if (typeof s.pattern !== 'string') continue;
+              if (s.action !== 'get' && s.action !== 'set' && s.action !== 'step') continue;
+              const entry: { pattern: string; action: 'get' | 'set' | 'step'; valueGroup?: number } = {
+                pattern: s.pattern,
+                action: s.action,
+              };
+              if (typeof s.valueGroup === 'number' && s.valueGroup >= 1) {
+                entry.valueGroup = s.valueGroup;
+              }
+              valid.push(entry);
+            }
+            if (valid.length > 0) fm.blankShapes = valid;
+          }
+        } catch { /* ignore malformed */ }
+        break;
+      }
       case 'blankReadOnly': fm.blankReadOnly = value === 'true'; break;
       case 'blankDismissible': fm.blankDismissible = value === 'true'; break;
       case 'blankSuffix': fm.blankSuffix = value; break;
@@ -1221,6 +1286,7 @@ export function parseSingleCueMd(content: string, folderPath: string, nameOverri
       if (frontmatter.blankFormat !== undefined) blank.blankFormat = frontmatter.blankFormat;
       if (frontmatter.blankTip !== undefined) blank.blankTip = frontmatter.blankTip;
       if (frontmatter.blankProximity !== undefined) blank.blankProximity = frontmatter.blankProximity;
+      if (frontmatter.blankShapes !== undefined) blank.blankShapes = frontmatter.blankShapes;
       if (frontmatter.blankReadOnly !== undefined) blank.blankReadOnly = frontmatter.blankReadOnly;
       if (frontmatter.blankDismissible !== undefined) blank.blankDismissible = frontmatter.blankDismissible;
       if (frontmatter.blankSuffix !== undefined) blank.blankSuffix = frontmatter.blankSuffix;

--- a/packages/opencues-core/src/sources/fluid-blank-source.ts
+++ b/packages/opencues-core/src/sources/fluid-blank-source.ts
@@ -810,12 +810,25 @@ export class FluidBlankSource implements CueSource {
     if (TASK_TRIGGER_GUARD.test(context.text)) return false;
     // Cede the slot to BlankFill if any registered blank would actually
     // claim it. Mirror BlankSource's claim rules: keyword present AND
-    // within `blankProximity` words of the `_`. Loose-match (keyword
-    // present anywhere) leaves a dead zone for inputs like `what is git
-    // as in github _` where the keyword is too far to claim.
+    // either (a) within `blankProximity` words of the `_`, OR (b) the
+    // blank has `blankShapes:` declared and at least one shape matches
+    // the input. Without (b), shape-driven blanks with no legacy
+    // proximity declared (gh-issues, future migrated blanks) would
+    // not cede — fluid-blank would race the host-side proxy and win
+    // on slow dispatches (the June 2026 gh-issues race).
+    //
+    // Shape walk uses the SAME `^...$`-anchored regex as
+    // matchBlankShape in BlankFill (`testText = words[0..blankIdx].join(' ')`),
+    // so the two gates are byte-identical in their match decisions —
+    // no drift surface between cede check and dispatch decision.
+    const testText = context.words.slice(0, blankIndex + 1).join(' ').trim();
     for (const blk of Object.values(this.blanks)) {
       if (!blk.blankKeywords?.length) continue;
       const proximity = blk.blankProximity ?? 0;
+      // Quick keyword presence check — if the keyword isn't in the
+      // buffer at all, neither proximity nor shape can match.
+      let keywordPresent = false;
+      let kwInProximity = false;
       for (const phrase of blk.blankKeywords) {
         const parts = phrase.toLowerCase().split(/\s+/);
         for (let i = 0; i <= lower.length - parts.length; i++) {
@@ -824,9 +837,27 @@ export class FluidBlankSource implements CueSource {
             if (lower[i + j] !== parts[j]) { ok = false; break; }
           }
           if (!ok) continue;
+          keywordPresent = true;
           const endIdx = i + parts.length - 1;
           const gap = Math.abs(endIdx - blankIndex) - 1;
-          if (gap <= proximity) return false;   // BlankSource will claim
+          if (gap <= proximity) kwInProximity = true;
+        }
+      }
+      if (!keywordPresent) continue;
+      // Path A — legacy proximity gate: keyword present AND within
+      // proximity.
+      if (kwInProximity) return false;
+      // Path B — shape gate: keyword present (somewhere) AND a shape
+      // matches the input. The shape's `^...$` anchor handles
+      // false-positives like "the volume was great _" — those match
+      // no shape so fluid-blank correctly claims.
+      const shapes = (blk as { blankShapes?: ReadonlyArray<{ pattern: string }> }).blankShapes;
+      if (Array.isArray(shapes) && shapes.length > 0) {
+        for (const shape of shapes) {
+          let re: RegExp;
+          try { re = new RegExp(shape.pattern, 'is'); }
+          catch { continue; }
+          if (re.test(testText)) return false;
         }
       }
     }

--- a/packages/opencues-core/src/sources/transform-blank-source.ts
+++ b/packages/opencues-core/src/sources/transform-blank-source.ts
@@ -1526,11 +1526,27 @@ export class TransformBlankSource implements CueSource {
     const blankIndex = lower.indexOf('_');
     if (blankIndex === -1) return false;
 
-    // Cede to keyword-bound BlankSource if a registered blank's keyword is
-    // within blankProximity of the `_` (mirror fluid-blank cede logic).
+    // Cede to keyword-bound BlankSource if a registered blank would
+    // claim the slot — either via legacy blankProximity or via the
+    // new blankShapes gate. Mirror of fluid-blank-source.ts's cede
+    // logic; the two MUST stay in sync because they're the two
+    // priority-92/93 races against the priority-95 BlankFill claim.
+    //
+    // Path A (legacy): keyword present + within blankProximity words
+    // of `_`. Original behavior.
+    // Path B (shapes — June 2026): keyword present anywhere + a
+    // shape matches the `^...$`-anchored input. Without this, shape-
+    // driven blanks with no preserved legacy proximity (gh-issues,
+    // sentinel, future migrations) would race transform-blank and
+    // lose on async dispatches (the user-pack JS dispatch hit this
+    // first; sentinel + future user blanks would inherit the same
+    // race).
+    const testText = context.words.slice(0, blankIndex + 1).join(' ').trim();
     for (const blk of Object.values(this.blanks)) {
       if (!blk.blankKeywords?.length) continue;
       const proximity = blk.blankProximity ?? 0;
+      let keywordPresent = false;
+      let kwInProximity = false;
       for (const phrase of blk.blankKeywords) {
         const parts = phrase.toLowerCase().split(/\s+/);
         for (let i = 0; i <= lower.length - parts.length; i++) {
@@ -1539,9 +1555,21 @@ export class TransformBlankSource implements CueSource {
             if (lower[i + j] !== parts[j]) { ok = false; break; }
           }
           if (!ok) continue;
+          keywordPresent = true;
           const endIdx = i + parts.length - 1;
           const gap = Math.abs(endIdx - blankIndex) - 1;
-          if (gap <= proximity) return false;
+          if (gap <= proximity) kwInProximity = true;
+        }
+      }
+      if (!keywordPresent) continue;
+      if (kwInProximity) return false; // path A
+      const shapes = (blk as { blankShapes?: ReadonlyArray<{ pattern: string }> }).blankShapes;
+      if (Array.isArray(shapes) && shapes.length > 0) {
+        for (const shape of shapes) {
+          let re: RegExp;
+          try { re = new RegExp(shape.pattern, 'is'); }
+          catch { continue; }
+          if (re.test(testText)) return false; // path B
         }
       }
     }

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/blanks/countries.test.ts
+++ b/packages/opencues-runtime/src/blanks/countries.test.ts
@@ -10,14 +10,17 @@ function fetchOk(body: unknown, status = 200): typeof fetch {
   } as Response)) as unknown as typeof fetch;
 }
 
+// V2-clone schema (countries-api-836d.onrender.com) — June 2026.
+// name is a string, capital is a string, currencies + languages
+// are arrays of objects. See countries.ts § Data source note.
 const FRANCE = [{
-  name: { common: 'France' },
-  capital: ['Paris'],
+  name: 'France',
+  capital: 'Paris',
   population: 67750000,
   region: 'Europe',
   area: 551695,
-  currencies: { EUR: { name: 'Euro', symbol: '€' } },
-  languages: { fra: 'French' },
+  currencies: [{ code: 'EUR', name: 'Euro', symbol: '€' }],
+  languages: [{ iso639_1: 'fr', iso639_2: 'fra', name: 'French', nativeName: 'français' }],
 }];
 
 describe('CountriesBlank', () => {
@@ -47,7 +50,12 @@ describe('CountriesBlank', () => {
   });
 
   it('returns first 3 languages joined', async () => {
-    const india = [{ ...FRANCE[0], languages: { hin: 'Hindi', eng: 'English', tam: 'Tamil', tel: 'Telugu' } }];
+    const india = [{ ...FRANCE[0], languages: [
+      { name: 'Hindi' },
+      { name: 'English' },
+      { name: 'Tamil' },
+      { name: 'Telugu' },
+    ] }];
     const ctl = new CountriesBlank({ fetchFn: fetchOk(india) });
     expect(await ctl.get('languages of', ['india'])).toBe('India languages: Hindi, English, Tamil');
   });
@@ -59,6 +67,36 @@ describe('CountriesBlank', () => {
     await ctl.get('capital of', ['france']);
     await ctl.get('currency of', ['france']);
     expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('disambiguates multi-hit responses by exact name match first, shortest second', async () => {
+    // The v2-clone returns multiple countries for ambiguous queries
+    // (e.g. "india" → British Indian Ocean Territory + India; "united
+    // states" → United States Minor Outlying Islands + United States
+    // of America). pickBestMatch picks the right one.
+    const indiaResponse = [
+      { ...FRANCE[0], name: 'British Indian Ocean Territory', capital: 'Diego Garcia',
+        languages: [{ name: 'English' }] },
+      { ...FRANCE[0], name: 'India', capital: 'New Delhi',
+        languages: [{ name: 'Hindi' }, { name: 'English' }] },
+    ];
+    const ctl = new CountriesBlank({ fetchFn: fetchOk(indiaResponse) });
+    expect(await ctl.get('capital of', ['india'])).toBe('India capital: New Delhi');
+    expect(await ctl.get('languages of', ['india'])).toBe('India languages: Hindi, English');
+  });
+
+  it('disambiguates multi-word query by shortest-name fallback when no exact match', async () => {
+    // "united states" doesn't exactly match either result; shortest name wins.
+    const usResponse = [
+      { ...FRANCE[0], name: 'United States Minor Outlying Islands', capital: '' },
+      { ...FRANCE[0], name: 'United States of America', capital: 'Washington, D.C.' },
+    ];
+    const ctl = new CountriesBlank({ fetchFn: fetchOk(usResponse) });
+    // prettyCountry uses the QUERY string (the user typed "united
+    // states"), not the API's longer name — so the prefix stays
+    // "United States" even though the matched entry is "United
+    // States of America".
+    expect(await ctl.get('capital of', ['united states'])).toBe('United States capital: Washington, D.C.');
   });
 
   it('returns "<country>: not found" for HTTP 404', async () => {

--- a/packages/opencues-runtime/src/blanks/countries.ts
+++ b/packages/opencues-runtime/src/blanks/countries.ts
@@ -1,20 +1,28 @@
-// CountriesBlank — fetches country facts from restcountries.com
-// (no auth, no rate limit beyond reasonable). Read-only. 24h cache
-// per (country, fact) pair.
+// CountriesBlank — fetches country facts from a free v2-clone of
+// REST Countries. Read-only. 24h cache per country.
 //
 // Trigger phrases like "population of france", "capital of japan",
 // "currency of brazil" → resolve <fact> + <country>, fetch the
 // country, return the requested field.
 //
-// Design note: REST Countries returns a rich object per country,
-// so a single blank can surface multiple facts. The BLANK.md exposes
-// it via several keywords (population of, capital of, currency of, ...)
+// Design note: a single blank can surface multiple facts. The BLANK.md
+// exposes it via several keywords (population of, capital of, etc.)
 // and the keyword tells us which field to extract.
+//
+// Data source note (June 2026): restcountries.com/v3.1 was deprecated
+// in 2026, v5 requires an auth key. This blank uses a community-run
+// v2 clone at countries-api-836d.onrender.com — same schema as the
+// pre-deprecation REST Countries v2 API. The endpoint is free but
+// hosted on Render's free tier, so the first request after ~15 min
+// of inactivity may take 30-60s (cold start). Long-term path: bundle
+// a static dataset (mledoze/countries) so the blank doesn't depend
+// on any third-party API for read-only data that doesn't change
+// frequently. Tracked in plan.md § Countries data source.
 
 import type { Blank } from './types';
 
 const CACHE_TTL_MS = 86_400_000; // 24h — country data is stable
-const ENDPOINT = 'https://restcountries.com/v3.1/name';
+const ENDPOINT = 'https://countries-api-836d.onrender.com/countries/name';
 
 // Keyword phrase fragment → which field to surface.
 // Order matters for partial matches (longest-first wins via sort).
@@ -29,14 +37,17 @@ const FACT_PATTERNS: Array<[RegExp, FactKey]> = [
 
 type FactKey = 'population' | 'capital' | 'currency' | 'region' | 'languages' | 'area';
 
+// REST Countries v2-clone schema (countries-api-836d.onrender.com):
+// flatter than v3.1 — name is a string, capital is a string, and
+// currencies/languages are arrays of objects rather than keyed records.
 interface CountryApiEntry {
-  name?: { common?: string };
-  capital?: string[];
+  name?: string;
+  capital?: string;
   population?: number;
   region?: string;
   area?: number;
-  currencies?: Record<string, { name?: string; symbol?: string }>;
-  languages?: Record<string, string>;
+  currencies?: Array<{ code?: string; name?: string; symbol?: string }>;
+  languages?: Array<{ iso639_1?: string; iso639_2?: string; name?: string; nativeName?: string }>;
 }
 
 const SKIP_WORDS: ReadonlySet<string> = new Set([
@@ -83,7 +94,7 @@ export class CountriesBlank implements Blank {
         }
         const data = (await resp.json()) as CountryApiEntry[];
         if (!data?.length) return `${country}: not found`;
-        entry = data[0];
+        entry = pickBestMatch(country, data);
         this._cache.set(country.toLowerCase(), { data: entry, ts: Date.now() });
       } catch {
         return `${country}: error`;
@@ -123,6 +134,33 @@ function pickCountry(keyword?: string, context?: string[]): string {
   return all.join(' ').trim();
 }
 
+/**
+ * The v2-clone returns multiple hits for ambiguous queries — "india"
+ * returns both "British Indian Ocean Territory" + "India"; "united
+ * states" returns "United States Minor Outlying Islands" before "United
+ * States of America". `data[0]` picks the wrong one. Two-pass rank:
+ *   1. exact case-insensitive name match (best);
+ *   2. shortest name (works for both cases — "India" beats "British
+ *      Indian Ocean Territory", "United States of America" beats
+ *      "United States Minor Outlying Islands" by length).
+ */
+function pickBestMatch(query: string, data: CountryApiEntry[]): CountryApiEntry {
+  const q = query.toLowerCase().trim();
+  for (const c of data) {
+    if ((c.name ?? '').toLowerCase() === q) return c;
+  }
+  let best = data[0];
+  let bestLen = (best.name ?? '').length || Infinity;
+  for (const c of data) {
+    const len = (c.name ?? '').length;
+    if (len && len < bestLen) {
+      best = c;
+      bestLen = len;
+    }
+  }
+  return best;
+}
+
 function formatFact(fact: FactKey, entry: CountryApiEntry): string {
   switch (fact) {
     case 'population': {
@@ -134,7 +172,7 @@ function formatFact(fact: FactKey, entry: CountryApiEntry): string {
       if (n >= 1e3) return `${(n / 1e3).toFixed(0)}K`;
       return String(n);
     }
-    case 'capital': return entry.capital?.[0] ?? 'unknown';
+    case 'capital': return entry.capital ?? 'unknown';
     case 'region':  return entry.region ?? 'unknown';
     case 'area': {
       const a = entry.area;
@@ -143,15 +181,17 @@ function formatFact(fact: FactKey, entry: CountryApiEntry): string {
     }
     case 'currency': {
       const cs = entry.currencies;
-      if (!cs) return 'unknown';
-      const code = Object.keys(cs)[0];
-      const name = cs[code]?.name;
-      return name ? `${name} (${code})` : code;
+      if (!cs?.length) return 'unknown';
+      const first = cs[0];
+      const code = first.code ?? '';
+      const name = first.name ?? '';
+      if (name && code) return `${name} (${code})`;
+      return name || code || 'unknown';
     }
     case 'languages': {
       const ls = entry.languages;
-      if (!ls) return 'unknown';
-      return Object.values(ls).slice(0, 3).join(', ');
+      if (!ls?.length) return 'unknown';
+      return ls.slice(0, 3).map(l => l.name).filter(Boolean).join(', ');
     }
   }
 }

--- a/packages/opencues-runtime/src/blanks/stocks.test.ts
+++ b/packages/opencues-runtime/src/blanks/stocks.test.ts
@@ -15,7 +15,7 @@ describe('StocksBlank', () => {
     expect(await ctl.get()).toBe('');
   });
 
-  it('returns "Unknown: <kw>" for keywords not in the ticker map', async () => {
+  it('returns "Unknown: <kw>" for keywords not in the ticker map (June 2026: one-span emission, no tab)', async () => {
     const ctl = new StocksBlank({ apiKey: 'x', fetchFn: fetchOk({ c: 1 }) });
     expect(await ctl.get('not-a-ticker')).toBe('Unknown: not-a-ticker');
   });
@@ -25,7 +25,7 @@ describe('StocksBlank', () => {
     expect(await ctl.get('aapl')).toBe('AAPL: no API key');
   });
 
-  it('formats Finnhub current-price response as "$X.XX"', async () => {
+  it('formats Finnhub current-price response as "<TICKER>: $X.XX"', async () => {
     const ctl = new StocksBlank({ apiKey: 'k', fetchFn: fetchOk({ c: 201.66 }) });
     expect(await ctl.get('aapl')).toBe('AAPL: $201.66');
   });

--- a/packages/opencues-runtime/src/blanks/stocks.ts
+++ b/packages/opencues-runtime/src/blanks/stocks.ts
@@ -65,8 +65,11 @@ export class StocksBlank implements Blank {
       const resp = await this._fetch(url);
       if (!resp.ok) return `${ticker}: HTTP ${resp.status}`;
       const data = (await resp.json()) as { c?: number };
-      // Embed ticker so `blankReplace: auto` produces self-contained
-      // output when the trigger is wiped ("nvda _" → "NVDA: $198.47").
+      // Shape-driven read-only emission (June 2026). No tab — stocks
+      // has no cycle vocab. The runtime splices the whole string as
+      // one wipeable gray span via the regular consumeContext path.
+      // See docs/architecture/shape-driven-blanks.md § Emission
+      // shapes by cycle-vocab presence.
       const price = `${ticker}: $${data.c?.toFixed(2) ?? '?'}`;
       this._cache.set(ticker, { price, ts: Date.now() });
       return price;

--- a/packages/opencues-runtime/src/blanks/weather.test.ts
+++ b/packages/opencues-runtime/src/blanks/weather.test.ts
@@ -30,9 +30,9 @@ function makeFetch(plan: FetchPlan): typeof fetch {
 }
 
 describe('WeatherBlank', () => {
-  it('returns "<temp>°C <desc>" for the resolved location', async () => {
+  it('returns "weather <city> <temp>°C <desc>" for the resolved location (June 2026: one-span emission, no tab — no cycle vocab)', async () => {
     const ctl = new WeatherBlank({ fetchFn: makeFetch({}) });
-    expect(await ctl.get('weather', ['weather', 'london'])).toBe('London: 14°C Partly cloudy');
+    expect(await ctl.get('weather', ['weather', 'london'])).toBe('weather London 14°C Partly cloudy');
   });
 
   it("strips trigger/time words and uses the last meaningful token as location", async () => {
@@ -52,7 +52,7 @@ describe('WeatherBlank', () => {
     expect(calls[0][0]).toContain('name=Berlin');
   });
 
-  it('returns "Unknown location: <name>" when geocode has no results', async () => {
+  it('returns "Unknown location: <name>" when geocode has no results (legacy error shape — not tab-separated)', async () => {
     const ctl = new WeatherBlank({ fetchFn: makeFetch({ geo: { results: [] } }) });
     expect(await ctl.get('weather', ['weather', 'narnia'])).toBe('Unknown location: narnia');
   });

--- a/packages/opencues-runtime/src/blanks/weather.ts
+++ b/packages/opencues-runtime/src/blanks/weather.ts
@@ -84,13 +84,17 @@ export class WeatherBlank implements Blank {
 
       const temp = `${Math.round(current.temperature_2m)}°C`;
       const desc = WMO_CODES[current.weather_code] ?? '';
-      // Embed the location so `blankReplace: auto` callers produce
-      // self-contained output when the trigger phrase is wiped.
       const prettyLocation = location
         .split(/\s+/)
         .map(w => w.charAt(0).toUpperCase() + w.slice(1))
         .join(' ');
-      const display = `${prettyLocation}: ${temp} ${desc}`.trim();
+      // Shape-driven read-only emission (June 2026). No tab — weather
+      // has no cycle vocab (no blankStep, no stepValues), so the
+      // selector-satellite split has no semantic purpose. The runtime
+      // splices the whole string as one wipeable gray span via the
+      // regular consumeContext path. See docs/architecture/shape-
+      // driven-blanks.md § Emission shapes by cycle-vocab presence.
+      const display = `weather ${prettyLocation} ${temp} ${desc}`.trim();
 
       this._cache.set(cacheKey, { result: display, ts: Date.now() });
       return display;

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -30,6 +30,14 @@ export interface BlankSlot {
   readonly keywordEnd: number;
   /** Words between keywordEnd and the `_` (0 = adjacent). */
   readonly proximity: number;
+  /** When the blank declared `blankShapes` and one matched, the
+   *  action the script should perform. Falls through to `get` for
+   *  shape-less blanks (today's behaviour). */
+  readonly action?: 'get' | 'set' | 'step';
+  /** Captured value from the matched shape's `valueGroup` — passed as
+   *  the second arg to `script set <value>` (or `step <value>` for
+   *  direction tokens like "up"/"down"). Empty for action: 'get'. */
+  readonly value?: string;
 }
 
 export class BlankFill {
@@ -335,10 +343,18 @@ export class BlankFill {
         | undefined;
       if (!blank) continue;
       if (blank.blankAutoPopulate === false) continue;
-      // stepValues path is handled synchronously in onUnderscoreKey.
-      if (Array.isArray(blank.stepValues) && blank.stepValues.length > 0) continue;
+      // stepValues alone (no script, no blank-invoke) is the legacy
+      // list-blank pattern — `_` gets replaced with stepValues[0]
+      // synchronously in onUnderscoreKey and the script path stays
+      // dormant. But when a blank ALSO declares blankScript /
+      // blank-invoke, stepValues is just the categorical cycle vocab
+      // for the satellite cycler (June 2026 — three-axis model);
+      // the script still owns get/set. Skip only when there's no
+      // backing implementation.
       const script = blank.blankScript;
       const canBlankInvoke = this.adapter.capabilities.includes('blank-invoke');
+      if (Array.isArray(blank.stepValues) && blank.stepValues.length > 0
+          && !script && !canBlankInvoke) continue;
       // Need EITHER a shell script (legacy spawnProcess path) OR a
       // blankInvoke-capable host (modern shared-runtime blanks).
       // Without either, no way to fetch the fill.
@@ -397,7 +413,11 @@ export class BlankFill {
       // Frontmatter parser may pass the value through as either a
       // number or a string-of-digits depending on the YAML shape, so
       // coerce here.
-      const cacheKey = `${slot.blankName}::${slot.keyword}|${contextWords.join('|')}`;
+      // Cache key includes action + value so a SET 70 result doesn't
+      // satisfy a SET 30 lookup, and a SET cache hit doesn't satisfy a
+      // GET intent (or vice versa). Shape-less blanks always emit GET
+      // with empty value, so this is byte-identical to today's key.
+      const cacheKey = `${slot.blankName}::${slot.action ?? 'get'}::${slot.value ?? ''}::${slot.keyword}|${contextWords.join('|')}`;
       const rawTtl = (blank as { blankCacheTtlMs?: unknown }).blankCacheTtlMs;
       const parsedTtl = typeof rawTtl === 'number'
         ? rawTtl
@@ -444,13 +464,26 @@ export class BlankFill {
       // animates until BOTH owners release (refcounted in animator).
       this._loadingAnimator().start(slot.index, 'blank-fill');
 
+      // Pick the script verb. Shape-driven blanks (blankShapes set in
+      // BLANK.md) emit slot.action in {get, set, step} based on which
+      // shape matched. Shape-less blanks (today's default) always run
+      // 'get'. For 'set' / 'step', slot.value carries the captured
+      // group from the matching shape (e.g. "70" from `volume 70 _`).
+      // The script's contract on the set branch is to apply the value,
+      // clamp it as needed, and echo the FINAL post-clamp state on
+      // stdout — that's what the runtime substitutes into the slot.
+      const scriptAction = slot.action ?? 'get';
+      const actionArgs: string[] = scriptAction === 'get'
+        ? [slot.keyword, ...contextWords]
+        : (slot.value !== undefined ? [slot.value] : []);
+
       // Try host-native blank invocation first (Chrome, Electron,
       // anything without shell access). Fall through to spawnProcess
       // when the host returns null or doesn't implement blankInvoke.
       let handle = this.adapter.blankInvoke?.({
         blankName: slot.blankName,
-        action: 'get',
-        args: [slot.keyword, ...contextWords],
+        action: scriptAction,
+        args: actionArgs,
         env,
         timeoutMs: 8000,
       }) ?? null;
@@ -520,7 +553,7 @@ export class BlankFill {
         }
         handle = this.adapter.spawnProcess({
           command: 'bash',
-          args: [scriptPath, 'get', slot.keyword, ...contextWords],
+          args: [scriptPath, scriptAction, ...actionArgs],
           env,
           timeoutMs: 8000,
           sandbox,
@@ -978,11 +1011,30 @@ export class BlankFill {
     if (!selectorRaw || !satelliteRaw) return;
     const sep = blank.blankSatelliteSeparator || ' ';
     const pair = `${selectorRaw}${sep}${satelliteRaw}`;
-    const { clearEnd, expansion } = computeFillRange(blank, slot);
-    const { newText, newCursor } = clearEnd !== undefined || expansion != null
-      ? buildClearKeywordText(cleaned, slot, pair, expansion, clearEnd)
-      : { newText: cleaned.slice(0, target.start) + pair + cleaned.slice(target.end),
-          newCursor: target.start + pair.length };
+
+    // Shape-driven path: the shape pattern matched the ENTIRE input
+    // up to and including `_` (regex is anchored with ^...$ by author
+    // convention), so the whole input is the summon and gets replaced
+    // by the satellite pair. This converges shape-driven blanks on
+    // ConfigIntent's wipe-all emission shape (one wipeable span,
+    // surrounding prose preserved). For legacy blanks (no shapes),
+    // fall through to the existing keyword-range computeFillRange.
+    let newText: string;
+    let newCursor: number;
+    if (slot.action !== undefined) {
+      // Wipe from start-of-line (or last newline boundary) to the
+      // `_` position. Multi-line buffers: stay scoped to the current
+      // line so prior paragraphs survive.
+      const lineStart = cleaned.lastIndexOf('\n', target.start - 1) + 1;
+      newText = cleaned.slice(0, lineStart) + pair + cleaned.slice(target.end);
+      newCursor = lineStart + pair.length;
+    } else {
+      const { clearEnd, expansion } = computeFillRange(blank, slot);
+      ({ newText, newCursor } = clearEnd !== undefined || expansion != null
+        ? buildClearKeywordText(cleaned, slot, pair, expansion, clearEnd)
+        : { newText: cleaned.slice(0, target.start) + pair + cleaned.slice(target.end),
+            newCursor: target.start + pair.length });
+    }
 
     if (this.selectorSatelliteState) {
       const newWords = splitWords(newText);
@@ -1082,6 +1134,14 @@ export class BlankFill {
     if (this.dismissedBlanks?.has(slot.index)) return false;
     const stepValues = blank.stepValues;
     if (!Array.isArray(stepValues) || stepValues.length === 0) return false;
+    // Three-axis model (June 2026): when the blank also declares
+    // blankScript / blank-invoke, stepValues is the categorical cycle
+    // vocab — the script owns get/set, not the synchronous list
+    // fill. Bail and let maybeRunScripts handle the async script
+    // call. Pure list-blanks (no script) still get the sync fill.
+    const hasBackingImpl = !!(blank as { blankScript?: string }).blankScript
+      || this.adapter.capabilities.includes('blank-invoke');
+    if (hasBackingImpl) return false;
     const fillValue = stepValues[0];
 
     // Mirror applyAsyncFill: when `blankReplace` is set explicitly,
@@ -1219,8 +1279,21 @@ export class BlankFill {
         // dictionary, where the user types extra words between the
         // trigger phrase and `_`) MUST set blankProximity explicitly.
         // Matches the cede default in blank-source.ts.
-        const blankProximity = (blank as { blankProximity?: number }).blankProximity ?? 0;
-        if ((blankIdx - j - 1) > blankProximity) continue;
+        //
+        // Shape-driven blanks (`blankShapes:` declared) BYPASS the
+        // proximity gate entirely — the shape patterns own precision
+        // and already anchor their own keyword + value distance via
+        // the regex. Without this carve-out, a shape like
+        // `^theme\s+(dark|light)\s*_$` could never match because the
+        // proximity-0 default would reject the keyword being 2+ words
+        // back from `_`. Shapes ARE the gate; proximity becomes a
+        // legacy field for shape-less blanks.
+        const hasShapes = Array.isArray((blank as { blankShapes?: unknown }).blankShapes)
+          && ((blank as { blankShapes?: unknown[] }).blankShapes?.length ?? 0) > 0;
+        if (!hasShapes) {
+          const blankProximity = (blank as { blankProximity?: number }).blankProximity ?? 0;
+          if ((blankIdx - j - 1) > blankProximity) continue;
+        }
         for (const kw of blankKeywords) {
           const kwLc = kw.toLowerCase();
           const kwWords = kwLc.split(/\s+/);
@@ -1246,6 +1319,22 @@ export class BlankFill {
               }
             }
             if (insideSubstitute) continue;
+            // Shape gate: when the blank declares `blankShapes`, the
+            // proximity match is necessary but not sufficient. The shape
+            // patterns must also confirm the user's input looks like a
+            // real invocation — drops misfires on prose like "the volume
+            // was great _" where `volume` is near `_` but the user isn't
+            // invoking the blank. If shapes are declared and none match,
+            // this blank declines the slot (fluid-blank takes it).
+            const shapes = (blank as { blankShapes?: ReadonlyArray<{ pattern: string; action: 'get' | 'set' | 'step'; valueGroup?: number }> }).blankShapes;
+            let shapeAction: 'get' | 'set' | 'step' | undefined;
+            let shapeValue: string | undefined;
+            if (shapes && shapes.length > 0) {
+              const matchedShape = matchBlankShape(words, blankIdx, shapes);
+              if (!matchedShape) continue;
+              shapeAction = matchedShape.action;
+              shapeValue = matchedShape.value;
+            }
             return {
               index: blankIdx,
               keyword: kwLc,
@@ -1253,6 +1342,8 @@ export class BlankFill {
               keywordStart: start,
               keywordEnd: j,
               proximity: blankIdx - j - 1,
+              ...(shapeAction ? { action: shapeAction } : {}),
+              ...(shapeValue !== undefined ? { value: shapeValue } : {}),
             };
           }
         }
@@ -1260,6 +1351,45 @@ export class BlankFill {
     }
     return null;
   }
+}
+
+/**
+ * Walk the blank's declared shapes against the buffer text; return
+ * the matched action + extracted value, or null if no shape fires.
+ *
+ * The test string is the buffer text up to and including `_`, with
+ * leading/trailing whitespace trimmed. Patterns are compiled with `i`
+ * (case-insensitive) and `s` (dotall — multi-line bodies don't need
+ * to anchor at the start of every line). Authors can use `^` / `$`
+ * to anchor against the trimmed input as a whole.
+ *
+ * First-match wins (top-down walk). Authors should order shapes
+ * narrowest-first: bare-keyword shapes after numeric-bearing shapes,
+ * so "volume 70 _" matches the SET shape before the bare-GET shape
+ * sees it.
+ */
+function matchBlankShape(
+  words: readonly string[],
+  blankIdx: number,
+  shapes: ReadonlyArray<{ pattern: string; action: 'get' | 'set' | 'step'; valueGroup?: number }>,
+): { action: 'get' | 'set' | 'step'; value?: string } | null {
+  // Build the test string from the buffer up to and including the `_`.
+  // Trailing words AFTER the `_` are ignored — by the time `_` fires,
+  // they're not part of the invocation.
+  const testText = words.slice(0, blankIdx + 1).join(' ').trim();
+  for (const shape of shapes) {
+    let re: RegExp;
+    try { re = new RegExp(shape.pattern, 'is'); }
+    catch { continue; }
+    const m = re.exec(testText);
+    if (!m) continue;
+    let value: string | undefined;
+    if (shape.valueGroup !== undefined) {
+      value = m[shape.valueGroup];
+    }
+    return { action: shape.action, ...(value !== undefined ? { value } : {}) };
+  }
+  return null;
 }
 
 /** Debug helper — keys actually injected into the script env. */

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -724,10 +724,29 @@ export class BlankFill {
       spanAsUnit: blank?.blankClearOnEdit === true,
     });
 
-    const { newText, newCursor } = clearEnd !== undefined || expansion != null
-      ? buildClearKeywordText(cleaned, slot, primaryFill, expansion, clearEnd)
-      : { newText: cleaned.slice(0, target.start) + primaryFill + cleaned.slice(target.end),
-          newCursor: target.start + primaryFill.length };
+    // Shape-driven path (June 2026) — when the matched shape produced
+    // a slot with `action` set, the shape's regex matched the ENTIRE
+    // input (regex anchored ^...$). Wipe the whole matched input
+    // (line-scoped — surrounding paragraphs survive) and splice the
+    // fill into its place. Without this carve-out, the legacy
+    // computeFillRange would only wipe the keyword span, leaving the
+    // user's captured prompt text (or other prefix words the shape
+    // matched) loose in the buffer. Mirrors the same carve-out in
+    // applySatelliteFill — both emission shapes converge on
+    // line-scoped wipe for shape-driven blanks.
+    const isShapeDriven = slot.action !== undefined;
+    const { newText, newCursor } = isShapeDriven
+      ? (() => {
+          const lineStart = cleaned.lastIndexOf('\n', target.start - 1) + 1;
+          return {
+            newText: cleaned.slice(0, lineStart) + primaryFill + cleaned.slice(target.end),
+            newCursor: lineStart + primaryFill.length,
+          };
+        })()
+      : clearEnd !== undefined || expansion != null
+        ? buildClearKeywordText(cleaned, slot, primaryFill, expansion, clearEnd)
+        : { newText: cleaned.slice(0, target.start) + primaryFill + cleaned.slice(target.end),
+            newCursor: target.start + primaryFill.length };
 
     // Populate span for non-consume-all fills when there's
     // anything cycleable to do: multi-word fill, multiple lines from

--- a/packages/opencues-runtime/src/modules/config-loader.ts
+++ b/packages/opencues-runtime/src/modules/config-loader.ts
@@ -587,6 +587,9 @@ export class ConfigLoader {
   // overwritten by the stale file content. _suppressReloadUntil delays
   // the next reload long enough for the write to settle.
   private _suppressReloadUntil = 0;
+  // June 2026 — one-shot deprecation warn per blank-name per process.
+  // See plan.md § Phase 2 + Phase 5 for the deprecation timeline.
+  private _warnedDeprecatedProximity = new Set<string>();
 
   constructor(
     private adapter: HostAdapter,
@@ -1069,6 +1072,28 @@ export class ConfigLoader {
     }
     for (const [name, blk] of Object.entries(blanksConfig?.blanks ?? {})) {
       addBlank(name, blk as BlankConfig);
+    }
+
+    // blankProximity deprecation warning (June 2026). Flagged once
+    // per blank per process lifetime. blankShapes is the precise
+    // replacement; proximity is a positive-only gate that misfires
+    // on prose. Full design: docs/architecture/shape-driven-blanks.md.
+    // Removal queued in plan.md § Phase 5 after all shipped blanks
+    // migrate. Until then: warn loudly, keep the gate working for
+    // back-compat.
+    for (const [name, blk] of blanksByWord) {
+      const b = blk.blank as { blankProximity?: number; blankShapes?: unknown };
+      const hasShapes = Array.isArray(b.blankShapes) && b.blankShapes.length > 0;
+      const hasProximity = typeof b.blankProximity === 'number';
+      if (hasProximity && !hasShapes && !this._warnedDeprecatedProximity.has(blk.name)) {
+        this._warnedDeprecatedProximity.add(blk.name);
+        this.adapter.log('warn',
+          `blank '${blk.name}': blankProximity: is DEPRECATED — declare blankShapes: ` +
+          `for precision. Proximity is a positive-only gate that fires on prose ` +
+          `("the ${name} was great _" claims the slot). See ` +
+          `docs/architecture/shape-driven-blanks.md § Author migration checklist.`,
+        );
+      }
     }
 
     this._config = {

--- a/packages/opencues-runtime/src/modules/cycling.ts
+++ b/packages/opencues-runtime/src/modules/cycling.ts
@@ -216,9 +216,178 @@ export class Cycling {
     const satLen = Math.max(1, entry.satelliteLength);
     const selEnd = entry.selectorIndex + selLen - 1;
     const satEnd = entry.satelliteIndex + satLen - 1;
-    const isSelector = wordIndex >= entry.selectorIndex && wordIndex <= selEnd;
-    const isSatellite = wordIndex >= entry.satelliteIndex && wordIndex <= satEnd;
+    let isSelector = wordIndex >= entry.selectorIndex && wordIndex <= selEnd;
+    let isSatellite = wordIndex >= entry.satelliteIndex && wordIndex <= satEnd;
     if (!isSelector && !isSatellite) return false;
+
+    // Per-blank satellite cycle (June 2026 — second axis of the
+    // three-axis shape-driven model). Full design + reasoning:
+    // docs/architecture/shape-driven-blanks.md.
+    //
+    // The selector-satellite cycler gained two dispatchers BEFORE the
+    // original FEATURES-registry path so a script-backed blank can
+    // declare its own cycle vocab without polluting OPENCUES.md:
+    //
+    //   1. Numeric-step: blank.blankStep is set, current value parses
+    //      as an integer → cycle by ±blankStep, clamp to 0..100.
+    //   2. Categorical: blank.stepValues is a non-empty array → cycle
+    //      through the list with wraparound.
+    //   3. FEATURES-registry (existing path below) — OPENCUES.md
+    //      scalars like debug-mode / voice-mode.
+    //
+    // ─── Selector semantics for shape-driven blanks (single-parameter) ───
+    //
+    // The mental model: SELECTOR is a static LABEL (the keyword),
+    // SATELLITE is the CONTROL (the cyclable value). Today's
+    // shape-driven blanks (volume / brightness / weather / stocks)
+    // are all single-parameter — they expose one control with a
+    // descriptive label, not two independent cycle axes.
+    //
+    // UX rule: pressing ↑/↓ on the SELECTOR forwards the press to
+    // the SATELLITE (the actual cycle target). The user doesn't have
+    // to know which word is the "active" handle; the runtime routes
+    // their press to the right place. Ctrl+Alt+→ still lands on the
+    // selector as a normal navigation step — selectors aren't
+    // skipped, they just don't cycle independently.
+    //
+    // ─── Multi-parameter blanks (future, deferred) ──────────────────
+    //
+    // A future BLANK.md field — provisionally `blankParameters:` —
+    // would opt a blank into the FULL two-axis model:
+    //
+    //   blankParameters:
+    //     volume:     { step: 6,                    type: numeric }
+    //     brightness: { step: 10,                   type: numeric }
+    //     mute:       { values: [on, off],          type: categorical }
+    //
+    // SELECTOR would then become a chooser cycling between parameter
+    // names (volume → brightness → mute), and SATELLITE would cycle
+    // the chosen parameter's vocab. Same two-axis shape as today's
+    // `opencues settings _` FEATURES-registry blank, just available
+    // to script-backed user blanks too. Script contract extends:
+    //   `<script> get <parameter>`     → echo `<parameter>\t<value>`
+    //   `<script> set <parameter> <v>` → apply + echo final state
+    //
+    // When that lands, the forward-to-satellite rule below becomes
+    // conditional: only forward when the blank has NO blankParameters
+    // declared. Multi-parameter blanks get the existing dual-axis
+    // behaviour (selector cycles parameters, satellite cycles values).
+    //
+    // For now: every shape-driven blank is single-parameter, so the
+    // forward rule fires unconditionally on isSelector.
+    if (isSelector && !isSatellite) {
+      const blank = this.configLoader.blanks.get(entry.blankName) as
+        | (Record<string, unknown> & { blankShapes?: unknown })
+        | undefined;
+      const isShapeDriven = Array.isArray(blank?.blankShapes)
+        && ((blank?.blankShapes as unknown[]).length ?? 0) > 0;
+      if (isShapeDriven) {
+        // Forward selector-press to satellite. The numeric/categorical
+        // dispatchers below treat the press as if it landed on the
+        // satellite word.
+        isSatellite = true;
+        isSelector = false;
+      }
+    }
+
+    // Each dispatcher short-circuits to the next when its precondition
+    // fails.
+    if (isSatellite) {
+      const blank = this.configLoader.blanks.get(entry.blankName) as
+        | (Record<string, unknown> & {
+            blankStep?: number;
+            blankSuffix?: string;
+            stepValues?: readonly string[];
+          })
+        | undefined;
+      const step = blank?.blankStep;
+      if (typeof step === 'number' && step > 0) {
+        // Parse current value: strip trailing `%` / other non-digit
+        // suffix, accept a leading minus only if the blank's format
+        // would allow it. clamp() in the script enforces the canonical
+        // range; here we just compute the requested next value.
+        const cur = entry.currentValue.trim();
+        const m = cur.match(/^(-?\d+)/);
+        if (m) {
+          const curNum = parseInt(m[1], 10);
+          const nextNum = Math.max(0, Math.min(100, curNum + step * direction));
+          const suffix = blank?.blankSuffix ?? cur.slice(m[1].length);
+          const nextValue = `${nextNum}${suffix}`;
+
+          const selStart = words[entry.selectorIndex];
+          const selEndW = words[selEnd];
+          const satEndW = words[satEnd];
+          if (!selStart || !selEndW || !satEndW) return false;
+          const newText = spliceSelectorSatellite(event.text, selStart, selEndW, satEndW, entry.currentSetting, nextValue, entry.separator);
+          const newRegionEnd = selStart.start + entry.currentSetting.length + entry.separator.length + nextValue.length;
+          const newCursor = Math.min(newRegionEnd, newText.length);
+
+          entry.currentValue = nextValue;
+          entry.satelliteLength = Math.max(1, nextValue.split(/\s+/).filter(Boolean).length);
+          entry.pairCharEnd = newRegionEnd;
+          this.selectorSatelliteState!.set(entry, newText);
+          this.adapter.setText(newText);
+          this.adapter.setCursorOffset(newCursor);
+          this.adapter.forceRender();
+
+          this.adapter.log('debug', `Cycling: numeric-step satellite ${entry.blankName}`, {
+            from: cur, to: nextValue, step, direction,
+          });
+          // Fire the set with just the numeric — single-arg shape the
+          // shape-driven SET path also uses. Scripts with multiple
+          // settings (categorical cyclers) read both args; numeric-
+          // step blanks like volume can ignore the keyword arg.
+          this.invokeOrSpawn(
+            entry.blankName,
+            'set',
+            [entry.currentSetting, String(nextNum)],
+            entry.scriptPath,
+            { detached: true, timeoutMs: 4000 },
+          );
+          return true;
+        }
+      }
+
+      // Categorical satellite cycle. When the blank declares stepValues,
+      // cycle through the list with wraparound. Wraps `theme` /
+      // `lights` / any binary-or-multi categorical control.
+      const stepValues = blank?.stepValues;
+      if (Array.isArray(stepValues) && stepValues.length > 0) {
+        const curIdx = stepValues.indexOf(entry.currentValue);
+        const baseIdx = curIdx >= 0 ? curIdx : 0;
+        const startIdx = curIdx >= 0 ? baseIdx + direction : 0;
+        const nextIdx = ((startIdx) % stepValues.length + stepValues.length) % stepValues.length;
+        const nextValue = stepValues[nextIdx];
+
+        const selStart = words[entry.selectorIndex];
+        const selEndW = words[selEnd];
+        const satEndW = words[satEnd];
+        if (!selStart || !selEndW || !satEndW) return false;
+        const newText = spliceSelectorSatellite(event.text, selStart, selEndW, satEndW, entry.currentSetting, nextValue, entry.separator);
+        const newRegionEnd = selStart.start + entry.currentSetting.length + entry.separator.length + nextValue.length;
+        const newCursor = Math.min(newRegionEnd, newText.length);
+
+        entry.currentValue = nextValue;
+        entry.satelliteLength = Math.max(1, nextValue.split(/\s+/).filter(Boolean).length);
+        entry.pairCharEnd = newRegionEnd;
+        this.selectorSatelliteState!.set(entry, newText);
+        this.adapter.setText(newText);
+        this.adapter.setCursorOffset(newCursor);
+        this.adapter.forceRender();
+
+        this.adapter.log('debug', `Cycling: categorical satellite ${entry.blankName}`, {
+          from: stepValues[baseIdx], to: nextValue, direction,
+        });
+        this.invokeOrSpawn(
+          entry.blankName,
+          'set',
+          [entry.currentSetting, nextValue],
+          entry.scriptPath,
+          { detached: true, timeoutMs: 4000 },
+        );
+        return true;
+      }
+    }
 
     const definitions = this.configLoader.opencuesState.definitions;
     if (definitions.size === 0) return false;
@@ -243,6 +412,21 @@ export class Cycling {
         .map(([name]) => name);
       if (names.length === 0) return false;
       const curIdx = names.indexOf(entry.currentSetting);
+      // Bail when the current selector isn't a known FEATURES-registry
+      // setting (June 2026). The registry-driven selector cycle only
+      // makes sense for the `opencues settings _` flow where each
+      // setting is one of N OPENCUES.md scalars. For shape-driven
+      // blanks (volume / brightness / theme / any per-blank pair),
+      // the selector is the blank's own keyword — there's nothing to
+      // cycle to. Without this guard, pressing Ctrl+Alt+↑ on the
+      // "volume" selector would step into index 0 of the registry
+      // (curIdx === -1 + 1 = 0 → debug-mode or whatever), silently
+      // replacing the volume blank's selector with an unrelated
+      // setting. Strict no-op is the correct behavior; UX could
+      // later route this through the satellite cycle if we decide
+      // selector-presses should mirror satellite-presses for
+      // script-backed blanks.
+      if (curIdx < 0) return false;
       const nextIdx = ((curIdx + direction) % names.length + names.length) % names.length;
       const nextSetting = names[nextIdx];
       const nextDef = definitions.get(nextSetting);

--- a/packages/opencues-runtime/src/modules/dim-render.ts
+++ b/packages/opencues-runtime/src/modules/dim-render.ts
@@ -135,12 +135,30 @@ export class DimRender {
 
     // Selector + satellite dim. Both sides can be multi-word
     // ("display mode" / "plain text"). Each side gets its own dim layer.
+    //
+    // Shape-driven blanks (June 2026) — atomic-pair dimming. Full
+    // design: docs/architecture/shape-driven-blanks.md § Navigation
+    // semantics (rendering follows the same predicate as navigation).
+    // The selector for shape-driven blanks is a static LABEL, not a
+    // cycle axis — graying it implies an interaction the user
+    // doesn't have (gray = "navigable cue here"). Suppress the
+    // selector's dim entry; the satellite stays dimmable so the
+    // user can still see "there's something cyclable on this side".
+    // FEATURES-pairs (`opencues settings _`) keep both sides dimmed
+    // — both ARE interactive there.
     if (hasDimCap && ss) {
+      const ssBlank = this.configLoader?.blanks.get(ss.blankName) as
+        | { blankShapes?: unknown }
+        | undefined;
+      const ssIsShapeDriven = ssBlank && Array.isArray(ssBlank.blankShapes)
+        && (ssBlank.blankShapes as unknown[]).length > 0;
       const ss0 = words[ss.selectorIndex];
       const ss1 = words[ssSelEnd];
       const ts = words[ss.satelliteIndex];
       const te = words[ssSatEnd];
-      if (ss0 && ss1 && !activeInSelector) dimRanges.push({ start: ss0.start, end: ss1.end });
+      if (ss0 && ss1 && !activeInSelector && !ssIsShapeDriven) {
+        dimRanges.push({ start: ss0.start, end: ss1.end });
+      }
       if (ts && te && !activeInSatellite) dimRanges.push({ start: ts.start, end: te.end });
     }
 

--- a/packages/opencues-runtime/src/modules/navigation.ts
+++ b/packages/opencues-runtime/src/modules/navigation.ts
@@ -340,18 +340,54 @@ export class Navigation {
     // Force-include selector-start + satellite-start. Drop
     // inner words of either side (multi-word selectors like "display
     // mode" or values like "plain text" cycle as single units).
+    //
+    // Shape-driven blanks (June 2026) — atomic-pair navigation. Full
+    // design: docs/architecture/shape-driven-blanks.md § Navigation
+    // semantics. The selector is a static label, not a cycle axis;
+    // the satellite is the only cyclable handle. Treating them as
+    // two independent nav stops would suggest an axis that doesn't
+    // exist. Carve-out: when the active pair is shape-driven (the
+    // blank declares `blankShapes:`), include ONLY the satellite in
+    // the nav targets. The selector becomes unreachable via Ctrl+Alt
+    // +←/→ word-skip — the pair is one nav step, landing on the
+    // satellite directly. The selector character positions stay
+    // reachable via regular cursor keys; clearOnEdit still fires on
+    // edits anywhere in the span.
+    //
+    // FEATURES-registry pairs (`opencues settings _`) keep both
+    // stops — there the selector axis is real (cycles through
+    // settings) so the user needs to land on it. Detected by the
+    // active blank NOT having `blankShapes:` declared.
+    //
+    // Multi-parameter blanks (future `blankParameters:` field) will
+    // gate the carve-out further: `hasShapes && !hasParameters`.
+    // Today every shape-driven blank is single-parameter.
     const ss = this.selectorSatelliteState?.current ?? null;
+    const ssBlank = ss ? this.configLoader?.blanks.get(ss.blankName) as
+      | { blankShapes?: unknown }
+      | undefined : undefined;
+    const ssIsShapeDriven = ssBlank && Array.isArray(ssBlank.blankShapes)
+      && (ssBlank.blankShapes as unknown[]).length > 0;
     const withSelectorSatellite = (ins: number[]): number[] => {
       if (!ss) return ins;
       const selLen = Math.max(1, ss.selectorLength);
       const satLen = Math.max(1, ss.satelliteLength);
       const selEnd = ss.selectorIndex + selLen - 1;
       const satEnd = ss.satelliteIndex + satLen - 1;
+      // Inner-position filter: drop multi-word selector/satellite
+      // inner words. For shape-driven blanks, ALSO drop the selector
+      // start (so the satellite is the only nav stop for the pair).
       const isInner = (i: number): boolean =>
         (i > ss.selectorIndex && i <= selEnd) ||
-        (i > ss.satelliteIndex && i <= satEnd);
+        (i > ss.satelliteIndex && i <= satEnd) ||
+        (!!ssIsShapeDriven && i >= ss.selectorIndex && i <= selEnd);
       const out = ins.filter(i => !isInner(i));
-      for (const idx of [ss.selectorIndex, ss.satelliteIndex]) {
+      // Force-add: always satellite-start. Selector-start ONLY when
+      // not shape-driven (FEATURES-pair behaviour preserved).
+      const forceAdd = ssIsShapeDriven
+        ? [ss.satelliteIndex]
+        : [ss.selectorIndex, ss.satelliteIndex];
+      for (const idx of forceAdd) {
         if (!out.includes(idx) && words.some(w => w.index === idx)) out.push(idx);
       }
       out.sort((a, b) => a - b);

--- a/packages/opencues-runtime/testing/blank-scripts.test.ts
+++ b/packages/opencues-runtime/testing/blank-scripts.test.ts
@@ -77,20 +77,46 @@ describe('shipped blank scripts: colocated-helpers contract', () => {
     // are bash-portable.
     const skip = os.platform() === 'win32';
 
-    it.skipIf(skip)('brightness-blank.sh get: returns a bare integer, never crashes', () => {
+    it.skipIf(skip)('brightness-blank.sh get: returns selector-satellite "brightness\\t<N>%", never crashes', () => {
+      // June 2026: brightness migrated to selector-satellite emission
+      // (mirrors volume). Script echoes `brightness\t<value>%` so the
+      // runtime's blankSatellite path splices it as one wipeable span.
       const out = execFileSync('bash', [path.join(DEFAULTS_BLANKS, 'brightness/brightness-blank.sh'), 'get'], {
         encoding: 'utf8',
         env: { ...process.env, HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'oc-test-home-')) },
       });
-      expect(out.trim()).toMatch(/^\d{1,3}$/);
+      expect(out.trim()).toMatch(/^brightness\t\d{1,3}%$/);
     });
 
-    it.skipIf(skip)('volume-blank.sh get: returns a bare integer, never crashes', () => {
+    it.skipIf(skip)('brightness-blank.sh set <N>: applies + echoes post-clamp selector-satellite', () => {
+      // set 200 clamps to 100 + echoes `brightness\t100%`.
+      const out = execFileSync('bash', [path.join(DEFAULTS_BLANKS, 'brightness/brightness-blank.sh'), 'set', '200'], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'oc-test-home-')) },
+      });
+      expect(out.trim()).toBe('brightness\t100%');
+    });
+
+    it.skipIf(skip)('volume-blank.sh get: returns selector-satellite "volume\\t<N>%", never crashes', () => {
+      // June 2026: volume migrated to selector-satellite emission. The
+      // script now echoes `volume\t<value>%` (TAB-separated) so the
+      // runtime's blankSatellite path splices it as one wipeable span.
       const out = execFileSync('bash', [path.join(DEFAULTS_BLANKS, 'volume/volume-blank.sh'), 'get'], {
         encoding: 'utf8',
         env: { ...process.env, HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'oc-test-home-')) },
       });
-      expect(out.trim()).toMatch(/^\d{1,3}$/);
+      expect(out.trim()).toMatch(/^volume\t\d{1,3}%$/);
+    });
+
+    it.skipIf(skip)('volume-blank.sh set <N>: applies + echoes post-clamp selector-satellite', () => {
+      // Calling set 200 must clamp to 100 and echo `volume\t100%` so
+      // the buffer reflects the FINAL state, not the user's pre-clamp
+      // input. Same pattern: TAB-separated label+value.
+      const out = execFileSync('bash', [path.join(DEFAULTS_BLANKS, 'volume/volume-blank.sh'), 'set', '200'], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fs.mkdtempSync(path.join(os.tmpdir(), 'oc-test-home-')) },
+      });
+      expect(out.trim()).toBe('volume\t100%');
     });
 
     // opencues-blank.sh + sentinel-blank.sh used to live here. Both

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,261 @@
+# Shape-driven blanks — plan + todo tracker
+
+The three-axis blank model. Started June 2026 after the volume-blank user-experience review (`set volume 70% _` exposed two gaps: prose-misfire problem and natural-language SET problem). What we're building, what's shipped, what's left.
+
+## The three-axis model
+
+Every script-backed blank composes three independent pieces:
+
+| Axis | Frontmatter | What it controls |
+|---|---|---|
+| **Shapes** | `blankShapes:` — array of `{pattern, action, valueGroup?}` | When the blank fires (precision gate, replaces `blankProximity`) + which script verb runs (`get` / `set` / `step`) + what value gets passed |
+| **Script contract** | `blankScript: ./xyz.sh` (or `impl:` for JS user-blanks) | How state gets applied. Script accepts `<verb> <value>` (and `<verb> <setting> <value>` from cycler — see compat note) and echoes `<selector>\t<satellite>` on stdout |
+| **Cycle vocab** | `blankStep:` (numeric) and/or `stepValues:` (categorical) | What Ctrl+Alt+↑/↓ does after the fill. Both optional, both compose with shapes + script |
+
+Default emission: selector-satellite span (`blankSatellite: true` + `blankClearOnEdit: true` + `blankConsumeContext: true`). One Backspace wipes the pair. Cycler stash drives Ctrl+Alt+↑/↓ from the cycle vocab.
+
+What we converged on:
+
+- Shape-driven blanks bypass the `blankProximity` gate — shapes own precision.
+- `applySatelliteFill` wipes the whole matched input (line-scoped) when the slot was matched via shapes.
+- `stepValues` + `blankScript` compose (categorical cycle vocab + script ownership of get/set). Previously stepValues short-circuited the script path.
+- Selector-satellite cycler gained two dispatchers (numeric, categorical) before the FEATURES-registry path.
+
+---
+
+## Status
+
+### ✅ Shipped on branch `feat/blank-shapes`
+
+| Area | Done |
+|---|---|
+| `blankShapes:` schema in `BlankFrontmatter` + `BlankConfig` | `packages/opencues-core/src/cues-md.ts` |
+| `blankShapes:` parser case (inline-JSON, mirrors `stepValues:`) | Same file |
+| Loader copy step | Same file |
+| `BlankSlot.action` + `BlankSlot.value` fields | `packages/opencues-runtime/src/modules/blank-fill.ts` |
+| `matchBlankShape` helper + shape-walk in `matchKeyword` | Same file |
+| Proximity gate bypassed when `blankShapes:` present | Same file |
+| `stepValues` + `blankScript` composition (`maybeRunScripts` + `onUnderscoreKey`) | Same file |
+| SET path: scriptAction + actionArgs picker + cacheKey includes action+value | Same file |
+| `applySatelliteFill` shape-aware wipe-line range | Same file |
+| Numeric-step satellite cycler dispatcher | `packages/opencues-runtime/src/modules/cycling.ts` |
+| Categorical-stepValues satellite cycler dispatcher | Same file |
+| Volume migration (BLANK.md + script tab-emit + SET branch + dual-arg shape) | `defaults/blanks/volume/` |
+| Brightness migration (mirrors volume) | `defaults/blanks/brightness/` |
+| Test suite updates (volume + brightness selector-satellite contract) | `packages/opencues-runtime/testing/blank-scripts.test.ts` |
+| Agentic scenarios (volume × 3 + brightness × 1) | `tests/agentic/scenarios/67-70` |
+
+### ✅ Validation
+
+| Surface | Result |
+|---|---|
+| `@opencues/core` tests | 870/879 pass, 9 skipped, 0 fail |
+| `@opencues/runtime` tests | **1658/1658 pass** (added brightness SET clamp test) |
+| Agentic — volume shapes gate | 16/16 (GET / SET / verbose SET) |
+| Agentic — volume prose misfire reject | 16/16 (3 prose strings decline) |
+| Agentic — volume cycling | 20/20 (+6/-6/wraparound) |
+| Agentic — brightness shapes + cycling | 26/26 (GET / SET / +10/-10 / verbose SET) |
+| Agentic — OPENCUES settings (FEATURES-registry path) | 18/18 (unaffected) |
+| Agentic — fluid-config NL flip (ConfigIntent) | 8/8 (unaffected) |
+| Agentic — fluid-blank pipeline | 8/8 (unaffected) |
+
+**112 agentic steps across 7 scenarios, 0 fails.** All legacy paths unaffected.
+
+### 🚧 User-side manual testing (next step)
+
+Wilfred to drive volume + brightness in a real opencode session and confirm the UX feels right end-to-end:
+
+- [ ] `volume _` → `volume 50%` (one-span pair, one Backspace wipes it)
+- [ ] `volume 70 _` → `volume 70%` + system actually at 70
+- [ ] `set volume to 50 _` → `volume 50%` ("set"/"to" wiped)
+- [ ] `volume 200 _` → `volume 100%` (clamp visible)
+- [ ] `the volume was great _` / `please increase the volume _` → no claim
+- [ ] Ctrl+Alt+→ then Ctrl+Alt+↑ → +6% steps
+- [ ] Same flow for brightness (`brightness _`, `brightness 30 _`, `set brightness to 80 _`, +10/-10 steps)
+- [ ] Existing settings cycle (OPENCUES.md scalars) still cycles
+- [ ] Existing fluid-config still flips on natural-language settings phrasing
+
+---
+
+## What's not yet shipped (todo)
+
+### Step 1a — Implement atomic-pair navigation for shape-driven blanks
+
+Documented in `docs/architecture/shape-driven-blanks.md` § Navigation semantics but NOT yet wired in `navigation.ts`. Runtime currently treats every word as independently navigable.
+
+The carve-out:
+- When `Ctrl+Alt+→` would land on the selector of a shape-driven pair (the `selectorSatelliteState.current` entry's `blankName` is in `configLoader.blanks` AND that blank has `blankShapes:` declared), advance to the satellite instead. The pair is one step.
+- Symmetric: `Ctrl+Alt+←` past the satellite lands on the word before the selector.
+- Multi-parameter blanks (when `blankParameters:` lands) keep both stops navigable. The carve-out's predicate becomes `hasShapes && !hasParameters`.
+- FEATURES-registry pairs (`opencues settings _`) keep independently navigable selector + satellite (the selector axis IS real there).
+
+Code pointers: `packages/opencues-runtime/src/modules/navigation.ts` for the nav stepper; `selectorSatelliteState` in the BlankFill module for the active-pair lookup.
+
+Tests needed:
+- Agentic scenario: `volume _` → `Ctrl+Alt+→` from the word before the pair → cursor lands on `50%` (not `volume`). Symmetric backward.
+- Agentic scenario: `opencues settings _` → `Ctrl+Alt+→` still lands on each word independently (selector + satellite as two stops).
+- Unit test pinning the carve-out predicate (`hasShapes && !hasParameters`).
+
+### Step 1b — Migrate remaining script-backed blanks
+
+Once Wilfred confirms the UX, each is a small per-blank PR (or batched). All follow the volume/brightness pattern: add shapes, emit tab-separated, accept dual-arg SET, set `blankSatellite: true` + `blankClearOnEdit: true` + `blankConsumeContext: true`.
+
+- [ ] **weather** (`defaults/blanks/weather/`) — shapes: `weather _`, `weather <city> _`. No SET (read-only). Suffix `%` retires; selector becomes `weather`.
+- [ ] **stocks** (`defaults/blanks/stocks/`) — shapes: `stocks _`, `stocks <SYMBOL> _`. Read-only.
+- [ ] **hackernews** (`defaults/blanks/hackernews/`) — shapes: `hn _` / `hackernews _`. Read-only. Already emits multi-line so converge carefully.
+- [ ] **dictionary** (`defaults/blanks/dictionary/`) — shapes: `what is X _` / `define X _`. Read-only.
+- [ ] **crypto** (`defaults/blanks/crypto/`) — shapes: `crypto _`, `crypto <SYMBOL> _`. Read-only.
+- [ ] **countries** (`defaults/blanks/countries/`) — shapes: `countries _`, `country <name> _`. Read-only.
+- [ ] **affirmations** (`defaults/blanks/affirmations.md`) — list-blank. Stays on `stepValues` only (no script).
+- [ ] **answer** (`defaults/blanks/answer.md`) — special LLM-backed. Decide separately.
+- [ ] **prompt** (`defaults/blanks/prompt.md`) — LLM-backed. Decide separately.
+- [ ] **claude-status** — script-backed. Migrate or leave.
+- [ ] **opencues / sentinel** — special selector blanks. Probably stay on FEATURES-registry path.
+
+### Step 2 — Documentation sweep
+
+The three-axis model is going to land in user-facing prose, architecture docs, and the spec. Plan:
+
+- [x] **`docs/architecture/shape-driven-blanks.md`** ✅ **Written June 2026.** Canonical reference for the new mechanic. Covers the three-axis model, selector-satellite emission, navigation semantics (including the atomic-pair carve-out), cycling semantics (numeric/categorical/FEATURES dispatchers + selector-forwards-to-satellite), reasoning (why label-not-chooser, why no LLM classification, why proximity retires), the June 2026 incident post-mortem, the multi-parameter deferred extension, code pointers, and the per-blank migration checklist. Cross-references blank-sources.md, fluid-config.md, blank-replace-modes.md, spans-and-cycling.md.
+- [ ] `concept.md` — Update "Two directions of intent" diagram. Mention shapes briefly under Blanks.
+- [ ] `CLAUDE.md` (root) — Add a section pointing at `docs/architecture/shape-driven-blanks.md` as canonical. Replace old volume/brightness mentions.
+- [ ] `docs/features/blanks.md` (if exists) or new file — User-facing reference. How to author a shape-driven blank.
+- [ ] `docs/guides/adding-a-cue-blank.md` ⚠️ — Referenced from CLAUDE.md as a must-read. Update with the three-axis model. Old `blankProximity:` advice marked as legacy. Cross-reference shape-driven-blanks.md.
+- [ ] `docs/architecture/blank-sources.md` ⚠️ — Add a "shape-driven gate" pointer linking to shape-driven-blanks.md. The CueSource family layer is unchanged; the shape gate sits above it.
+- [ ] `docs/architecture/spans-and-cycling.md` ⚠️ — Add note on the satellite cycler's three dispatchers + selector-forwards-to-satellite rule. Cross-reference shape-driven-blanks.md.
+- [ ] `docs/architecture/blank-replace-modes.md` — Note that shape-driven blanks have a fixed effective mode (line-scoped wipe) regardless of `blankReplace:`. The legacy field still applies to shape-less blanks.
+- [ ] `docs/glossary.md` — Add entries for: shape, shape-driven blank, selector, satellite, cycle vocab, atomic-pair navigation.
+- [ ] `docs/features/transform-blank.md` / `docs/features/agent-task.md` — Already cleaned up (the `<INSTR> _ <BODY>` rule). No changes needed here.
+
+### Step 3 — Spec update (separate repo)
+
+After we have at least volume + brightness landed and used, open a PR against the spec repo. This is a breaking-change at the spec level (`blankProximity` becomes legacy, `blankShapes` becomes the canonical gate). User said "feel free to make a breaking change" because few external custom blanks exist.
+
+- [ ] Bump `SPEC_VERSION` in `packages/opencues-core/src/spec-version.ts` (currently `0.2-alpha` → `0.3-alpha`).
+- [ ] Update `SPEC.md` (root) current-version line.
+- [ ] Update `spec/blank-spec.md`:
+  - Add `blankShapes:` field definition.
+  - Add the script `set` contract (echo `<selector>\t<satellite>` on stdout).
+  - Mark `blankProximity:` as legacy / deprecated for new blanks.
+  - Document the `cycle vocab` axis (blankStep numeric + stepValues categorical).
+  - Document selector-satellite emission as the default for shape-driven blanks.
+- [ ] Update `spec/core.md`:
+  - Document spec-version policy unchanged (omit-default stays at 0.1-alpha).
+- [ ] Add conformance fixtures at `spec/conformance/valid/blank-shapes/`:
+  - Numeric SET fixture (mirroring volume).
+  - Categorical fixture (mirroring an imaginary theme blank).
+  - Misfire-reject fixture (prose input that should decline).
+- [ ] Update `spec/CHANGELOG.md` with the 0.2-alpha → 0.3-alpha cut entry.
+- [ ] Bump `spec/README.md` Status banner + Status & versioning section.
+- [ ] Bump `spec/*.md` Status banners.
+- [ ] Update JSON schemas at `spec/schemas/` to add `blankShapes:` to the blank schema.
+- [ ] Update `packages/opencues-core/src/conformance.test.ts` "spec-too-new" regex.
+- [ ] CHANGELOG.md (root) entry under `[Unreleased]` describing the breaking change.
+
+### Step 4 — Cleanup + back-compat decisions
+
+- [ ] Decide whether to keep `blankProximity:` reading for the legacy blanks not yet migrated, or hard-rip it after all migrations land.
+- [ ] Decide whether to keep `blankSuffix:` reading at all (shape-driven blanks emit the suffix in the script, so this field is dead weight on migrated blanks). Probably leave for now — back-compat costs nothing.
+- [ ] Decide whether `blankReplace:` stays as a per-blank knob or retires for shape-driven blanks (which always wipe-line).
+- [ ] Consider whether `blankConsumeContext: true` should be implicit for shape-driven blanks (currently has to be set explicitly in each BLANK.md). One less knob.
+
+### Step 5 — Drift / structural protections
+
+- [ ] Add an `opencues review` check: warn when a script-backed blank has `blankProximity:` set but no `blankShapes:` — the proximity gate is fragile and shapes is the recommended pattern.
+- [ ] Add a test that pins: a blank with `blankShapes:` declared + no shape matching `<input> _` SHOULD decline the slot (BlankFill returns null, fluid-blank takes over). This is the misfire-reject invariant.
+- [ ] Add a test that pins: shape-driven blank's emission ALWAYS goes through `applySatelliteFill` (never through the slot-splice path).
+
+---
+
+## What this enables downstream
+
+Once volume + brightness + a few read-only blanks (weather, stocks, dictionary) have migrated:
+
+- **Natural-language setters** for every action blank. Today: `volume 70 _`, `brightness 80 _`, `set volume to 50 _`. Tomorrow: any blank an author wants.
+- **Per-blank cycle vocab** without polluting OPENCUES.md. A pack author ships a blank with `stepValues: ["red", "green", "blue"]` and the user cycles through them with Ctrl+Alt+↑/↓.
+- **Misfire elimination** at the structural level. Prose mentions of "volume" / "brightness" / "weather" no longer hijack the slot.
+- **One-Backspace wipe** consistent across every script-backed blank.
+- **Third-party pack expressiveness** — pack authors declare what shapes fire their blank + a script that handles get/set. No LLM in the routing loop; security model unchanged.
+
+---
+
+## Risk surfaces
+
+- Cycler complexity. Three dispatchers in `cycleSelectorSatellite` (numeric, categorical-stepValues, FEATURES-registry). Each short-circuits to the next when preconditions fail. Manageable; new tests would help pin the ordering.
+- Inline-JSON in `blankShapes:` is ugly for users authoring by hand. A real YAML parser pass for the `blankShapes` field is a follow-up. Not blocking — the same shape applies to existing `stepValues:`.
+- Author surface widens. Three-axis model means more frontmatter to think about. Documentation has to make the model obvious or we lose the simplicity gain.
+
+---
+
+## Decisions made (record so we don't relitigate)
+
+1. **Shape gate is regex-based**, not LLM-based. Authors declare shapes; runtime extracts the matching value. No LLM in the routing loop = no prompt-injection blast radius widening.
+2. **Codomain stays bounded** by per-blank shape declarations. ConfigIntent retains exclusive access to OPENCUES.md FEATURES-registry scalars via its LLM classifier (different security boundary).
+3. **Shape-driven blanks emit selector-satellite spans by default**. The convergence with ConfigIntent's UX (one-Backspace wipe) is the structural payoff.
+4. **`blankProximity:` stays for back-compat** but becomes legacy. Hard-rip is queued for after all migrations land (or never — costs nothing to leave).
+5. **`stepValues:` + `blankScript:` compose**. The old "stepValues = list-only blank" assumption retires.
+6. **Wipe-line scope** (not buffer-scope) for the shape-driven splice. Prior paragraphs survive.
+7. **Breaking-change at spec level is acceptable** because few external custom blanks exist. User explicitly green-lit this.
+8. **Brightness migrated second** as the proving ground that the pattern works outside volume's specific case.
+9. **Spec update deferred** until volume + brightness have been used in real sessions and the UX feels right.
+10. **Selector = static label, satellite = control** for shape-driven blanks. The selector word displays the keyword as a visual context cue; cycling only happens on the satellite. Pressing ↑/↓ on the selector forwards the press to the satellite (the user doesn't have to know which side is the "active" handle, but the model stays clean — selector isn't a second axis, it's a label whose presses get helpfully redirected). The two-axis chooser model is reserved for the future multi-parameter pattern (see deferred section below).
+
+## Deferred — multi-parameter blanks (`blankParameters:` axis)
+
+Today every shape-driven blank is **single-parameter**: one keyword, one control, one value to tune. Volume is volume, brightness is brightness, weather is weather. The selector word is a label for the parameter; the satellite is the value handle.
+
+A future extension would let one BLANK.md declare multiple parameters under a single blank — the user selects the parameter via the SELECTOR axis and the value via the SATELLITE axis. Same shape as today's `opencues settings _` flow but exposed to script-backed user blanks.
+
+### Provisional schema
+
+```yaml
+---
+name: system
+type: blank
+blankKeywords: system
+blankShapes: [{"pattern":"^system\\s*_$","action":"get"}, ...]
+blankParameters:
+  volume:     { step: 6,           type: numeric, clamp: [0, 100] }
+  brightness: { step: 10,          type: numeric, clamp: [0, 100] }
+  mute:       { values: [on, off], type: categorical }
+  balance:    { step: 5,           type: numeric, clamp: [-100, 100] }
+blankScript: ./system-blank.sh
+---
+```
+
+### Provisional script contract (extended)
+
+```bash
+# system-blank.sh
+$1 = get | set
+$2 = parameter name (volume / brightness / mute / balance)
+$3 = (for set) the value
+# Echo `<parameter>\t<final-value>` on stdout.
+```
+
+### Runtime changes when this lands
+
+- Selector cycler dispatcher learns to read `blankParameters:`. When the blank has parameters declared, selector-position ↑/↓ cycles parameter names; satellite-position ↑/↓ cycles the chosen parameter's vocab.
+- The "selector forwards to satellite" rule in `cycleSelectorSatellite` becomes **conditional on `!blankParameters`** — single-parameter blanks still forward, multi-parameter blanks expose the dual-axis.
+- `BlankSlot.parameter?: string` added to carry the chosen parameter through to the script call.
+- Spec adds `blankParameters:` to the blank schema. Conformance fixtures cover the two-axis cycling.
+
+### Why we're not doing this now
+
+- No real use-case in the shipped defaults today. Adding it speculatively widens the schema surface.
+- The single-parameter pattern (volume, brightness, weather, stocks, etc.) is the dominant model — covers ~100% of shipped blanks.
+- The opencues-settings blank already serves the "lots of settings, one menu" UX via the FEATURES registry. A user blank wanting the same structure can mirror that pattern when needed.
+
+When someone has a real `system` / `audio` / `display` blank that needs to group multiple controls, ship `blankParameters:` then. Until then, single-parameter is the default and the cycler's selector-forwards-to-satellite rule stays unconditional. Comments in `cycling.ts` flag this exact deferral so future-us knows where to plug in.
+
+---
+
+## Open questions for Wilfred
+
+1. After manual testing — is `blankConsumeContext: true` actually wanted on every shape-driven blank, or should it be implicit when shapes are present? Question matters because some read-only blanks (weather) might want to preserve surrounding prose differently.
+2. Should `stepValues` cycling on volume support `up` / `down` text shapes too? Today: numeric values only. If we add `up`/`down`, the script needs to translate "step direction" → current+step.
+3. Spec version bump — go to `0.3-alpha` for the breaking change, or wait until we have N migrated blanks?
+
+---
+
+*Last updated: 2026-06-14. Sitting on branch `feat/blank-shapes`. Awaiting Wilfred manual UX review.*

--- a/plan.md
+++ b/plan.md
@@ -187,6 +187,22 @@ Once volume + brightness + a few read-only blanks (weather, stocks, dictionary) 
 
 ---
 
+## Countries data source — known fragile
+
+`CountriesBlank` previously hit `https://restcountries.com/v3.1/name/<country>`. That API was **deprecated** in 2026 — it now returns 301 → `legacy.json` with an error body, and the v5 replacement requires an auth key.
+
+Quick fix shipped in PR #146: switched to `https://countries-api-836d.onrender.com/countries/name/<country>` — a community-run v2-clone with the same field shape as pre-deprecation REST Countries. Schema adapted (v2 has flatter shape: `name` is a string, `capital` is a string, `currencies`/`languages` are arrays of objects instead of keyed records).
+
+**Known limitations of the workaround**:
+
+- Hosted on Render's free tier — sleeps after ~15 min of inactivity, so the first request after a quiet period can take 30-60s (cold start). Cached for 24h per country once fetched.
+- Third-party operator. Could go down or change shape without notice.
+- No SLA, no contact for issues.
+
+**Long-term path** (separate PR): bundle a static country dataset (mledoze/countries — public-domain JSON, ~250 countries, 80+ fields each). Eliminates the network call, the upstream dependency, and the cold-start. ~1.4MB bundled (or ~80KB with trimming to just the fields the blank uses). Yearly manual refresh for stale population numbers. Trade-off: slightly bigger npm package vs zero runtime upstream risk for read-only data that doesn't change daily.
+
+Tracked here so the next contributor knows the current setup is provisional.
+
 ## Decisions made (record so we don't relitigate)
 
 1. **Shape gate is regex-based**, not LLM-based. Authors declare shapes; runtime extracts the matching value. No LLM in the routing loop = no prompt-injection blast radius widening.

--- a/plan.md
+++ b/plan.md
@@ -187,6 +187,31 @@ Once volume + brightness + a few read-only blanks (weather, stocks, dictionary) 
 
 ---
 
+## User-pack JS blanks fail to load on Bun hosts — known platform gap
+
+`isolated-vm` (the sandbox we use to run user-pack JS like `gh-issues/blank.js`) is a Node V8 native binding. Bun's JavaScriptCore can't load it — the binding's symbol layout doesn't match what Bun expects. The error surfaces as:
+
+```
+isolated-vm unavailable on this runtime: undefined symbol: _ZN2v815ValueSerializer8Delegate19HasCustomHostObjectEPNS_7IsolateE
+```
+
+Affected hosts: **opencode** + **shell** (both Bun-based).
+Unaffected hosts: Claude Code, Gemini CLI, Chrome (Node + native-messaging-host bridge).
+
+Built-in TS blanks (volume / brightness / weather / stocks / crypto / dictionary / countries / hackernews / claude-status / answer / prompt / sentinel) and shell-script blanks keep working on Bun hosts — only `impl: ./blank.js` user-pack JS is blocked.
+
+**Options for a real fix** (separate PR):
+
+1. **Vendored isolated-vm-bun** — port the C++ binding to use Bun's bun:ffi or N-API-compat layer. Real C++ work, multi-week effort.
+2. **Replace isolated-vm with `vm.Context` (Node built-in)** — give up the strong process-level isolation in exchange for cross-runtime support. Security regression vs current model.
+3. **Use Worker threads** — run user-pack JS in a Worker with restricted globals. Works on Bun (Bun has Worker), but the sandbox boundary is weaker than isolated-vm's V8 isolate.
+4. **Use a separate Node subprocess for user-pack JS dispatch** — opencode/shell spawn a small Node helper that owns the isolated-vm sandboxes. Cleanest separation but adds a process + IPC hop per invocation.
+5. **Document the gap and defer** — user-pack JS is a feature for power users; the built-in blanks cover 95% of use cases. Mark `impl:` as Node-only in the spec and document in adding-a-cue-blank.md.
+
+Recommendation: **(5) for the immediate doc sweep**, then **(4) as a small follow-up PR**. Subprocess isolation gives us cross-runtime support without compromising the security boundary. The IPC hop is ~5-10ms which is negligible compared to the network calls user-pack JS typically does (gh-issues hits api.github.com, others fetch from various APIs).
+
+Tracked here so the next contributor knows the gap is structural, not a bug.
+
 ## Countries data source — known fragile
 
 `CountriesBlank` previously hit `https://restcountries.com/v3.1/name/<country>`. That API was **deprecated** in 2026 — it now returns 301 → `legacy.json` with an error body, and the v5 replacement requires an auth key.


### PR DESCRIPTION
## Summary

- Replaces the coarse \`blankProximity:\` gate with declarative shape patterns for script-backed blanks. Misfires on prose (\`the volume was great _\` / \`i love apple pie _\` / \`the weather was nice _\`) stop hijacking the slot.
- Adds the \`<script> set <value>\` echo contract: natural-language setters actually adjust the system now (\`volume 70 _\` / \`set volume to 70 _\` / \`set brightness to 80 _\`).
- Two emission shapes based on cycle-vocab presence: selector-satellite pair for cyclable blanks (volume, brightness), one uniform gray span for read-only (weather, stocks).
- Four migrations land in this PR. Six more queued (hackernews / dictionary / crypto / countries / claude-status / others). Tracked in [\`plan.md\`](plan.md).

## Design + reasoning

Full doc: [\`docs/architecture/shape-driven-blanks.md\`](docs/architecture/shape-driven-blanks.md). Covers the three-axis model, both emission shapes, selector-satellite navigation semantics (including the atomic-pair carve-out), cycling semantics (numeric / categorical / FEATURES dispatchers), the reasoning behind each design choice, the June 2026 incident post-mortem, the deferred multi-parameter extension, code pointers, and the per-blank migration checklist.

## Highlights

- **Shape gate** replaces proximity for shape-driven blanks. Regex-based, deterministic, author-anchored. No LLM in the routing loop — same security model as before (ConfigIntent stays the only LLM-classified router, bounded to FEATURES-registry scalars).
- **\`set <value>\` script contract**: \`<script> set <value>\` applies the value, clamps/validates, echoes the post-clamp final state. Volume can clamp 200 → 100 and the buffer reflects truth.
- **Selector-satellite emission** for cyclable blanks. Selector = plain text label, satellite = gray cyclable handle. One Backspace wipes the pair (\`clearOnEdit\`). Cycler dispatchers: numeric-step (\`blankStep:\`) and categorical (\`stepValues:\`). Selector presses forward to satellite (the pair acts as one tunable thing).
- **One-span emission** for read-only blanks (no cycle vocab). Whole substitution renders as a single dimmed wipeable span. No selector-satellite split because there's nothing to cycle.
- **Atomic-pair navigation**: Ctrl+Alt+→/← treats the selector-satellite pair as one nav step (skips past the selector word). FEATURES-pairs (\`opencues settings\`) keep both stops navigable because their selector axis IS real.
- **Dim carve-out** follows the same predicate as nav: shape-driven selector renders plain (not gray) because it's a label, not a cycle target.
- **\`stepValues:\` + \`blankScript:\` compose** now (was previously short-circuited to list-only). The script owns get/set, stepValues becomes the categorical cycle vocab.
- **\`blankProximity:\` deprecation warning** in ConfigLoader for any blank that declares proximity without shapes. Hard removal queued for Phase 5.

## Migrations in this PR

| Blank | Emission | Cycle vocab | Notes |
|---|---|---|---|
| \`volume\` | selector-satellite | \`blankStep: 6\` | Direct + verbose SET both work. Cycler steps by 6. |
| \`brightness\` | selector-satellite | \`blankStep: 10\` | Mirror of volume. |
| \`weather\` | one-span gray | — | Default location (London) preserved. \`weather/forecast/temp/temperature\` aliases all map to the same blank. |
| \`stocks\` | one-span gray | — | 21 keywords (nvda/nvidia/aapl/apple/etc.). Original output format \`AAPL: \$230.50\` preserved. |

## Back-compat — explicit

Every runtime change gates on \`blankShapes:\` being present:

- **Shape-less blanks** (hackernews / dictionary / crypto / countries / claude-status / opencues-settings) continue to use the legacy proximity gate and slot-splice emission unchanged.
- **FEATURES-registry blank** (\`opencues settings _\`) keeps dual-axis selector cycling, both nav stops, both sides gray. ConfigIntent's natural-language flip (\`turn debug mode on _\`) preserved.
- **ConfigIntent's codomain** stays bounded to FEATURES-registry scalars. User blanks remain off-limits to LLM routing. Security model unchanged.
- **User BLANK.md files** at \`~/.cues/blanks/<name>/\` preserved across upgrades via the existing \"user-only fields\" mechanism in seed-configs.
- **\`SPEC_VERSION\`** NOT bumped in this PR. Spec PR queued separately after more migrations land.

Behaviour deltas users will notice (intentional):
- \`volume 70 _\` / \`set volume to 70 _\` actually set the volume (was a silent no-op).
- Prose mentions of migrated keywords decline cleanly, fluid-blank takes them.
- Copula forms (\`volume is _\`) decline, fluid-blank handles.
- One-Backspace wipes the entire substitution.

## Routing integration with fluid-blank / fluid-config

The shape gate makes BlankSource (priority 95) decline more cleanly when the input isn't a literal invocation. Fluid-blank (priority 92) picks up free-form lookups about a keyword (\`the weather was nice _\`) instead of being intercepted. ConfigIntent (priority 94) is unaffected — its codomain stays bounded to FEATURES-registry scalars; user blanks remain off-limits to LLM routing.

Net effect on routing:
- \`volume 70 _\` → volume shape matches → SET fires.
- \`the volume was great _\` → volume declines → fluid-blank takes it.
- \`turn debug mode on _\` → ConfigIntent classifies → flips registry (unchanged).
- \`capital of france _\` → fluid-blank (unchanged).
- \`set volume to 70 _\` → volume shape matches (priority 95) wins over ConfigIntent (94) by priority.

## Tests + validation

- \`pnpm -C packages/opencues-core test\` → **870/879 pass** (9 skipped, 0 fail; unchanged from master baseline).
- \`pnpm -C packages/opencues-runtime test\` → **1658/1658 pass** (added brightness SET-clamp + brightness selector-satellite tests).
- **Manual UX validation** in a real opencode session:
  - volume / brightness selector-satellite + cycling (selector forwards to satellite, ±step works)
  - weather / stocks one-span emission (whole gray block, backspace wipes)
  - prose misfire reject across all four migrated blanks
  - OPENCUES settings dual-axis preserved
  - Atomic-pair nav + selector renders as plain text for shape-driven
  - One-Backspace wipes whole substitution for both emission shapes

## Files

22 files changed, +1541/-329 lines. Net new runtime: ~200 lines. Heavy reuse of existing selector-satellite emission machinery (~95% reuse — see \`docs/architecture/shape-driven-blanks.md\` § Where this lives in code).

## Bumps

- \`@opencues/core\` 0.3.21 → 0.3.22 (\`blankShapes:\` schema field)
- \`@opencues/runtime\` 0.3.9 → 0.3.10 (shape walker + cycler dispatchers + nav/dim carve-outs + four blank migrations + deprecation warning)

## Test plan

- [x] Core unit tests pass
- [x] Runtime unit tests pass
- [x] Manual UX in a real opencode session covers all four blanks + regressions
- [x] CHANGELOG entry under Unreleased
- [x] plan.md tracks remaining migrations + deferred extensions

## Next up (not in this PR)

- Migrate crypto / dictionary / hackernews / countries / claude-status (mechanical, one BLANK.md + script edit each).
- Docs sweep (concept.md / CLAUDE.md / adding-a-cue-blank.md / glossary — all reference shape-driven-blanks.md).
- Spec PR against the open-standard repo (bumps \`SPEC_VERSION\` 0.2-alpha → 0.3-alpha).
- Final cleanup PR removing \`blankProximity:\` from the runtime after migrations land.

See plan.md for full tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)