### PR TITLE
fix(core+runtime+cli): write resolved defaultModel on provider cycle, not the 'default' sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — provider-cycle resets sibling model to the resolved `defaultModel`, not the legacy `default` sentinel
+
+When the user flipped a bucket provider without naming a model — either via the ConfigIntent natural-language path (`switch model to cerebras _`) or via the cycling satellite (Ctrl+Alt+↑ on `blanks-llm-provider`) — the apply path wrote the literal string `default` to the sibling `<bucket>-llm-model` scalar. That kept the (provider, model) pair valid at dispatch time (the runtime treats `default` as a fall-through sentinel) but tripped doctor's "inert sentinel" warning and confused users reading OPENCUES.md ("what is `default`? why is it stuck?").
+
+The apply path now writes the **resolved defaultModel for the new provider** — explicit, self-explanatory, no sentinel concept on the surface. Two code sites converged:
+
+- `packages/opencues-core/src/sources/config-intent-source.ts:981` — ConfigIntent's natural-language flip path.
+- `packages/opencues-runtime/src/modules/cycling.ts:545,568` — satellite-cycle pair-invariant.
+
+Both look up the provider adapter via `getProvider(verdict.provider)` and write `adapter.defaultModel` directly. When the cycled-to value is the `inherit` meta-provider (no adapter), both fall back to writing `'default'` — semantics match (both mean "fall through to global `llm-model:`").
+
+The one semantic difference vs the old behaviour: if a user later hand-edits the global `llm-model:` to a different value, the per-bucket scalar no longer cascades — each bucket is independent once cycled. This is the expected mental model for most users (the bucket they explicitly flipped shouldn't silently change when they edit the global later); the sentinel was clever-but-wrong UX.
+
+**Self-heal for existing files:** `packages/opencues-cli/src/commands/seed-configs.cjs` gained a new step (§ 3.2) that rewrites any pre-existing `<bucket>-llm-model: default` line to the bucket's effective-provider defaultModel on the next `opencues install`. Idempotent; skips when no provider is resolvable. So existing users get the clean state without having to hand-edit OPENCUES.md.
+
+**Test updates:**
+- `packages/opencues-runtime/src/modules/llm-config-cycling.scenarios.test.ts` — 4 scenarios + the full-cycle invariant updated to expect `getProvider(provider)?.defaultModel ?? 'default'` (the `?? 'default'` matches the `inherit` carve-out).
+- `packages/opencues-core/src/sources/config-intent-source.test.ts` — `getCues provider hit (no model)` no longer expects the literal `default`; checks the second apply call's model value matches the new provider's known shape (e.g. `^claude-` for anthropic).
+
+All 10 cycling scenarios green, 57/57 config-intent-source tests green, 1671/1671 runtime tests green, full pre-pr gates green.
+
+Bumps:
+- `@opencues/core` 0.3.23 → 0.3.24.
+- `@opencues/runtime` 0.3.13 → 0.3.14.
+- `opencues` (CLI) 0.2.4 → 0.2.5.
+
 ### Fix — `opencues doctor` false-positives on volume / brightness; `sandbox: off` now recognized as the F9 acknowledgement
 
 Two related cleanups to the scripted-blank trust check in `opencues doctor`.

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/seed-configs.cjs
+++ b/packages/opencues-cli/src/commands/seed-configs.cjs
@@ -433,6 +433,63 @@ module.exports = function seedConfigs(argv, ctx) {
     }
   }
 
