### PR TITLE
fix(runtime): shape gate slices from keyword, unblocking stacked blanks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — shape-anchored blanks rejected when stacked behind a prior substituted span
+
+A user filling `apple stock _` → `AAPL: $298.97`, then appending ` + nvda stock _` to the same buffer, found the second invocation silently fell through to FluidBlank (which returned just `"NVDA"` — no Finnhub call, no price). Every shipped blank with a `^...\s*_$` shape (stocks, weather, volume, brightness, crypto, countries, answer, sentinel, claude-status, example) hit the same bug shape: the moment any text preceded the keyword in the buffer, the `^` anchor failed and BlankFill dropped the slot.
+
+Cause: `matchBlankShape` in `packages/opencues-runtime/src/modules/blank-fill.ts` built its `testText` from `words.slice(0, blankIdx + 1)` — the entire buffer prefix up to `_`. Author intent on every shape pattern was "the keyword leads the *invocation*", but the code conflated the invocation window with the whole buffer.
+
+Fix: `matchBlankShape` now takes the keyword's leading word index (already known by the caller) and slices from there. `^` anchors against the keyword span; preceding spans in the buffer no longer break the gate. The earlier `indexInsideSubstitutedSpan` guard (June 2026, stocks-chain regression) still prevents a keyword from re-entering its own substitute, so the chain-loop class stays closed.
+
+Scenario test in `blank-fill.test.ts` reproduces the exact 16:14:05 log buffer (`AAPL: $298.97 + nvda stock _` with the prior 2-word DynDef registered) and asserts the `nvda stock` slot is detected. Verified failing without the fix, passing with it.
+
+Bumps:
+- `@opencues/runtime` 0.3.14 → 0.3.15.
+
 ### Fix (chrome) — popup Provider / Model dropdowns auto-populate on key entry; no longer gated behind Save
 
 The popup's `Provider` and `Model` dropdowns only list providers whose API key has been verified (a live probe against each provider's `/models` endpoint). That verification previously ran only on popup `init()` (from already-saved keys) and inside the `Save` click handler. So a user pasting a *fresh* key saw `Provider` stuck on `— no verified keys —` until they clicked `Save` — which sits **below** the Provider/Model controls. The required action order (paste key → Save → pick provider → pick model → Save again) contradicted the top-to-bottom layout.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/blank-fill.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.test.ts
@@ -175,6 +175,57 @@ blankProximity: 0
     });
   });
 
