### PR TITLE
fix(install): unblock macOS + Node 24 — isolated-vm + setup.sh BSD cp flattening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 22
       - name: Enable corepack (pnpm)
         run: corepack enable
       - name: pnpm install
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 22
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -167,7 +167,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 22
       - name: Enable corepack (pnpm)
         run: corepack enable
       - name: pnpm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — macOS / Node 24 install blockers: isolated-vm Node-24 support + setup.sh BSD `cp` flattening
+
+Two unrelated blockers stacked on a clean `pnpm exec opencues install claude-code` on macOS + Node 24. Both surfaced as install-time failures rather than silent runtime drift (the `validateFork` boot-smoke probe and the native-module probe both fired loudly), but together they made a fresh install impossible on the platform.
+
+**1. `isolated-vm` couldn't build on Node 24.** The dependency was pinned `^5.0.4`. isolated-vm 5.0.4's `binding.gyp` compiles with `-std=c++17`, but Node 24's bundled V8 headers (`cppgc/.../conditional-stack-allocated.h`) use C++20 `concept` / `requires`, so the node-gyp fallback failed with `unknown type name 'concept'`. Forcing C++20 then surfaced deeper V8 API removals 5.0.4 doesn't track (`CopyablePersistentTraits`, `ObjectTemplate::SetAccessor`, non-virtual `PostTask`) — i.e. 5.0.4 is fundamentally Node-24-incompatible, not just a compiler-flag issue. Bumped to `^6.1.2` (engines `node >=22`), which ships a prebuilt darwin-arm64 binary for the Node 24 ABI and loads via `node-gyp-build` with no local toolchain. The JS API surface the runtime uses (`Isolate` / `createContextSync` / `Reference` / `ExternalCopy` / `compileScriptSync` / `derefInto`) is unchanged across the 5→6 major (that bump was purely engine support), so `node-loader.ts` needed no code change. **Note:** this raises the runtime's effective Node floor to 22 (no single isolated-vm version spans Node 18–25; Node 18 and 20 are both EOL as of June 2026).
+
+**2. `setup.sh`'s core copy flattened `dist/sources/` on macOS.** `setup.sh` § 5 copies every `dist/*/` subdir into the installed fork's `@opencues/core/`. The `for sub in "$CUES_CORE"/dist/*/` glob yields paths with a **trailing slash** (`.../dist/sources/`), and `cp -r src/ dest/` diverges by platform: GNU cp (Linux) copies the directory (`core/sources/`), but BSD cp (macOS) copies the directory *contents* into `core/`, flattening `dist/sources/*.js` to `core/*.js`. The installed `core/index.js`'s `require("./sources/config-source")` then 404'd, the boot-smoke probe failed, and install aborted. This is the same BSD/GNU portability class the repo already wraps for `sed -i` / `stat -c` (root CLAUDE.md § Cross-platform shell scripts). Fix: strip the glob's trailing slash with `${sub%/}` so `cp -r` copies the directory on both platforms. CI runs on Linux (GNU cp), so this was invisible to the existing `check-cc-bundle-integrity.sh` gate — macOS-only.
+
+Bumps:
+- `@opencues/runtime` 0.3.9 → 0.3.10.
+- `@opencues/claude-code` 0.2.0 → 0.2.1.
+
 ### Fix — Word-cue dispatch: in-progress-word gate no longer fires on unknown cursor (regression from #136)
 
 PR #136 (`perf(core): skip in-progress trailing word from word-cue dispatch`) introduced a `findInProgressTrailingWord` gate that drops the trailing word from word-cue dispatch when the user is actively typing at end-of-buffer. The gate's three checks: (1) buffer non-empty, (2) buffer doesn't end in whitespace, (3) cursor is at end-of-buffer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,12 @@ Two unrelated blockers stacked on a clean `pnpm exec opencues install claude-cod
 
 Bumps:
 - `@opencues/runtime` 0.3.9 → 0.3.10.
-- `@opencues/claude-code` 0.2.0 → 0.2.1.
 - `opencues` (CLI) 0.2.2 → 0.2.3.
