### PR TITLE
fix(runtime): cycleBlankStep syncs spanFillState.lastFilledText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Fix — `cycleBlankStep` syncs `spanFillState.lastFilledText` (runtime 0.3.16)
+
+Numeric-step blanks (`brightness`, `volume`, anything with `blankStep`) wiped the entire buffer the first time the user cycled Up/Down after auto-populate. Root cause: `cycleBlankStep` updated the DynDef + called `setText` but never refreshed `spanFillState.lastFilledText`. The next `_onTextChangeImpl` then saw `cleaned !== lastFilledText` (stale at the previous cycle's value), classified the cycle output as a user edit inside the clear-on-edit span, and ran `applyClearOnEdit` over the whole `"<keyword> <value>%"` pair — buffer ended empty.
+
+`cycleSpanFill` (Path 0) already does this sync at the equivalent point — `cycleBlankStep` (Path 2) was the only cycling path missing it. Added the same `spanFillState.set(entry, newText)` call gated on the entry's index matching the cycle target.
+
+User-visible repro: type `brightness _`. Pre-fix: auto-populates to `brightness 80%`, then Ctrl+Alt+Right + Ctrl+Alt+Up wipes the whole buffer instead of cycling to `brightness 90%`. Volume blank behaves identically. Post-fix: cycles correctly through 10% increments. Same shape for any user blank declaring `blankStep:` in its frontmatter.
+
 ### Revert — shape-driven blanks system (PRs #146, #155, #156) — keep on `dev/shape-system` for exploration
 
 The shape system (PR #146) introduced `blankShapes:` as a declarative precision gate replacing `blankProximity:`. Migrated 14 blanks (stocks / volume / brightness / weather / crypto / countries / dictionary / answer / prompt / sentinel / claude-status / example / gh-issues / hackernews) and added shape-handling code paths in `blank-fill.ts`, `cycling.ts`, `dim-render.ts`, `navigation.ts`.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/cycling.ts
+++ b/packages/opencues-runtime/src/modules/cycling.ts
@@ -562,6 +562,15 @@ export class Cycling {
       });
     }
 
+    // Sync spanFillState.lastFilledText to the new buffer BEFORE setText —
+    // otherwise BlankFill._onTextChangeImpl sees the cycle output as a
+    // user edit inside the clear-on-edit span and wipes everything.
+    // Mirrors what cycleSpanFill does at the equivalent point.
+    const spanEntry = this.spanFillState?.current;
+    if (spanEntry && spanEntry.index === target.index) {
+      this.spanFillState!.set(spanEntry, newText);
+    }
+
     this.adapter.setText(newText);
     this.adapter.setCursorOffset(clampedCursor);
     this.adapter.forceRender();


### PR DESCRIPTION
## Summary

- `cycleBlankStep` (Path 2 — numeric step blanks like `brightness` / `volume`) updated the DynDef + called `setText` but never refreshed `spanFillState.lastFilledText`.
- Result: the cycle output landed in the buffer, then `BlankFill._onTextChangeImpl` compared the new text to the stale `lastFilledText` from the previous cycle, classified it as a user edit inside the `clearOnEdit` span, and `applyClearOnEdit` wiped the whole `"<keyword> <value>%"` pair. Buffer ended empty.
- `cycleSpanFill` (Path 0) already does this sync; `cycleBlankStep` was the only cycling path missing it. One-line fix gated on the entry's index matching the cycle target.

## Test plan

- [x] User-visible repro: type `brightness _`. Pre-fix: auto-populates to `brightness 80%`, then Ctrl+Alt+Right + Ctrl+Alt+Up wipes the whole buffer instead of cycling. Post-fix: cycles correctly to `brightness 90%`, `brightness 100%`, …
- [x] Volume blank verified to behave identically — same `blankStep:` shape, same bug, same fix.
- [x] Bumped `@opencues/runtime` 0.3.15 → 0.3.16 + CHANGELOG entry per `docs/architecture/versioning.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)