### PR TITLE
fix(chrome): auto-populate popup Provider/Model dropdowns on key entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix (chrome) — popup Provider / Model dropdowns auto-populate on key entry; no longer gated behind Save
+
+The popup's `Provider` and `Model` dropdowns only list providers whose API key has been verified (a live probe against each provider's `/models` endpoint). That verification previously ran only on popup `init()` (from already-saved keys) and inside the `Save` click handler. So a user pasting a *fresh* key saw `Provider` stuck on `— no verified keys —` until they clicked `Save` — which sits **below** the Provider/Model controls. The required action order (paste key → Save → pick provider → pick model → Save again) contradicted the top-to-bottom layout.
+
+`integrations/chrome/src/popup/popup.ts` now wires a debounced (`600ms`) `input` listener on every provider-key field that re-runs the same `refreshProviderDropdown` verify-and-populate path used by `init()`/`Save`. Pasting or typing a valid key now populates Provider/Model automatically, so the layout reads in execution order and `Save` reverts to purely "persist my final choices". Skipped while `use ~/.cues/ config (chrome-host)` (defer mode) is on, since Provider/Model are ignored then. The stale `— no verified keys —` hover hint ("…and click save") was updated to reflect the automatic behaviour.
+
+Typecheck clean; 9/9 `popup-roundtrip.test.ts` green.
+
+Bumps:
+- `@opencues/chrome` 0.2.20 → 0.2.21 (`manifest.json` + `package.json` in lockstep).
+
 ### Fix — provider-cycle resets sibling model to the resolved `defaultModel`, not the legacy `default` sentinel
 
 When the user flipped a bucket provider without naming a model — either via the ConfigIntent natural-language path (`switch model to cerebras _`) or via the cycling satellite (Ctrl+Alt+↑ on `blanks-llm-provider`) — the apply path wrote the literal string `default` to the sibling `<bucket>-llm-model` scalar. That kept the (provider, model) pair valid at dispatch time (the runtime treats `default` as a fall-through sentinel) but tripped doctor's "inert sentinel" warning and confused users reading OPENCUES.md ("what is `default`? why is it stuck?").

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/src/popup/popup.ts
+++ b/integrations/chrome/src/popup/popup.ts
@@ -114,7 +114,7 @@ async function refreshProviderDropdown(preferred: string, currentModel: string):
     opt.value = '';
     opt.textContent = '— no verified keys —';
     providerEl.appendChild(opt);
-    providerEl.title = 'Paste an API key above and click save. Verified keys appear here.';
+    providerEl.title = 'Paste an API key above — verified providers appear here automatically.';
     if (hint) hint.textContent = '';
     populateModelDropdown('', currentModel);
     return;
@@ -235,6 +235,31 @@ async function init(): Promise<void> {
   };
   applyDeferUI();
   deferEl.addEventListener('change', applyDeferUI);
+
+  // Auto-verify keys as they're entered so the Provider / Model
+  // dropdowns populate WITHOUT a Save round-trip first. Previously the
+  // dropdowns only repopulated on init() (from saved keys) and on Save,
+  // so a freshly-pasted key left Provider showing "— no verified keys —"
+  // until the user clicked Save — which sits BELOW provider/model. That
+  // made the action order (paste → save → pick provider → pick model →
+  // save) contradict the visual top-to-bottom order. Auto-verifying here
+  // means the layout reads in execution order and Save is purely
+  // "persist my final choices". Debounced so we probe each provider's
+  // /models endpoint once after typing/paste settles, not per keystroke.
+  let verifyTimer: ReturnType<typeof setTimeout> | undefined;
+  const scheduleKeyVerify = (): void => {
+    if (deferEl.checked) return; // provider/model ignored in defer mode
+    if (verifyTimer !== undefined) clearTimeout(verifyTimer);
+    verifyTimer = setTimeout(() => {
+      void refreshProviderDropdown(
+        providerEl.value || config.provider || '',
+        modelEl.value || config.model || '',
+      );
+    }, 600);
+  };
+  for (const el of providerKeyInputs()) {
+    el.addEventListener('input', scheduleKeyVerify);
+  }
 
   const dimMix = document.getElementById('dimMix') as HTMLInputElement;
   const dimMixValue = document.getElementById('dimMixValue') as HTMLSpanElement;


### PR DESCRIPTION
## Problem

In the OpenCues Chrome extension popup, the **Provider** and **Model** dropdowns only list providers whose API key has passed a live verification probe. That verification (`refreshProviderDropdown`) ran only on popup `init()` (from *already-saved* keys) and inside the **Save** click handler.

So when a user pasted a *fresh* key, Provider stayed on `— no verified keys —` until they clicked **Save** — which sits **below** the Provider/Model controls. The required order of operations (paste key → Save → pick provider → pick model → Save again) contradicted the visual top-to-bottom layout, as reported.

## Fix

Rather than reshuffle the layout, this removes the hidden dependency: the dropdowns now **auto-populate as soon as a valid key is entered**, exactly as `init()` already does for saved keys.

- A debounced (600 ms) `input` listener on each provider-key field re-runs the same `refreshProviderDropdown` verify-and-populate path.
- The layout now reads in execution order: enter key → Provider/Model fill in → **Save**.
- **Save** reverts to its honest role — "persist my final choices."
- Skipped while *use ~/.cues/ config (chrome-host)* defer mode is on (Provider/Model are ignored there).
- Updated the now-stale `…and click save` hover hint.

## Testing

- `tsc --noEmit` clean.
- `popup-roundtrip.test.ts` — 9/9 green.
- Manually verified in-browser by the reporter (dropdowns populate on key paste without a Save first).

## Version

Bumps `@opencues/chrome` 0.2.20 → 0.2.21 in both `manifest.json` and `package.json` (lockstep rule), plus a root CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