+  // Regression: shape-anchored blank rejected when stacked behind a
+  // prior substituted span (June 2026 — `apple stock _` → "AAPL: $298.97";
+  // then `<that> + nvda stock _` silently fell through to FluidBlank).
+  //
+  // Cause: matchBlankShape tested the full buffer prefix up to `_`. Every
+  // shipped blank's shape uses `^...\s*_$`, so the `^` failed to anchor
+  // once anything preceded the keyword in the buffer.
+  //
+  // Fix: matchBlankShape now slices from the keyword's leading word,
+  // so `^` anchors against the invocation window. Spans that come
+  // before don't break the gate.
+  it('shape-anchored keyword matches when stacked behind a prior span', async () => {
+    const STOCKS = `---
+type: blank
+name: stocks
+blankKeywords: nvda, apple stock, nvda stock
+blankShapes: [{"pattern":"^(nvda|apple\\\\s+stock|nvda\\\\s+stock)\\\\s*_$","action":"get","valueGroup":1}]
+---
+`;
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: {
+        '/mock/CUES.md': TIPS,
+        '/proj/blanks/stocks/BLANK.md': STOCKS,
+      },
+    });
+    const loader = new ConfigLoader(adapter);
+    await loader.load();
+    const dynDefs = new DynDefs();
+    // Prior apple-stock fill substituted "apple stock _" → "AAPL: $298.97".
+    // DynDefs registers that 2-word span at indices 0-1.
+    dynDefs.set(0, {
+      originalWord: 'apple',
+      alternatives: ['AAPL: $298.97'],
+      currentIndex: 0,
+      spanStart: 0,
+      spanEnd: 13,
+      blankName: 'stocks',
+    });
+    const bf = new BlankFill(adapter, loader, undefined, undefined, undefined, dynDefs);
+    // The exact buffer from the 16:14:05 log line.
+    const slots = bf.scan('AAPL: $298.97 + nvda stock _');
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({
+      keyword: 'nvda stock',
+      blankName: 'stocks',
+      action: 'get',
+      value: 'nvda stock',
+    });
+  });
+
   it('still matches keyword OUTSIDE substituted spans', async () => {
     const STOCKS = `---
 type: blank

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -1349,7 +1349,7 @@ export class BlankFill {
             let shapeAction: 'get' | 'set' | 'step' | undefined;
             let shapeValue: string | undefined;
             if (shapes && shapes.length > 0) {
-              const matchedShape = matchBlankShape(words, blankIdx, shapes);
+              const matchedShape = matchBlankShape(words, start, blankIdx, shapes);
               if (!matchedShape) continue;
               shapeAction = matchedShape.action;
               shapeValue = matchedShape.value;
@@ -1376,11 +1376,15 @@ export class BlankFill {
  * Walk the blank's declared shapes against the buffer text; return
  * the matched action + extracted value, or null if no shape fires.
  *
- * The test string is the buffer text up to and including `_`, with
- * leading/trailing whitespace trimmed. Patterns are compiled with `i`
- * (case-insensitive) and `s` (dotall — multi-line bodies don't need
- * to anchor at the start of every line). Authors can use `^` / `$`
- * to anchor against the trimmed input as a whole.
+ * The test string is the buffer slice from the matched keyword's
+ * leading word up to and including `_`, with leading/trailing
+ * whitespace trimmed. Patterns are compiled with `i` (case-
+ * insensitive) and `s` (dotall — multi-line bodies don't need to
+ * anchor at the start of every line). Authors can use `^` / `$` to
+ * anchor against the trimmed invocation window — NOT the whole
+ * buffer. The slice starts at the keyword so a `^foo\s*_$` shape
+ * matches `<prior-span> + foo _` the same way it matches `foo _`
+ * alone (stacked-blank composition).
  *
  * First-match wins (top-down walk). Authors should order shapes
  * narrowest-first: bare-keyword shapes after numeric-bearing shapes,
@@ -1389,13 +1393,11 @@ export class BlankFill {
  */
 function matchBlankShape(
   words: readonly string[],
+  start: number,
   blankIdx: number,
   shapes: ReadonlyArray<{ pattern: string; action: 'get' | 'set' | 'step'; valueGroup?: number }>,
 ): { action: 'get' | 'set' | 'step'; value?: string } | null {
-  // Build the test string from the buffer up to and including the `_`.
-  // Trailing words AFTER the `_` are ignored — by the time `_` fires,
-  // they're not part of the invocation.
-  const testText = words.slice(0, blankIdx + 1).join(' ').trim();
+  const testText = words.slice(start, blankIdx + 1).join(' ').trim();
   for (const shape of shapes) {
     let re: RegExp;
     try { re = new RegExp(shape.pattern, 'is'); }


### PR DESCRIPTION
## Summary

Every shipped blank's shape pattern uses `^...\s*_$`. `matchBlankShape` in `blank-fill.ts` tested those against the full buffer prefix up to `_`, so the moment any text preceded the keyword in the buffer the `^` anchor failed and BlankFill silently dropped the slot. Concrete shape from the user's log:

| Buffer | testText | Matches `^...$`? |
|---|---|---|
| `nvda _` | `nvda _` | ✓ |
| `apple stock _` | `apple stock _` | ✓ |
| `AAPL: $298.97 + nvda stock _` | `AAPL: $298.97 + nvda stock _` | ✗ |

When the gate returns null, BlankFill detects no slot at all and FluidBlank wins the resolver race — the user sees `"NVDA"` (just the ticker, no Finnhub price) instead of `"NVDA: $209.49"`.

Every shipped blank with `^` in its shape pattern hit this — stocks, weather, volume, brightness, crypto, countries, answer, sentinel, claude-status, example. The June 2026 comment on the stocks shape explicitly says *"the keyword must be the leading word in the input"* — meaning the leading word of the invocation, not the whole buffer.

## Fix

`matchKeyword` already knows the keyword's word-start. Thread it through so `matchBlankShape` slices `words.slice(start, blankIdx + 1)` instead of `words.slice(0, blankIdx + 1)`. `^` anchors against the invocation window. The earlier `indexInsideSubstitutedSpan` guard (June 2026, stocks-chain regression) still prevents a keyword re-entering its own substitute, so the chain-loop class stays closed.

## Test plan

- [x] `pnpm --filter @opencues/runtime exec vitest run src/modules/blank-fill` — 101/101 green
- [x] New scenario test reproduces the exact 16:14:05 log buffer (`AAPL: $298.97 + nvda stock _` with the prior 2-word DynDef registered) and asserts the `nvda stock` slot is detected
- [x] Verified the test FAILS without the fix and PASSES with it (`git stash` round-trip)
- [x] `bash scripts/pre-pr.sh` — every gate passes except the pre-existing "stale bundles" doctor warnings (unrelated to this change)
- [x] CHANGELOG.md + `@opencues/runtime` 0.3.14 → 0.3.15 bumped per the versioning discipline

🤖 Generated with [Claude Code](https://claude.com/claude-code)