+- `@opencues/claude-code` 0.2.0 → 0.2.1.
+- `@opencues/opencode` 0.2.0 → 0.2.1.
+- `@opencues/gemini-cli` 0.2.0 → 0.2.1.
+- `@opencues/shell` 0.2.0 → 0.2.1.
+- `@opencues/chrome` 0.2.19 → 0.2.20 (manifest.json bumped in lockstep).
 
 ### Fix — Word-cue dispatch: in-progress-word gate no longer fires on unknown cursor (regression from #136)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ Two unrelated blockers stacked on a clean `pnpm exec opencues install claude-cod
 
 **2. `setup.sh`'s core copy flattened `dist/sources/` on macOS.** `setup.sh` § 5 copies every `dist/*/` subdir into the installed fork's `@opencues/core/`. The `for sub in "$CUES_CORE"/dist/*/` glob yields paths with a **trailing slash** (`.../dist/sources/`), and `cp -r src/ dest/` diverges by platform: GNU cp (Linux) copies the directory (`core/sources/`), but BSD cp (macOS) copies the directory *contents* into `core/`, flattening `dist/sources/*.js` to `core/*.js`. The installed `core/index.js`'s `require("./sources/config-source")` then 404'd, the boot-smoke probe failed, and install aborted. This is the same BSD/GNU portability class the repo already wraps for `sed -i` / `stat -c` (root CLAUDE.md § Cross-platform shell scripts). Fix: strip the glob's trailing slash with `${sub%/}` so `cp -r` copies the directory on both platforms. CI runs on Linux (GNU cp), so this was invisible to the existing `check-cc-bundle-integrity.sh` gate — macOS-only.
 
+**Node floor raised to 22.** Because no single isolated-vm version spans Node 18–25 and Node 18/20 are both EOL as of June 2026, the `engines.node` constraint is moved from `>=18` to `>=22` across the workspace (root, CLI, and all integrations), with an explicit `engines.node: ">=22"` added to `@opencues/runtime` where the native constraint originates. Bun-based hosts (opencode, shell) run their host process on Bun, not Node; the floor governs the Node-based install/CLI tooling and the runtime's `isolated-vm` JS-user-blank sandbox (which already degrades gracefully when the binding is absent).
+
 Bumps:
 - `@opencues/runtime` 0.3.9 → 0.3.10.
 - `@opencues/claude-code` 0.2.0 → 0.2.1.
+- `opencues` (CLI) 0.2.2 → 0.2.3.
 
 ### Fix — Word-cue dispatch: in-progress-word gate no longer fires on unknown cursor (regression from #136)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -611,15 +611,15 @@ done
 |---|---|---|---|
 | `SPEC.md` (open-standard) | `cues-spec` | 0.2 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
-| `packages/opencues-core/` | `@opencues/core` | 0.3.5 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.2.8 | private |
-| `packages/opencues-cli/` | `opencues` (real CLI) | 0.2.0 | private |
+| `packages/opencues-core/` | `@opencues/core` | 0.3.21 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.3.10 | private |
+| `packages/opencues-cli/` | `opencues` (real CLI) | 0.2.3 | private |
 | `packages/opencues-park/` | `opencues` (placeholder) | 0.0.1 | **PUBLISHED on npm** |
