### PR TITLE
fix(runtime): shape-driven substitute replaces keyword window, not line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — shape-driven substitute wiped the whole current line
+
+Follow-up to the shape-anchor stacked-blank fix (0.3.15). With the shape gate now slicing from the keyword window, the substitute path was still wiping from the last newline before `_` — losing any prefix the user had written. `hello world nvda _` → `NVDA: $208.79` instead of `hello world NVDA: $208.79`.
+
+The shape-driven branches in `applyAsyncFill` and `applySatelliteFill` (`blank-fill.ts:737-749` and `blank-fill.ts:1043-1049`) now replace `[words[slot.keywordStart].start .. target.end)` — the same window the shape gate validated — instead of `[lastNewline .. target.end)`. Author intent: "broader shaping, proximity-style range". Every shipped shape-driven blank (stocks, weather, volume, brightness, crypto, countries, answer, sentinel, claude-status, example) now preserves prefix text exactly as proximity-only blanks always have.
+
+Scenario test in `blank-fill.test.ts` covers `hello world apple stock _` → `hello world AAPL: $298.97`. Verified failing without the fix, passing with it. Full 1673-test runtime suite green.
+
+Bumps:
+- `@opencues/runtime` 0.3.15 → 0.3.16.
+
 ### Fix — shape-anchored blanks rejected when stacked behind a prior substituted span
 
 A user filling `apple stock _` → `AAPL: $298.97`, then appending ` + nvda stock _` to the same buffer, found the second invocation silently fell through to FluidBlank (which returned just `"NVDA"` — no Finnhub call, no price). Every shipped blank with a `^...\s*_$` shape (stocks, weather, volume, brightness, crypto, countries, answer, sentinel, claude-status, example) hit the same bug shape: the moment any text preceded the keyword in the buffer, the `^` anchor failed and BlankFill dropped the slot.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/blank-fill.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.test.ts
@@ -226,6 +226,51 @@ blankShapes: [{"pattern":"^(nvda|apple\\\\s+stock|nvda\\\\s+stock)\\\\s*_$","act
     });
   });
 
