### PR TITLE
perf(ci): cache pnpm store + turbo, merge test-hermeticity, composite setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,77 @@
+name: Setup OpenCues build env
+description: >
+  Reusable composite for CI jobs — Node + pnpm via corepack, with the pnpm
+  store cached (keyed by lockfile hash) and optional .turbo cache for warm
+  builds. Every CI job repeats this prelude, so consolidating here keeps
+  cache hits consistent across jobs and shaves ~35-40s off each one (cold
+  `pnpm install --frozen-lockfile` is ~45s; warm-cache restore + symlink
+  is ~5s).
+
+  Usage:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/setup
+    - uses: ./.github/actions/setup
+      with:
+        install: 'false'          # skip pnpm install (rare; only when no JS work)
+        turbo-cache: 'true'       # restore .turbo/ for warm builds
+
+inputs:
+  node-version:
+    description: Node.js version
+    default: "22"
+    required: false
+  install:
+    description: Run `pnpm install --frozen-lockfile` after restoring the store cache
+    default: "true"
+    required: false
+  turbo-cache:
+    description: Restore .turbo/ keyed by lockfile + git sha (falls back to lockfile-only)
+    default: "false"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Enable corepack (pnpm)
+      shell: bash
+      run: corepack enable
+
+    - name: Resolve pnpm store path
+      if: inputs.install == 'true'
+      shell: bash
+      run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+
+    # Cache the global pnpm CAS store. The cache key uses the lockfile
+    # hash so any dep change invalidates; restore-keys gives partial hits
+    # when only some deps changed.
+    - name: Cache pnpm store
+      if: inputs.install == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.PNPM_STORE_PATH }}
+        key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-store-${{ runner.os }}-
+
+    - name: pnpm install
+      if: inputs.install == 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
+    # Turbo cache: keyed by lockfile + sha. The sha key keeps the cache
+    # fresh for the exact commit; the restore-keys ladder pulls the most
+    # recent cache for the same lockfile (deps unchanged → build cache
+    # still valid) and falls through to any prior cache as a last resort.
+    - name: Cache .turbo
+      if: inputs.turbo-cache == 'true'
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+          turbo-${{ runner.os }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,55 +12,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── build · typecheck · test + hermeticity (merged) ──────────────────
+  # The previously-separate `test-hermeticity` job did the same install +
+  # build + run-tests sequence as this one, just with HOME pointed at a
+  # tempdir. Merging them saves a whole job's worth of runner-minutes
+  # (≈90s on a cold cache, ≈30s warm) and removes the rebuild that ran
+  # twice in parallel. The hermeticity check still runs the same scripts
+  # — it just shares the install + build with the rest of the job.
   build-and-test:
-    name: build · typecheck · test
+    name: build · typecheck · test + hermeticity
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
-
-      # pnpm is pinned in package.json's `packageManager` field —
-      # action/setup-node honours that when corepack is enabled.
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: 22
+          turbo-cache: "true"
 
-      - name: Enable corepack (pnpm)
-        run: corepack enable
-
-      - name: pnpm install
-        run: pnpm install --frozen-lockfile
-
-      # turbo run build — builds @opencues/core, @opencues/runtime,
-      # and the chrome extension's dist/ in dependency order. Cached
-      # via .turbo/ but cache isn't restored across CI runs yet (would
-      # need actions/cache with the turbo cache dir).
       - name: Build
         run: pnpm build
 
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Test
-        run: pnpm test
+      # Runs the full test sweep under a sandboxed $HOME and asserts the
+      # real ~/.opencues/ + ~/.cues/ are untouched. Covers `pnpm -r test`
+      # AND the CLI's own `npm test` target. CI runners don't normally
+      # have either dir, so the diff is vacuous — the HOME override is
+      # the load-bearing contract. PR #41 (June 2026) caught
+      # vendor-pins.test.cjs wiping the user's tmux dir; this gate
+      # structurally prevents the regression class.
+      - name: Test + hermeticity (sandboxed HOME)
+        run: bash scripts/check-test-hermeticity.sh
 
-      - name: Test (CLI unit + integration)
+      - name: Test (CLI integration)
         run: |
           cd packages/opencues-cli
-          npm test
           npm run test:integration
         env:
           # Tests should never need a real LLM key. If a unit test
           # requires one, that's the bug — file it instead of unsetting
-          # this. Existing tests use mocked providers (see
-          # @opencues/core's source-class tests).
-          GROQ_API_KEY: ''
-          CEREBRAS_API_KEY: ''
-          OPENAI_API_KEY: ''
-          ANTHROPIC_API_KEY: ''
-          GEMINI_API_KEY: ''
+          # this. Existing tests use mocked providers.
+          GROQ_API_KEY: ""
+          CEREBRAS_API_KEY: ""
+          OPENAI_API_KEY: ""
+          ANTHROPIC_API_KEY: ""
+          GEMINI_API_KEY: ""
 
+  # ── lints (no install needed) ────────────────────────────────────────
   shell-portability:
     name: shell portability lint
     runs-on: ubuntu-latest
@@ -91,6 +91,7 @@ jobs:
       - name: Run legacy-names lint
         run: bash scripts/lint-legacy-names.sh
 
+  # ── install-dependent gates ──────────────────────────────────────────
   cc-patch-boot-smoke:
     name: CC patch boot smoke
     runs-on: ubuntu-latest
@@ -105,13 +106,7 @@ jobs:
     # evaluation surfaced the bug. This job runs that evaluation in CI.
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - name: Enable corepack (pnpm)
-        run: corepack enable
-      - name: pnpm install
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - name: Run CC patch boot smoke
         run: node scripts/check-cc-patch-boot.cjs
 
@@ -129,16 +124,12 @@ jobs:
     # incident — every opencode + shell user crashed at boot for hours.
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: 22
+          turbo-cache: "true"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-      - name: Enable corepack (pnpm)
-        run: corepack enable
-      - name: pnpm install
-        run: pnpm install --frozen-lockfile
       - name: Build @opencues/{core,runtime}
         run: pnpm --filter @opencues/core --filter @opencues/runtime build
       - name: Probe runtime load under Bun
@@ -165,13 +156,9 @@ jobs:
     # references.
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: 22
-      - name: Enable corepack (pnpm)
-        run: corepack enable
-      - name: pnpm install
-        run: pnpm install --frozen-lockfile
+          turbo-cache: "true"
       - name: Build @opencues/{core,runtime}
         run: pnpm --filter @opencues/core --filter @opencues/runtime build
       - name: Probe CC fork bundle integrity
@@ -192,7 +179,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # need master ref for the diff base
+          fetch-depth: 0 # need master ref for the diff base
       - name: Run version-bump gate
         run: bash scripts/lint-version-bump.sh
         env:
@@ -211,43 +198,10 @@ jobs:
     # pipeline the main job uses.
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup
         with:
-          node-version: 22
-      - name: Enable corepack (pnpm)
-        run: corepack enable
-      - name: pnpm install
-        run: pnpm install --frozen-lockfile
+          turbo-cache: "true"
       - name: pnpm build
         run: pnpm build
       - name: Check chrome bundle
         run: bash scripts/check-chrome-bundle.sh
-
-  test-hermeticity:
-    name: test hermeticity (sandboxed HOME)
-    runs-on: ubuntu-latest
-    timeout-minutes: 12
-
-    # Runs the full test sweep under a sandboxed $HOME and asserts
-    # that the real ~/.opencues/ (if any) wasn't touched. Catches
-    # PR #41-class bugs where a unit test wrote to os.homedir()
-    # without sandboxing — the vendor-pins test was destroying users'
-    # vendored tmux on every `pnpm test` run before that PR.
-    #
-    # CI runners don't normally have ~/.opencues/, so the diff is
-    # vacuous. The override + run-pattern is still the contract —
-    # any test that tries to write under HOME gets a tempdir, not
-    # the runner's real /github/home.
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - name: Enable corepack (pnpm)
-        run: corepack enable
-      - name: pnpm install
-        run: pnpm install --frozen-lockfile
-      - name: pnpm build
-        run: pnpm build
-      - name: Run hermeticity check
-        run: bash scripts/check-test-hermeticity.sh


### PR DESCRIPTION
## Summary

Every CI job is a clean ubuntu-latest VM repeating the same setup ritual: checkout → setup-node → corepack enable → pnpm install. With 9 jobs and no pnpm cache, `pnpm install --frozen-lockfile` runs ~45s fresh × 9 ≈ **6 minutes of pure dependency re-fetch per CI run**. PR #150's two longest jobs (build·typecheck·test 2m5s; test-hermeticity 2m18s) both did the same install + build before diverging only at the test step.

## Changes

**1. New composite action `.github/actions/setup/action.yml`** — consolidates the install prelude. Adds `actions/cache@v4` on the pnpm CAS store (keyed by lockfile hash) so cold install drops from ~45s → ~5s. Optional `turbo-cache: true` restores `.turbo/` for warm builds.

```yaml
- uses: actions/checkout@v4
- uses: ./.github/actions/setup
  with:
    turbo-cache: "true"
```

**2. Merge `test-hermeticity` into `build-and-test`.** The hermeticity script already runs `pnpm -r test` + CLI's `npm test` under a sandboxed HOME; running it once gives correctness AND the hermeticity contract. Saves a whole job's worth of runner-minutes (~90s cold, ~30s warm). Off critical path but frees a runner slot and ends double-builds.

**3. Every job that builds gets the turbo cache.** First job primes; rest get build no-ops on unchanged inputs.

## Expected impact (vs PR #150's run)

| Job | Before | Estimated after |
|---|---|---|
| build · typecheck · test + hermeticity (merged) | 2m18s (was test-hermeticity) | ~1m45s cold / ~1m15s warm |
| chrome bundle artifacts | 52s | ~25s warm |
| runtime loads on bun | 29s | ~15s warm |
| CC fork bundle integrity | 28s | ~15s warm |
| CC patch boot smoke | 16s | ~10s warm |
| version-bump gate | 10s | unchanged (no install needed) |
| shell portability lint | 6s | unchanged |
| legacy-names lint | 6s | unchanged |

**Target critical path: <1m30s warm, ~1m45s cold.** Down from 2m18s.

## Test plan

This PR's own CI run is the test. Will compare numbers to PR #150 after merge.

- [x] Composite action yaml parses
- [x] Workflow yaml parses
- [x] Job structure matches existing semantics (every gate still runs the same script)
- [ ] CI run completes green
- [ ] Report measured times

🤖 Generated with [Claude Code](https://claude.com/claude-code)