+  // ── 3.2 HEAL — rewrite legacy `*-llm-model: default` sentinel ──
+  //
+  // Up to PR #150 the apply path (ConfigIntent + cycling.ts) wrote the
+  // literal `default` sentinel to `<bucket>-llm-model` when the user
+  // changed provider without naming a model. It worked (runtime treated
+  // the sentinel as "fall through to global llm-model") but tripped
+  // doctor's "inert sentinel" warning and confused users reading
+  // OPENCUES.md. The apply path now writes the resolved defaultModel for
+  // the bucket's current provider; this heal updates any existing line
+  // in place so users don't have to wait for the next ConfigIntent flip.
+  //
+  // Each bucket's sentinel is rewritten to the bucket's current provider
+  // (in the SAME file) defaultModel. If the bucket has no provider
+  // scalar set, the global llm-provider serves; if neither is set, the
+  // line is left alone (no resolvable adapter to grab a name from).
+  if (settingsTarget && fs.existsSync(settingsTarget) && fs.statSync(settingsTarget).size > 0) {
+    const text = fs.readFileSync(settingsTarget, 'utf8');
+    // Lazy-require: the registry is bundled at install time. Best-effort
+    // — if @opencues/core can't be required (e.g. running from a non-
+    // workspace install), skip the heal silently.
+    // @opencues/core isn't a declared CLI dep — its symbols are reached
+    // either via host-side hoist (when installed from a fork) or via the
+    // workspace path (when running `opencues seed-configs` from a clone).
+    // Try the bare specifier first, fall through to the workspace path.
+    let getProvider;
+    try { ({ getProvider } = require('@opencues/core')); }
+    catch {
+      try { ({ getProvider } = require(path.join(ctx.REPO_ROOT, 'packages/opencues-core'))); }
+      catch { getProvider = null; }
+    }
+    if (getProvider) {
+      // Snapshot provider scalars currently in the file so we can compute
+      // each bucket's effective provider in one pass.
+      const grab = (key) => {
+        const m = text.match(new RegExp(`^${key}:\\s*(\\S+)`, 'm'));
+        return m ? m[1] : null;
+      };
+      const globalProvider = grab('llm-provider');
+      let rewritten = text;
+      const healedBuckets = [];
+      for (const bucket of ['cues', 'auditors', 'blanks']) {
+        const sentinelRe = new RegExp(`^${bucket}-llm-model:\\s*default\\s*$`, 'm');
+        if (!sentinelRe.test(rewritten)) continue;
+        const bucketProvider = grab(`${bucket}-llm-provider`) || globalProvider;
+        if (!bucketProvider) continue;
+        const adapter = getProvider(bucketProvider);
+        if (!adapter || !adapter.defaultModel) continue;
+        rewritten = rewritten.replace(sentinelRe, `${bucket}-llm-model: ${adapter.defaultModel}`);
+        healedBuckets.push(`${bucket}-llm-model: ${adapter.defaultModel} (${bucketProvider})`);
+      }
+      if (rewritten !== text) {
+        fs.writeFileSync(settingsTarget, rewritten);
+        log(`Self-heal: rewrote 'default' sentinel(s) in ${settingsTarget}: ${healedBuckets.join('; ')}`);
+      }
+    }
+  }
+
   // Migrate legacy `<userDir>/blanks/<name>/{cue.md,blank.md}` → `BLANK.md`
   // per the open standard (spec/blank-spec.md). Idempotent: if BLANK.md
   // already exists, skip the source; otherwise rename whichever legacy

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/config-intent-source.test.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.test.ts
@@ -472,15 +472,19 @@ describe('ConfigIntentSource', () => {
     const input = 'use anthropic for cues _';
     const result = await src.getCues(ctxFromText(input));
     assert.strictEqual(result.results.length, 1);
-    // Provider scalar written + sibling model reset to `default` so any
+    // Provider scalar written + sibling model reset to the NEW provider's
+    // resolved defaultModel (anthropic → claude-opus-4-7) so any
     // previously-pinned model (incompatible with the new provider) is
     // cleared. Mirrors the cycling-resets-model invariant — fluid-config
     // and cycling must produce identical OPENCUES.md state for an
     // equivalent user intent (provider switch with no model named).
-    assert.deepStrictEqual(apply.calls, [
-      ['cues-llm-provider', 'anthropic'],
-      ['cues-llm-model', 'default'],
-    ]);
+    // Writing the resolved model name (not the legacy `default` sentinel)
+    // makes OPENCUES.md self-explanatory and keeps doctor's "inert
+    // sentinel" warning silent.
+    assert.strictEqual(apply.calls.length, 2);
+    assert.deepStrictEqual(apply.calls[0], ['cues-llm-provider', 'anthropic']);
+    assert.strictEqual(apply.calls[1]![0], 'cues-llm-model');
+    assert.match(apply.calls[1]![1]!, /^claude-/, 'model scalar must be an anthropic defaultModel, not the legacy `default` sentinel');
     const r = result.results[0]!;
     assert.deepStrictEqual(r.alternatives, ['cues-llm-provider']);
     // Display falls back to anthropic's defaultModel so the user always

--- a/packages/opencues-core/src/sources/config-intent-source.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.ts
@@ -977,8 +977,12 @@ export class ConfigIntentSource implements CueSource {
           // and now says "use cerebras for auditors _" must NOT keep
           // the old model around — the resolver would then dispatch
           // `cerebras + claude-opus-4-7` and 400. Mirrors the
-          // providerScalarToModelScalar reset in cycling.ts.
-          await apply(modelScalar, 'default');
+          // providerScalarToModelScalar reset in cycling.ts. Write the
+          // NEW provider's defaultModel explicitly (not the literal
+          // `default` sentinel) so OPENCUES.md is self-explanatory and
+          // doctor's "inert sentinel" warning doesn't fire.
+          const providerAdapter = getProvider(verdict.provider);
+          await apply(modelScalar, providerAdapter?.defaultModel ?? 'default');
         }
         displaySelector = providerScalar;
         // Always show what model is in use — even when the user didn't

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/cycling.ts
+++ b/packages/opencues-runtime/src/modules/cycling.ts
@@ -19,7 +19,7 @@ import { resolveNavKeymap } from './nav-keymap';
 import type { SpanFillState } from '../state/span-fill';
 import type { DismissedBlanks } from '../state/dismissed-blanks';
 import type { SelectorSatelliteState } from '../state/selector-satellite';
-import { isProviderValueCyclable } from '@opencues/core';
+import { isProviderValueCyclable, getProvider } from '@opencues/core';
 
 /** Settings whose values are LLM provider ids — cycling on these
  *  filters out values whose env key isn't set so the user can't
@@ -535,14 +535,18 @@ export class Cycling {
     this.configLoader.applyOpenCuesScalar(entry.currentSetting, nextValue);
     // Pair invariant: cycling a `*-llm-provider` makes any pinned
     // sibling `*-llm-model` ambiguous (the prior model was valid only
-    // for the prior provider). Reset to `default` so the resolver
-    // falls through to the new provider's defaultModel — the alternative
-    // is silent invalid-pair errors at the next LLM dispatch (e.g.
-    // `groq` provider + `claude-opus-4-7` model → 400). Same write-path
-    // as the provider change so the 2.5s suppression window covers both.
+    // for the prior provider). Reset to the NEW provider's defaultModel
+    // — keeps (provider, model) valid by construction. Previously wrote
+    // the literal sentinel `default` here; that was equivalent at
+    // dispatch time but tripped doctor's "inert sentinel" warning and
+    // confused users reading OPENCUES.md. Writing the resolved name
+    // is explicit and matches what `displayValue` already shows below.
     const siblingModelScalar = providerScalarToModelScalar(entry.currentSetting);
-    if (siblingModelScalar) {
-      this.configLoader.applyOpenCuesScalar(siblingModelScalar, 'default');
+    const siblingDefaultModel = siblingModelScalar
+      ? (getProvider(nextValue)?.defaultModel ?? 'default')
+      : null;
+    if (siblingModelScalar && siblingDefaultModel) {
+      this.configLoader.applyOpenCuesScalar(siblingModelScalar, siblingDefaultModel);
     }
     this.adapter.setText(newText);
     this.adapter.setCursorOffset(newCursor);
@@ -561,11 +565,11 @@ export class Cycling {
       );
       // Fire the sibling write through the same blank-invoke path so
       // OPENCUES.md persists the model reset.
-      if (siblingModelScalar) {
+      if (siblingModelScalar && siblingDefaultModel) {
         this.invokeOrSpawn(
           entry.blankName,
           'set',
-          [siblingModelScalar, 'default'],
+          [siblingModelScalar, siblingDefaultModel],
           entry.scriptPath,
           { detached: true, timeoutMs: 4000 },
         );

--- a/packages/opencues-runtime/src/modules/llm-config-cycling.scenarios.test.ts
+++ b/packages/opencues-runtime/src/modules/llm-config-cycling.scenarios.test.ts
@@ -13,10 +13,14 @@
  *   1. PAIR DISPLAY — the buffer shows `<bucket>-llm-provider provider:model`
  *      whenever the verdict named a model, so the user always knows
  *      what's in use.
+
  *   2. PROVIDER-CYCLE RESETS MODEL — cycling Ctrl+Alt+Up on the
- *      provider satellite ALSO writes `default` to the sibling model
- *      scalar via applyOpenCuesScalar, so the (provider, model) pair
- *      stays valid by construction.
+ *      provider satellite ALSO writes the NEW provider's defaultModel
+ *      to the sibling model scalar via applyOpenCuesScalar, so the
+ *      (provider, model) pair stays valid by construction. (Up to PR
+ *      #149 this wrote the literal `default` sentinel; we now write
+ *      the resolved name so OPENCUES.md is self-explanatory and
+ *      doctor's "inert sentinel" warning doesn't fire.)
  *   3. MODEL MENU IS PROVIDER-AWARE — the `*-llm-model` features
  *      registered with valuesProvider show only the current provider's
  *      knownModels. Cycling provider reshapes the model menu.
@@ -25,6 +29,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { getProvider } from '@opencues/core';
 import { Cycling } from './cycling';
 import { ConfigLoader } from './config-loader';
 import { HighlightState } from '../state/highlight-state';
@@ -82,12 +87,17 @@ describe('LLM config cycling — provider cycle resets sibling model', () => {
     hlState.activate(1, 'auditors-llm-provider anthropic');
     adapter.fireKey('up', { ctrl: true, alt: true });
 
-    // Provider walked to the next value in the registry. Model reset to default.
+    // Provider walked to the next value in the registry. Model reset to
+    // the new provider's defaultModel — explicit, not the legacy
+    // `'default'` sentinel.
+    const newProvider = loader.opencuesState.settings.get('auditors-llm-provider')!;
     const newModel = loader.opencuesState.settings.get('auditors-llm-model');
-    expect(newModel, 'sibling model scalar must reset on provider cycle').toBe('default');
+    const expectedModel = getProvider(newProvider)?.defaultModel ?? 'default';
+    expect(newModel, 'sibling model scalar must reset to new provider\'s defaultModel').toBe(expectedModel);
+    expect(newModel, 'must NOT be the stale prior model').not.toBe('claude-opus-4-7');
   });
 
-  it('cycling blanks-llm-provider also resets blanks-llm-model', async () => {
+  it('cycling blanks-llm-provider also resets blanks-llm-model to the new provider\'s default', async () => {
     const { adapter, hlState, loader } = await setupBucketCycle(
       'blanks-llm-provider cerebras',
       'blanks-llm-provider',
@@ -96,10 +106,12 @@ describe('LLM config cycling — provider cycle resets sibling model', () => {
     loader.applyOpenCuesScalar('blanks-llm-model', 'gpt-oss-120b');
     hlState.activate(1, 'blanks-llm-provider cerebras');
     adapter.fireKey('up', { ctrl: true, alt: true });
-    expect(loader.opencuesState.settings.get('blanks-llm-model')).toBe('default');
+    const newProvider = loader.opencuesState.settings.get('blanks-llm-provider')!;
+    expect(loader.opencuesState.settings.get('blanks-llm-model'))
+      .toBe(getProvider(newProvider)?.defaultModel ?? 'default');
   });
 
-  it('cycling cues-llm-provider also resets cues-llm-model', async () => {
+  it('cycling cues-llm-provider also resets cues-llm-model to the new provider\'s default', async () => {
     const { adapter, hlState, loader } = await setupBucketCycle(
       'cues-llm-provider openai',
       'cues-llm-provider',
@@ -108,7 +120,9 @@ describe('LLM config cycling — provider cycle resets sibling model', () => {
     loader.applyOpenCuesScalar('cues-llm-model', 'gpt-5.4');
     hlState.activate(1, 'cues-llm-provider openai');
     adapter.fireKey('up', { ctrl: true, alt: true });
-    expect(loader.opencuesState.settings.get('cues-llm-model')).toBe('default');
+    const newProvider = loader.opencuesState.settings.get('cues-llm-provider')!;
+    expect(loader.opencuesState.settings.get('cues-llm-model'))
+      .toBe(getProvider(newProvider)?.defaultModel ?? 'default');
   });
 
   it('cycling a non-provider scalar (voice-mode) does NOT clear any model scalar', async () => {
@@ -213,14 +227,19 @@ describe('LLM config cycling — invariant: no invalid (provider, model) pair la
         hlState.activate(1, adapter.getText());
         adapter.fireKey('up', { ctrl: true, alt: true });
 
-        const provider = loader.opencuesState.settings.get(`${bucket}-llm-provider`);
+        const provider = loader.opencuesState.settings.get(`${bucket}-llm-provider`)!;
         const model = loader.opencuesState.settings.get(`${bucket}-llm-model`);
 
-        // After ANY cycle, model must be `default` (since the cycle
-        // unconditionally resets it). This is the strongest invariant:
-        // there's no path where an invalid pair can persist.
-        expect(model, `after cycle ${i + 1}, ${bucket}-llm-model must be 'default' (provider=${provider})`)
-          .toBe('default');
+        // After ANY cycle, model must be the new provider's defaultModel
+        // (since the cycle unconditionally resets it to a valid value).
+        // When the cycled-to value is the `inherit` meta-provider (no
+        // adapter), the runtime falls back to the legacy `default`
+        // sentinel — both have the same "fall through to global"
+        // semantics. This is the strongest invariant: there's no path
+        // where an invalid pair can persist.
+        const expectedDefault = getProvider(provider)?.defaultModel ?? 'default';
+        expect(model, `after cycle ${i + 1}, ${bucket}-llm-model must be ${provider}'s defaultModel (${expectedDefault})`)
+          .toBe(expectedDefault);
       }
     });
   }


### PR DESCRIPTION
## Summary

When you flipped a bucket provider without naming a model — either via ConfigIntent natural language (`switch model to cerebras _`) or via Ctrl+Alt+↑ on the provider satellite — the apply path wrote the literal string `default` to the sibling `<bucket>-llm-model`. That kept the (provider, model) pair valid at dispatch time (runtime treats `default` as fall-through), but tripped doctor's "inert sentinel" warning and confused users reading OPENCUES.md.

The apply path now writes the **resolved `defaultModel`** for the new provider. Explicit, self-explanatory, no sentinel concept on the surface.

## Two converging code sites

- **`packages/opencues-core/src/sources/config-intent-source.ts:981`** — ConfigIntent's natural-language flip path.
- **`packages/opencues-runtime/src/modules/cycling.ts:545,568`** — satellite-cycle pair-invariant.

Both look up `getProvider(verdict.provider)?.defaultModel ?? 'default'`. The `?? 'default'` carve-out handles the `inherit` meta-provider where there's no adapter — semantics match (both mean "fall through to global `llm-model:`").

## One semantic difference

If a user later hand-edits global `llm-model:` to a different value, per-bucket scalars no longer cascade — each bucket is independent once cycled. That's the expected mental model for most users (the bucket they explicitly flipped shouldn't silently change when they edit the global later); the sentinel was clever-but-wrong UX.

## Self-heal for existing files

`packages/opencues-cli/src/commands/seed-configs.cjs` gained a new step (§ 3.2) that rewrites any pre-existing `<bucket>-llm-model: default` line to the bucket's effective-provider `defaultModel` on next `opencues install`. Idempotent; skips when no provider is resolvable.

**Verified live on my install** before opening this PR:

```
blanks-llm-model: default  →  blanks-llm-model: gpt-oss-120b
```

Doctor's `default` warning is now gone.

## Test plan

- [x] **`packages/opencues-runtime/src/modules/llm-config-cycling.scenarios.test.ts`** — 4 scenario assertions + the full-cycle invariant updated to expect `getProvider(provider)?.defaultModel ?? 'default'`.
- [x] **`packages/opencues-core/src/sources/config-intent-source.test.ts`** — the "provider hit (no model)" scenario no longer expects the literal `default`; checks the model write matches the new provider's shape (e.g. `^claude-` for anthropic).
- [x] 10/10 cycling scenarios green
- [x] 57/57 config-intent-source tests green
- [x] 1671/1671 runtime tests green
- [x] Full `scripts/pre-pr.sh` gates green (the doctor finding is the same pre-existing chrome-srcHash drift we've been seeing all session — not a PR defect)
- [x] Self-heal verified live on my actual `~/.cues/OPENCUES.md`

Bumps:
- `@opencues/core` 0.3.23 → 0.3.24
- `@opencues/runtime` 0.3.13 → 0.3.14
- `opencues` (CLI) 0.2.4 → 0.2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)