### PR TITLE
perf(shell): bundle src/app.tsx → dist/app.js on install

### DIFF
--- a/integrations/shell/patches/setup.sh
+++ b/integrations/shell/patches/setup.sh
@@ -91,13 +91,21 @@ if [[ -d "$IVM_SRC" ]]; then
   fi
 fi
 
-# ─── Bundle skipped (oc-edit runs src/app.tsx directly) ────────────
-# A `bun run bundle` (scripts/bundle.ts) is wired up and works, but
-# we hit a leftover .jsc-segfault issue with the bytecode experiment
-# that bit production usage. Until the daemon model (see
-# DAEMON-PLAN.md) is built, oc-edit runs src/app.tsx directly via
-# the bun shim — ~1s cold start per input-box open, but reliable.
-# To opt in manually, run `bun run bundle` from integrations/shell/.
+# ─── Pre-bundle src/app.tsx → dist/app.js ───────────────────────────
+# oc-edit prefers dist/app.js when present (falls back to src/app.tsx
+# transpile-on-load otherwise). The bundle is a pure perf win: cuts
+# per-launch transpile cost from ~2-3s to ~0.5s. Single cold launch
+# measured: 3.3s without dist/, 1.2s with. Tooling that spawns
+# multiple oc-edit processes concurrently amplifies the saving
+# because Bun's on-the-fly transpile contends across instances.
+#
+# The earlier bytecode-segfault concern is in scripts/bundle.ts as
+# `bytecode: false` — bundle output is plain ESM and safe.
+echo "  ▸ bundling src/app.tsx → dist/app.js"
+(
+  cd "$TERM_DIR"
+  bun run bundle 2>&1 | tee -a "$LOG" | grep -E "bundle:|error" || true
+) || echo "    (bundle step failed — oc-edit will fall back to src/app.tsx transpile-on-load)"
 
 # ─── Optional symlink ────────────────────────────────────────────────
 if [[ -n "$LINK_DIR" ]]; then


### PR DESCRIPTION
## Summary

- `oc-edit` already prefers `dist/app.js` when present and falls back to `src/app.tsx` transpile-on-load otherwise — the bundle is a pure perf win.
- Most visible under parallel launch contention where Bun's on-the-fly transpile contends across multiple `oc-edit` processes.

Measured impact:

| Scenario | Without `dist/` | With `dist/` |
|---|---|---|
| Single cold launch | 3.3s | 1.2s |
| 8 concurrent oc-edit | 7.6s | 4.8s (-37%) |
| 16 concurrent oc-edit | 29.9s | 13.7s (-54%) |

- Bundle is plain ESM (no bytecode — `scripts/bundle.ts` has `bytecode: false` since bun's bytecode loader segfaults in 1.3.x).
- Step is fault-tolerant: if `bun run bundle` fails for any reason, `oc-edit` still works via the transpile-on-load fallback.

## Test plan

- [x] `pnpm exec opencues install shell` — verified `integrations/shell/dist/app.js` produced (~31 KB, ~330ms bundle time).
- [x] Single cold shell launch measured before/after: 3.3s → 1.2s.
- [x] 8 and 16 concurrent oc-edit launches measured (see table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)