+  // Regression: shape-driven substitute wiped the whole current line
+  // (June 2026 follow-up to the shape-anchor stacked-blank fix).
+  // The previous line-wipe carve-out assumed `matchBlankShape` had
+  // matched the entire buffer prefix, so it spliced from the last
+  // newline before `_` and lost any prefix the user had written. Now
+  // that the shape gate slices from the keyword window, the substitute
+  // mirrors that window so "hello world apple stock _" preserves
+  // "hello world " — proximity-style range with shape-style matching.
+  it('shape-driven substitute wipes only the keyword window, not the whole line', async () => {
+    const STOCKS = `---
+type: blank
+name: stocks
+blankKeywords: apple stock, nvda
+blankShapes: [{"pattern":"^(apple\\\\s+stock|nvda)\\\\s*_$","action":"get","valueGroup":1}]
+---
+`;
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: {
+        '/mock/CUES.md': TIPS,
+        '/proj/blanks/stocks/BLANK.md': STOCKS,
+      },
+    });
+    adapter.pushText('hello world apple stock _');
+    const loader = new ConfigLoader(adapter);
+    await loader.load();
+    const spanFillState = new SpanFillState();
+    const bf = new BlankFill(adapter, loader, spanFillState);
+    const slots = bf.scan('hello world apple stock _');
+    expect(slots).toHaveLength(1);
+    expect(slots[0]).toMatchObject({
+      keyword: 'apple stock',
+      blankName: 'stocks',
+      keywordStart: 2,
+      keywordEnd: 3,
+      action: 'get',
+    });
+    // Drive the shape-driven splice through applyAsyncFill (the post-
+    // script-result handler that the substitute path runs in prod).
+    // The "hello world " prefix MUST survive.
+    (bf as unknown as { applyAsyncFill: (s: typeof slots[0], v: string) => void })
+      .applyAsyncFill(slots[0], 'AAPL: $298.97');
+    expect(adapter.getText()).toBe('hello world AAPL: $298.97');
+  });
+
   it('still matches keyword OUTSIDE substituted spans', async () => {
     const STOCKS = `---
 type: blank

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -724,23 +724,22 @@ export class BlankFill {
       spanAsUnit: blank?.blankClearOnEdit === true,
     });
 
-    // Shape-driven path (June 2026) — when the matched shape produced
-    // a slot with `action` set, the shape's regex matched the ENTIRE
-    // input (regex anchored ^...$). Wipe the whole matched input
-    // (line-scoped — surrounding paragraphs survive) and splice the
-    // fill into its place. Without this carve-out, the legacy
-    // computeFillRange would only wipe the keyword span, leaving the
-    // user's captured prompt text (or other prefix words the shape
-    // matched) loose in the buffer. Mirrors the same carve-out in
-    // applySatelliteFill — both emission shapes converge on
-    // line-scoped wipe for shape-driven blanks.
+    // Shape-driven path (June 2026) — wipe from the matched keyword's
+    // leading word to (and including) `_`. Mirrors the proximity-blank
+    // semantics: the substitute replaces the invocation window, not the
+    // whole line. The earlier line-scoped wipe assumed the shape regex
+    // matched the entire buffer prefix (back when `matchBlankShape`
+    // tested `words.slice(0, blankIdx + 1)`); now that the shape gate
+    // slices from `slot.keywordStart`, the substitute mirrors that
+    // window so authors get "broader shaping, proximity-style range".
+    // Mirrors the same carve-out in applySatelliteFill.
     const isShapeDriven = slot.action !== undefined;
     const { newText, newCursor } = isShapeDriven
       ? (() => {
-          const lineStart = cleaned.lastIndexOf('\n', target.start - 1) + 1;
+          const kwStartChar = words[slot.keywordStart]?.start ?? target.start;
           return {
-            newText: cleaned.slice(0, lineStart) + primaryFill + cleaned.slice(target.end),
-            newCursor: lineStart + primaryFill.length,
+            newText: cleaned.slice(0, kwStartChar) + primaryFill + cleaned.slice(target.end),
+            newCursor: kwStartChar + primaryFill.length,
           };
         })()
       : clearEnd !== undefined || expansion != null
@@ -1031,22 +1030,21 @@ export class BlankFill {
     const sep = blank.blankSatelliteSeparator || ' ';
     const pair = `${selectorRaw}${sep}${satelliteRaw}`;
 
-    // Shape-driven path: the shape pattern matched the ENTIRE input
-    // up to and including `_` (regex is anchored with ^...$ by author
-    // convention), so the whole input is the summon and gets replaced
-    // by the satellite pair. This converges shape-driven blanks on
-    // ConfigIntent's wipe-all emission shape (one wipeable span,
-    // surrounding prose preserved). For legacy blanks (no shapes),
-    // fall through to the existing keyword-range computeFillRange.
+    // Shape-driven path: the shape regex matched the keyword window
+    // (`words.slice(slot.keywordStart, slot.index + 1)`), so the
+    // substitute replaces just that window — keyword leading word
+    // through `_`. This converges shape-driven blanks on the same
+    // proximity-style range proximity-only blanks always had,
+    // preserving prefix text the user wrote before the keyword.
+    // For legacy blanks (no shapes), fall through to the existing
+    // keyword-range computeFillRange.
     let newText: string;
     let newCursor: number;
     if (slot.action !== undefined) {
-      // Wipe from start-of-line (or last newline boundary) to the
-      // `_` position. Multi-line buffers: stay scoped to the current
-      // line so prior paragraphs survive.
-      const lineStart = cleaned.lastIndexOf('\n', target.start - 1) + 1;
-      newText = cleaned.slice(0, lineStart) + pair + cleaned.slice(target.end);
-      newCursor = lineStart + pair.length;
+      const wordSpans = splitWords(cleaned);
+      const kwStartChar = wordSpans[slot.keywordStart]?.start ?? target.start;
+      newText = cleaned.slice(0, kwStartChar) + pair + cleaned.slice(target.end);
+      newCursor = kwStartChar + pair.length;
     } else {
       const { clearEnd, expansion } = computeFillRange(blank, slot);
       ({ newText, newCursor } = clearEnd !== undefined || expansion != null


### PR DESCRIPTION
## Summary

Follow-up to #155. With the shape gate now slicing from the keyword window, the substitute path was still wiping from the last newline before \`_\` — losing any prefix the user had written:

| Buffer | Result before this PR | Result after |
|---|---|---|
| \`nvda _\` | \`NVDA: \$208.79\` | \`NVDA: \$208.79\` |
| \`hello world nvda _\` | \`NVDA: \$208.79\` (line wiped) | \`hello world NVDA: \$208.79\` |
| \`AAPL: \$298.97 + nvda stock _\` | \`NVDA: \$208.79\` (everything wiped) | \`AAPL: \$298.97 + NVDA: \$208.79\` |

The user's framing: *"its supposed to work like proximity blanks but broader shaping."* The OLD line-wipe carve-out at \`blank-fill.ts:737-745\` and \`blank-fill.ts:1043-1049\` assumed the shape regex matched the entire buffer prefix (back when \`matchBlankShape\` tested \`words.slice(0, blankIdx + 1)\`). #155 changed that to slice from the keyword window — but the substitute kept wiping the whole line.

## Fix

Both shape-driven branches now replace \`[words[slot.keywordStart].start .. target.end)\` — the same window the shape gate just validated. Every shipped shape-driven blank (stocks, weather, volume, brightness, crypto, countries, answer, sentinel, claude-status, example) gets proximity-style range with shape-style matching.

## Test plan

- [x] New scenario test \`hello world apple stock _\` → \`hello world AAPL: \$298.97\`
- [x] Verified the test FAILS without the fix and PASSES with it
- [x] \`pnpm --filter @opencues/runtime exec vitest run\` — 1673/1673 green
- [x] CHANGELOG.md + \`@opencues/runtime\` 0.3.15 → 0.3.16 bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)