-| `integrations/claude-code/` | `@opencues/claude-code` | 0.2.0 | private |
-| `integrations/opencode/` | `@opencues/opencode` | 0.2.0 | private |
-| `integrations/chrome/` | `@opencues/chrome` | 0.2.3 | private |
-| `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.2.0 | private |
-| `integrations/shell/` | `@opencues/shell` | 0.2.0 | private |
+| `integrations/claude-code/` | `@opencues/claude-code` | 0.2.1 | private |
+| `integrations/opencode/` | `@opencues/opencode` | 0.2.1 | private |
+| `integrations/chrome/` | `@opencues/chrome` | 0.2.20 | private |
+| `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.2.1 | private |
+| `integrations/shell/` | `@opencues/shell` | 0.2.1 | private |
 
 Two packages share the bare `opencues` name — the real CLI at `packages/opencues-cli/` (still private) and the parking placeholder at `packages/opencues-park/` (published as v0.0.1 to the public npm registry, owned by the `opencues` org via the `developers` team). Launch handover is described in the npm-name pre-launch checklist above; the real CLI's v0.1.0 cleanly supersedes the placeholder's v0.0.1 on first publish.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -29,7 +29,7 @@ After install, launch with `opencues run <host>` (except Chrome, which you load 
 
 ### What do I need installed first?
 
-Universal: Node.js 18+, [pnpm](https://pnpm.io), a Groq API key (or any OpenAI-compatible provider).
+Universal: Node.js 22+, [pnpm](https://pnpm.io), a Groq API key (or any OpenAI-compatible provider).
 
 Per-integration (the HOST's requirements, not OpenCues's):
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The three file formats (Cues / Blanks / Auditors) are open standards — designe
 
 ### 1. System prerequisites (one-time per machine)
 
-OpenCues needs **Node.js 18+** and **pnpm 8+**. The installers are bash +
+OpenCues needs **Node.js 22+** and **pnpm 8+**. The installers are bash +
 POSIX coreutils, so platform support is:
 
 - **macOS** (Intel + Apple Silicon) — supported natively.
@@ -76,12 +76,12 @@ POSIX coreutils, so platform support is:
   refuses up front on native Windows rather than failing mid-install.
 
 Pick your platform and run the matching block. Each ends by verifying
-`node --version` (v18+) and `pnpm --version` (8+).
+`node --version` (v22+) and `pnpm --version` (8+).
 
 **macOS** — default shell is zsh, so the API-key + alias steps below write to `~/.zshrc`:
 
 ```bash
-brew install node            # Node.js 18+ — or: brew install fnm && fnm install --lts
+brew install node            # Node.js 22+ — or: brew install fnm && fnm install --lts
 corepack enable pnpm         # pnpm 8+ — ships with Node 16+; or: npm install -g pnpm
 
 node --version && pnpm --version
@@ -91,7 +91,7 @@ node --version && pnpm --version
 
 ```bash
 curl -fsSL https://fnm.vercel.app/install | bash && exec $SHELL -l
-fnm install --lts && fnm use lts-latest    # Node.js 18+
+fnm install --lts && fnm use lts-latest    # Node.js 22+
 # OR (Debian/Ubuntu, if new enough): sudo apt install nodejs npm
 
 corepack enable pnpm         # pnpm 8+ — or: npm install -g pnpm

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -4,7 +4,7 @@ Get OpenCues running in Claude Code in under 5 minutes.
 
 ## 1. Prerequisites
 
-- Node.js 18+ (`node --version`)
+- Node.js 22+ (`node --version`)
 - [pnpm](https://pnpm.io/installation) (`corepack enable pnpm` works)
 - Claude Code installed (`which claude`)
 - A free [Groq API key](https://console.groq.com)

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@ Per-host installation, what each install does, where things land, and how to rec
 
 ## Prerequisites
 
-- **Node.js 18+** (`node --version`)
+- **Node.js 22+** (`node --version`)
 - **pnpm 8+** (`pnpm --version`; `corepack enable pnpm` ships it with Node 16+)
 - An **LLM provider API key.** Cerebras is the recommended default
   ([cloud.cerebras.ai/platform/](https://cloud.cerebras.ai/platform/) → *Generate API Key*); Groq, OpenAI, Anthropic, Gemini, OpenRouter,
@@ -60,7 +60,7 @@ brew install bash tmux brightness  # bash 4+ optional but recommended
 | `claude-code` | Claude Code 2.1.110+ on PATH (the installer reinstalls a pinned copy locally; the on-PATH check just confirms you have the auth set up) | `claude --version` |
 | `opencode`    | [bun](https://bun.sh/) (OpenCode is a bun app — the installer clones a fork itself) | `bun --version` |
 | `chrome`      | Chrome 121+ | `chrome://version` |
-| `gemini-cli`  | Node 18+ (installer clones a Gemini CLI 0.41.x fork itself) | `node --version` |
+| `gemini-cli`  | Node 22+ (installer clones a Gemini CLI 0.41.x fork itself) | `node --version` |
 
 A Claude-Code-only user never needs bun. An OpenCode user needs bun because OpenCode itself is a bun app, not because OpenCues requires it.
 

--- a/docs/install/dependencies.md
+++ b/docs/install/dependencies.md
@@ -15,7 +15,7 @@ prompted before being touched.**
 ```
                           ┌─────────────────────────────────┐
    pre-install gate       │ package.json "os" + "engines"   │  blocks Windows native,
-                          │ (npm-native, hard refuse)       │  Node <18 before any code runs
+                          │ (npm-native, hard refuse)       │  Node <22 before any code runs
                           └─────────────────────────────────┘
                                        │
                                        ▼

--- a/docs/install/walkthrough.md
+++ b/docs/install/walkthrough.md
@@ -20,7 +20,7 @@ npm install -g opencues
 ```
 
 What npm does at install time:
-- Checks `engines.node >=18` — refuses on older Node.
+- Checks `engines.node >=22` — refuses on older Node.
 - Checks `os` is `darwin` or `linux` — refuses on Windows native (use WSL).
 - Drops the `opencues` binary into `$(npm prefix -g)/bin/`.
 

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -11,7 +11,7 @@
     "opencues-chrome": "./bin/install.cjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "os": [
     "darwin",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/claude-code/package.json
+++ b/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/claude-code",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "OpenCues for Claude Code — patches Claude Code's CLI via tweakcc to add real-time word alternatives, blanks, and cue-controls.",
   "compatibility": {

--- a/integrations/claude-code/package.json
+++ b/integrations/claude-code/package.json
@@ -10,7 +10,7 @@
     "opencues-claude-code": "./bin/install.cjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "os": [
     "darwin",

--- a/integrations/claude-code/patches/setup.sh
+++ b/integrations/claude-code/patches/setup.sh
@@ -117,12 +117,12 @@ trap on_error ERR
 
 # ─── prerequisites ────────────────────────────────────────────────────
 if ! command -v node &>/dev/null; then
-  echo "Error: Node.js is not installed. Please install Node.js 18 or later." >&4
+  echo "Error: Node.js is not installed. Please install Node.js 22 or later." >&4
   exit 1
 fi
 NODE_MAJOR=$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
-if [ "$NODE_MAJOR" -lt 18 ]; then
-  echo "Error: Node.js 18+ required (found $(node --version))." >&4
+if [ "$NODE_MAJOR" -lt 22 ]; then
+  echo "Error: Node.js 22+ required (found $(node --version))." >&4
   exit 1
 fi
 

--- a/integrations/claude-code/patches/setup.sh
+++ b/integrations/claude-code/patches/setup.sh
@@ -376,9 +376,15 @@ mkdir -p "$OC_NM_DIR/core"
 # structurally safe.
 cp "$CUES_CORE"/dist/*.js "$CUES_CORE"/dist/*.d.ts "$OC_NM_DIR/core/" 2>/dev/null || true
 [ -f "$CUES_CORE/node-http-adapter.js" ] && cp "$CUES_CORE/node-http-adapter.js" "$OC_NM_DIR/core/"
+# NOTE: strip the trailing slash the `*/` glob leaves on $sub. With the
+# trailing slash, BSD cp (macOS) copies the directory *contents* into
+# core/ — flattening dist/sources/*.js to core/*.js so `require("./sources/
+# config-source")` 404s — whereas GNU cp (Linux) copies the dir itself.
+# `${sub%/}` makes `cp -r` copy the directory on both. (BSD/GNU compat,
+# same class as the sedi/stat_size wrappers — see root CLAUDE.md.)
 for sub in "$CUES_CORE"/dist/*/; do
   [ -d "$sub" ] || continue
-  cp -r "$sub" "$OC_NM_DIR/core/"
+  cp -r "${sub%/}" "$OC_NM_DIR/core/"
 done
 node -e "
 const pkg = JSON.parse(require('fs').readFileSync('$CUES_CORE/package.json', 'utf8'));

--- a/integrations/gemini-cli/package.json
+++ b/integrations/gemini-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/gemini-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "OpenCues for Gemini CLI — patches a Gemini CLI fork to add real-time word alternatives, blanks, and cue-controls.",
   "compatibility": {

--- a/integrations/gemini-cli/package.json
+++ b/integrations/gemini-cli/package.json
@@ -10,7 +10,7 @@
     "opencues-gemini-cli": "./bin/install.cjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "os": [
     "darwin",

--- a/integrations/gemini-cli/patches/setup.sh
+++ b/integrations/gemini-cli/patches/setup.sh
@@ -473,12 +473,12 @@ npm_install_fork() {
 
 # ─── prerequisites ────────────────────────────────────────────────────
 if ! command -v node &>/dev/null; then
-  echo "Error: Node.js is not installed. Gemini CLI requires Node 18+." >&2
+  echo "Error: Node.js is not installed. Gemini CLI requires Node 22+." >&2
   exit 1
 fi
 NODE_MAJOR=$(node -e "process.stdout.write(String(process.versions.node.split('.')[0]))")
-if [ "$NODE_MAJOR" -lt 18 ]; then
-  echo "Error: Node.js 18+ required (found $(node --version))." >&2
+if [ "$NODE_MAJOR" -lt 22 ]; then
+  echo "Error: Node.js 22+ required (found $(node --version))." >&2
   exit 1
 fi
 

--- a/integrations/opencode/package.json
+++ b/integrations/opencode/package.json
@@ -10,7 +10,7 @@
     "opencues-opencode": "./bin/install.cjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "os": [
     "darwin",

--- a/integrations/opencode/package.json
+++ b/integrations/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/opencode",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "OpenCues for OpenCode — patches an OpenCode TUI fork to add real-time word alternatives, blanks, and cue-controls.",
   "compatibility": {

--- a/integrations/shell/package.json
+++ b/integrations/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/shell",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "OpenCues for the terminal — `shell` wraps your interactive shell in a tmux session with an Alt+Shift+↑ input box that hosts the OpenCues TUI. Brings full cues, blanks, cycling, agent-rewrite to any shell.",
   "type": "module",

--- a/integrations/shell/package.json
+++ b/integrations/shell/package.json
@@ -10,7 +10,7 @@
     "oc-install-shell-integration": "./bin/oc-install-shell-integration"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "os": [
     "darwin",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "os": [
     "darwin",

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,13 +1,13 @@
 {
   "name": "opencues",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {
     "opencues": "./bin/cli.cjs"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "os": [
     "darwin",

--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -69,14 +69,14 @@ module.exports = async function doctor(argv, ctx) {
   {
     const s = section('Platform tooling', 'developer tools + shells the installers/runtime touch');
 
-    // Node version (declared in package.json engines as >=18).
+    // Node version (declared in package.json engines as >=22).
     const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
-    s.ok(`node ${process.versions.node}`, nodeMajor >= 18);
-    if (nodeMajor < 18) {
+    s.ok(`node ${process.versions.node}`, nodeMajor >= 22);
+    if (nodeMajor < 22) {
       findings.push({
         sev: 'warn',
-        msg: `Node ${process.versions.node} — opencues requires >=18`,
-        fix: 'install Node 18+ via fnm / nvm / brew / apt',
+        msg: `Node ${process.versions.node} — opencues requires >=22`,
+        fix: 'install Node 22+ via fnm / nvm / brew / apt',
       });
     }
 

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",
@@ -25,7 +25,7 @@
     "@opencues/core": "workspace:*",
     "acorn": "^8.12.1",
     "acorn-walk": "^8.3.3",
-    "isolated-vm": "^5.0.4"
+    "isolated-vm": "^6.1.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -5,6 +5,9 @@
   "private": true,
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "engines": {
+    "node": ">=22"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/opencues/opencues.git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,8 +167,8 @@ importers:
         specifier: ^8.3.3
         version: 8.3.5
       isolated-vm:
-        specifier: ^5.0.4
-        version: 5.0.4
+        specifier: ^6.1.2
+        version: 6.1.2
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1078,9 +1078,6 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   baseline-browser-mapping@2.10.34:
     resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
     engines: {node: '>=6.0.0'}
@@ -1093,9 +1090,6 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
-
   bmp-ts@1.0.9:
     resolution: {integrity: sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw==}
 
@@ -1106,9 +1100,6 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bun-ffi-structs@0.1.2:
     resolution: {integrity: sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==}
@@ -1160,9 +1151,6 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1210,21 +1198,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
-
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
 
   diff@9.0.0:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
@@ -1242,9 +1218,6 @@ packages:
 
   electron-to-chromium@1.5.369:
     resolution: {integrity: sha512-XM22K9FNaaCOvMMrBn1caIc8v0g6+pKt660ZbfQqUZvfil0hEzr8ZoiY7VcSLGM3L/x3rz5PqZrk+bKOOmVM9w==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1299,10 +1272,6 @@ packages:
   exif-parser@0.1.12:
     resolution: {integrity: sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw==}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1353,9 +1322,6 @@ packages:
     resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
     engines: {node: '>= 12.20'}
 
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -1386,9 +1352,6 @@ packages:
 
   gifwrap@0.10.1:
     resolution: {integrity: sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
@@ -1455,12 +1418,6 @@ packages:
   immutable@5.1.6:
     resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
 
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
@@ -1468,9 +1425,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
-  isolated-vm@5.0.4:
-    resolution: {integrity: sha512-RYUf/JC4ldWz/oi2BVs8a1XIprQ71q6eQPBwySaF5Apu0KMyf2gIpElbCyPh2OEmRT+FYw1GOKSdkv7jw2KLxw==}
-    engines: {node: '>=18.0.0'}
+  isolated-vm@6.1.2:
+    resolution: {integrity: sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==}
+    engines: {node: '>=22.0.0'}
 
   jimp@1.6.0:
     resolution: {integrity: sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==}
@@ -1555,10 +1512,6 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
   minimatch@8.0.7:
     resolution: {integrity: sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1574,9 +1527,6 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1584,13 +1534,6 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
-  node-abi@3.92.0:
-    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
-    engines: {node: '>=10'}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -1605,6 +1548,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-releases@2.0.47:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
@@ -1624,9 +1571,6 @@ packages:
 
   omggif@1.0.10:
     resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   opener@1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
@@ -1726,12 +1670,6 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
 
@@ -1759,9 +1697,6 @@ packages:
   prosemirror-view@1.41.8:
     resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
 
-  pump@3.0.4:
-    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1769,10 +1704,6 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   react-dom@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
@@ -1782,10 +1713,6 @@ packages:
   react@17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
     engines: {node: '>=0.10.0'}
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1816,9 +1743,6 @@ packages:
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -1838,11 +1762,6 @@ packages:
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
-    hasBin: true
-
-  semver@7.8.3:
-    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
-    engines: {node: '>=10'}
     hasBin: true
 
   seroval-plugins@1.3.3:
@@ -1877,12 +1796,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
   simple-xml-to-json@1.2.7:
     resolution: {integrity: sha512-mz9VXphOxQWX3eQ/uXCtm6upltoN0DLx8Zb5T4TFC4FHB7S9FDPGre8CfLWqPWQQH/GrQYd2AXhhVM5LDpYx6Q==}
     engines: {node: '>=20.12.2'}
@@ -1904,13 +1817,6 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-
   strtok3@10.3.5:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
@@ -1925,13 +1831,6 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
 
   three@0.177.0:
     resolution: {integrity: sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==}
@@ -1976,9 +1875,6 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
-
   turbo@2.9.16:
     resolution: {integrity: sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==}
     hasBin: true
@@ -2021,9 +1917,6 @@ packages:
 
   utif2@4.1.0:
     resolution: {integrity: sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==}
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@6.4.3:
     resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
@@ -2152,9 +2045,6 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -3151,8 +3041,6 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  base64-js@1.5.1: {}
-
   baseline-browser-mapping@2.10.34: {}
 
   basic-auth@2.0.1:
@@ -3162,12 +3050,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
 
   bmp-ts@1.0.9: {}
 
@@ -3182,11 +3064,6 @@ snapshots:
       electron-to-chromium: 1.5.369
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   bun-ffi-structs@0.1.2(typescript@5.8.2):
     dependencies:
@@ -3237,8 +3114,6 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chownr@1.1.4: {}
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3281,15 +3156,7 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
-  deep-extend@0.6.0: {}
-
   delayed-stream@1.0.0: {}
-
-  detect-libc@2.1.2: {}
 
   diff@9.0.0: {}
 
@@ -3310,10 +3177,6 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.369: {}
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   entities@6.0.1: {}
 
@@ -3379,8 +3242,6 @@ snapshots:
 
   exif-parser@0.1.12: {}
 
-  expand-template@2.0.3: {}
-
   expect-type@1.3.0: {}
 
   fbjs-css-vars@1.0.2: {}
@@ -3436,8 +3297,6 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
 
-  fs-constants@1.0.0: {}
-
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -3472,8 +3331,6 @@ snapshots:
     dependencies:
       image-q: 4.0.0
       omggif: 1.0.10
-
-  github-from-package@0.0.0: {}
 
   glob@9.3.5:
     dependencies:
@@ -3553,19 +3410,15 @@ snapshots:
 
   immutable@5.1.6: {}
 
-  inherits@2.0.4: {}
-
-  ini@1.3.8: {}
-
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.4
 
   is-potential-custom-element-name@1.0.1: {}
 
-  isolated-vm@5.0.4:
+  isolated-vm@6.1.2:
     dependencies:
-      prebuild-install: 7.1.3
+      node-gyp-build: 4.8.4
 
   jimp@1.6.0:
     dependencies:
@@ -3672,8 +3525,6 @@ snapshots:
 
   mime@3.0.0: {}
 
-  mimic-response@3.1.0: {}
-
   minimatch@8.0.7:
     dependencies:
       brace-expansion: 2.1.1
@@ -3684,23 +3535,17 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mkdirp-classic@0.5.3: {}
-
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
-
-  napi-build-utils@2.0.0: {}
-
-  node-abi@3.92.0:
-    dependencies:
-      semver: 7.8.3
 
   node-domexception@1.0.0: {}
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4: {}
 
   node-releases@2.0.47: {}
 
@@ -3711,10 +3556,6 @@ snapshots:
   obug@2.1.2: {}
 
   omggif@1.0.10: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   opener@1.5.2: {}
 
@@ -3802,21 +3643,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.92.0
-      pump: 3.0.4
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
-
   promise@7.3.1:
     dependencies:
       asap: 2.0.6
@@ -3863,23 +3689,11 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
-  pump@3.0.4:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
-
   punycode@2.3.1: {}
 
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.1
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
 
   react-dom@17.0.2(react@17.0.2):
     dependencies:
@@ -3892,12 +3706,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
 
   require-from-string@2.0.2: {}
 
@@ -3949,8 +3757,6 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
-  safe-buffer@5.2.1: {}
-
   safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
@@ -3967,8 +3773,6 @@ snapshots:
   secure-compare@3.0.1: {}
 
   semver@6.3.1: {}
-
-  semver@7.8.3: {}
 
   seroval-plugins@1.3.3(seroval@1.5.4):
     dependencies:
@@ -4008,14 +3812,6 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
   simple-xml-to-json@1.2.7: {}
 
   solid-js@1.9.10:
@@ -4033,12 +3829,6 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  strip-json-comments@2.0.1: {}
-
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
@@ -4050,21 +3840,6 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
-
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.2.0
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
 
   three@0.177.0:
     optional: true
@@ -4104,10 +3879,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.1.2
-
   turbo@2.9.16:
     optionalDependencies:
       '@turbo/darwin-64': 2.9.16
@@ -4144,8 +3915,6 @@ snapshots:
   utif2@4.1.0:
     dependencies:
       pako: 1.0.11
-
-  util-deprecate@1.0.2: {}
 
   vite@6.4.3(@types/node@22.19.20):
     dependencies:
@@ -4224,8 +3993,6 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
-
-  wrappy@1.0.2: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/scripts/check-cc-bundle-integrity.sh
+++ b/scripts/check-cc-bundle-integrity.sh
@@ -78,9 +78,13 @@ mkdir -p "$OC_NM_DIR/core" "$OC_NM_DIR/runtime/dist"
 # bug class returns and this gate catches it.
 cp "$CUES_CORE"/dist/*.js "$CUES_CORE"/dist/*.d.ts "$OC_NM_DIR/core/" 2>/dev/null || true
 [ -f "$CUES_CORE/node-http-adapter.js" ] && cp "$CUES_CORE/node-http-adapter.js" "$OC_NM_DIR/core/"
+# `${sub%/}` strips the trailing slash the `*/` glob leaves — without it
+# BSD cp (macOS) copies the directory *contents* into core/ (flattening
+# sources/ → core/*.js), diverging from GNU cp. Mirrors the same fix in
+# setup.sh § 5.
 for sub in "$CUES_CORE"/dist/*/; do
   [ -d "$sub" ] || continue
-  cp -r "$sub" "$OC_NM_DIR/core/"
+  cp -r "${sub%/}" "$OC_NM_DIR/core/"
 done
 
 # runtime: full recursive dist mirror, then point package.json's main


### PR DESCRIPTION
## Problem

A clean `pnpm exec opencues install claude-code` on **macOS + Node 24** hits two unrelated blockers in sequence. Both fail loudly at install time (good — no silent runtime drift), but together they make a fresh install impossible on the platform.

### 1. `isolated-vm` can't build on Node 24

Pinned `^5.0.4`. isolated-vm 5.0.4's `binding.gyp` compiles with `-std=c++17`, but Node 24's bundled V8 headers (`cppgc/.../conditional-stack-allocated.h`) use C++20 `concept`/`requires`:

```
error: unknown type name 'concept'
```

Forcing C++20 just surfaces deeper V8 API removals 5.0.4 doesn't track (`CopyablePersistentTraits`, `ObjectTemplate::SetAccessor`, non-virtual `PostTask`) — 5.0.4 is fundamentally Node-24-incompatible, not a flag issue.

**Fix:** bump to `^6.1.2`. Ships a prebuilt darwin-arm64 binary for the Node 24 ABI; loads via `node-gyp-build` with no local toolchain. The JS API the runtime uses (`Isolate`/`createContextSync`/`Reference`/`ExternalCopy`/`compileScriptSync`/`derefInto`) is unchanged across the 5→6 major (that bump was purely engine support) — `node-loader.ts` needed no change. **All 63 user-blank tests pass.**

### 2. `setup.sh` flattens `dist/sources/` on macOS

`setup.sh` § 5 copies every `dist/*/` subdir into the fork's `@opencues/core/`. The `*/` glob leaves a **trailing slash** (`.../dist/sources/`), and `cp -r src/ dest/` diverges by platform:

| | trailing-slash `cp -r src/ dest/` |
|---|---|
| GNU cp (Linux) | copies the dir → `core/sources/` ✓ |
| BSD cp (macOS) | copies dir *contents* → `core/*.js` (flattened) ✗ |

So `core/index.js`'s `require("./sources/config-source")` 404'd, the `validateFork` boot-smoke probe failed, and install aborted. Same BSD/GNU class the repo already wraps for `sed -i` / `stat -c` (root CLAUDE.md § Cross-platform shell scripts). CI runs on Linux, so the existing `check-cc-bundle-integrity.sh` gate never saw it — **macOS-only**.

**Fix:** strip the glob's trailing slash with `${sub%/}` so `cp -r` copies the directory on both platforms. Mirrored the identical fix into `scripts/check-cc-bundle-integrity.sh`, which deliberately clones § 5's copy logic (its own comment mandates parity) and was therefore failing on macOS for the same reason.

### Node floor → 22

isolated-vm `^6.1.2` requires Node ≥22, and no single isolated-vm version spans Node 18–25. Node 18 and 20 are both EOL as of June 2026, so this PR moves the floor explicitly: `engines.node` `>=18` → `>=22` across root + CLI + every integration, plus an explicit `engines.node: ">=22"` on `@opencues/runtime` where the native constraint originates. Bun-based hosts (opencode, shell) run their host process on Bun, not Node; the floor governs the Node install/CLI tooling and the runtime's isolated-vm JS-user-blank sandbox (which already degrades gracefully when the binding is absent).

## Verification

- `pnpm exec opencues install claude-code` → `✓ installed + validated` on darwin-arm64 / Node 24.10.
- Installed fork now nests `core/sources/` + `core/providers/` correctly; `boot.js` require smoke passes.
- `bash scripts/check-cc-bundle-integrity.sh` → exit 0 (was failing pre-fix on macOS).
- `bash scripts/lint-shell-portability.sh`, `scripts/check-runtime-loads-on-bun.sh`, `scripts/lint-version-bump.sh` → all green.
- 63/63 runtime user-blank tests pass against isolated-vm 6.1.2.
- `pnpm install` clean under the new floor (no `engine-strict` configured; dev env is Node 24.10).

## Bumps

- `@opencues/runtime` 0.3.9 → 0.3.10
- `@opencues/claude-code` 0.2.0 → 0.2.1
- `opencues` (CLI) 0.2.2 → 0.2.3
- CHANGELOG.md updated

The large `pnpm-lock.yaml` delta is just isolated-vm 6.x's simpler dep tree (drops `prebuild-install` for `node-gyp-build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)