### PR TITLE
feat(runtime): enable fluid-config / identity-context / blank-context by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Scope of this section**: only changes tied to an actual package version bump are listed. The project shipped many other features and fixes since 0.1.0 (sentence cues, auditors, agent-rewrite, ambient/user context, etc.) without bumping versions at the time — those landed in source but aren't formally versioned, so they're tracked in git, not here. From now on, the rule in `docs/architecture/versioning.md` § Discipline keeps changelog entries and version bumps shipping together.
 
+### Feat — three semantic-_ surfaces enabled by default (runtime 0.3.18)
+
+`fluid-config-mode`, `identity-context-mode`, and `blank-context-mode` now default to enabled. Concretely:
+
+- `fluid-config-mode: on` (was `off`) — semantic `_` → settings-change classifier. Type `enable debug logging _`, `switch to cerebras _`, etc. and the matching OPENCUES.md scalar flips with a confirming satellite pair. One extra ~200-300ms LLM call per `_` (Cerebras prefix-cached, bench-validated 100% precision); routes ONLY to FEATURES registry scalars, never user blanks.
+- `identity-context-mode: safe` (was `off`) — `~/.cues/IDENTITY.md` fields advertised to the fluid-blank LLM as identity-context tokens; runtime post-processor substitutes real values AFTER the response, so PII never reaches provider logs. Users who never created an IDENTITY.md see no behavioural diff (empty catalog).
+- `blank-context-mode: safe` (was `off`) — script-backed blanks (stocks, weather, crypto, …) expose their current values as ambient tokens; a `_` lookup like `buy more apple if _` reaches AAPL without typing the `apple` keyword. Catalog of token names ships to the LLM; values substituted post-response.
+
+The shipped `defaults/OPENCUES.md` carries the new values explicitly. Three rollout paths for existing users:
+
+- `defaults/OPENCUES.md` shipped with explicit `identity-context-mode: safe` / `fluid-config-mode: on` / `blank-context-mode: safe`. Fresh installs get all three on out of the box.
+- `DEFAULT_OPENCUES_STATE` in `config-loader.ts` now sets `identityContextMode: 'safe'` and `blankContextMode: 'safe'`. Existing users whose OPENCUES.md doesn't declare these typed-state scalars automatically pick up the new defaults — no file edit needed.
+- `opencues seed-configs` (runs on every `opencues install`) self-heal-appends `fluid-config-mode: on` and `blank-context-mode: safe` to existing OPENCUES.md when the keys are absent. The runtime check for `fluid-config-mode` reads from the settings map (absent = off), so this self-heal is the only way existing users see the flipped fluid-config default; the appended block sits inside the frontmatter with a leading `# why` comment. Existing values are never overwritten — only absent keys are appended.
+
+Feature-registry "(default)" annotations updated to reflect the new defaults; menu-cycle UI labels rotate `on (default)` / `safe (default)` accordingly.
+
 ### Fix — shell bridge `resetBufferState` wiring + clear static variant pool (runtime 0.3.17)
 
 Two correctness bugs in the shell adapter / resolver reset path:

--- a/defaults/OPENCUES.md
+++ b/defaults/OPENCUES.md
@@ -36,17 +36,48 @@ ambient-context-mode: off
 # Pulls field data from ~/.cues/IDENTITY.md (your first name, email,
 # work city, etc.) and offers it to FluidBlankSource so `_` lookups
 # personalise without you re-typing the same info.
-#   off  (default): IDENTITY.md never read; no personal data reaches any prompt.
-#   safe          : catalog of TOKENS + descriptions injected. The LLM
+#   off          : IDENTITY.md never read; no personal data reaches any prompt.
+#   safe (default): catalog of TOKENS + descriptions injected. The LLM
 #                   emits `[FIRST NAME]` etc; a post-processor substitutes
 #                   your real values AFTER the response. Your PII never
 #                   reaches the LLM provider's logs.
+# Users who never created an IDENTITY.md see no behavioural diff — the
+# catalog is empty so no tokens reach the prompt.
 # A `raw` mode (catalog values inlined into the prompt) is also
 # implementation-complete but deferred to Phase 2 — set it directly
 # here if you want, but it's intentionally not exposed in the
 # selector-satellite menu to prevent accidental flips. See
 # docs/architecture/identity-context.md § Future work.
-identity-context-mode: off
+identity-context-mode: safe
+
+# fluid-config-mode — semantic `_` → settings-change classifier. When
+# a `_` lookup phrases the surrounding text like a settings change
+# ("enable debug logging _", "switch to cerebras _", "turn on voice
+# mode _"), one LLM call classifies it against the FEATURES registry
+# and applies the matched setting + drops a selector-satellite pair as
+# visual confirmation. Routes ONLY to OPENCUES scalars, never user
+# blanks (the routing layer's prompt enumerates only registry-cyclable
+# values; runtime guard rejects anything else).
+#   off          : `_` falls through to fluid-blank as a generic lookup.
+#   on (default) : every `_` pays one extra ~200-300ms LLM call (Cerebras
+#                  prefix-cached) to classify settings intent; on hit,
+#                  setting is applied. Bench-validated at 100% precision.
+# See docs/architecture/fluid-config.md.
+fluid-config-mode: on
+
+# blank-context-mode — blanks expose their current values as ambient
+# tokens for fluid-blank, so a `_` lookup can reach stock prices,
+# weather, crypto rates etc. WITHOUT typing the keyword. e.g. "buy
+# more apple if _" resolves AAPL even though the user didn't write
+# "apple _". `safe` ships a tokens-only catalog to the LLM; the
+# runtime post-processor substitutes live values AFTER the response.
+# Values never reach the provider's logs.
+#   off          : blanks only fire on the keyword-trigger path.
+#   safe (default): catalog of context-eligible blanks injected as tokens.
+# A `raw` mode (values inlined into the prompt) is implementation-
+# complete but kept off the menu; requires identity-context-mode: raw too.
+# See docs/architecture/blank-as-context.md.
+blank-context-mode: safe
 
 # Surface-availability flags. "on" means the surface is registered and
 # ready to fire when matching input appears; "off" (or omitted) means the

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/seed-configs.cjs
+++ b/packages/opencues-cli/src/commands/seed-configs.cjs
@@ -394,6 +394,47 @@ module.exports = function seedConfigs(argv, ctx) {
     if (rewritten !== original) fs.writeFileSync(settingsTarget, rewritten);
   }
 
+  // ── 3.0c HEAL — append flipped-default scalars to existing OPENCUES.md ──
+  //
+  // June 2026: flipped `fluid-config-mode` (off → on) and
+  // `blank-context-mode` (off → safe) defaults. The runtime read
+  // paths fall through to `absent === off` for these two — so users
+  // whose OPENCUES.md predates this change are silently frozen at
+  // the old default until they add the key.
+  //
+  // Append missing keys in-place so the user can see the new default
+  // in their file and edit it back if desired. Existing values are
+  // NEVER overwritten — only ABSENT keys are appended. Insertion goes
+  // before the closing frontmatter fence so the keys land inside the
+  // YAML block where the runtime parses them.
+  //
+  // identity-context-mode is NOT in this list because the runtime
+  // path uses DEFAULT_OPENCUES_STATE.identityContextMode='safe' as
+  // the absent-key fallback — existing users automatically pick up
+  // the new default without a file rewrite.
+  if (settingsTarget && fs.existsSync(settingsTarget) && fs.statSync(settingsTarget).size > 0) {
+    const original = fs.readFileSync(settingsTarget, 'utf8');
+    let rewritten = original;
+    const newDefaults = [
+      ['fluid-config-mode', 'on',
+       'Semantic `_` → settings-change classifier (FEATURES registry only, no user blanks). One LLM call per `_` to classify intent; ~99.5% Cerebras prefix-cache hit.'],
+      ['blank-context-mode', 'safe',
+       'Blanks expose values as ambient tokens for fluid-blank. `safe` = tokens-only catalog; values never reach provider logs.'],
+    ];
+    for (const [key, value, why] of newDefaults) {
+      if (new RegExp(`^${key}:\\s*`, 'm').test(rewritten)) continue;
+      const block = `\n# ${why}\n${key}: ${value}\n`;
+      // Find the closing `---` of the frontmatter (every OPENCUES.md
+      // has one, opening + closing). Insert block JUST before it.
+      const fmRe = /^(---\s*\n[\s\S]*?)(^---\s*$)/m;
+      if (fmRe.test(rewritten)) {
+        rewritten = rewritten.replace(fmRe, (_, head, close) => `${head}${block}${close}`);
+        log(`Self-heal: appended ${key}: ${value} to ${settingsTarget} (new default June 2026)`);
+      }
+    }
+    if (rewritten !== original) fs.writeFileSync(settingsTarget, rewritten);
+  }
+
   // ── 3.1 HEAL — rename legacy bucket scalars in OPENCUES.md ──
   //
   // The three-bucket simplification (cues / auditors / blanks)

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/feature-registry.ts
+++ b/packages/opencues-core/src/feature-registry.ts
@@ -317,8 +317,8 @@ export const FEATURES: readonly FeatureSpec[] = [
     description: 'Semantic `_` → settings-change routing (LLM classifier over the FEATURES registry)',
     menuTip: 'Route `_` to a settings change when no keyword matched ("stop showing tips _" → tips-mode=off). Only routes to OPENCUES settings, never user blanks.',
     values: [
-      { id: 'off', description: 'Disabled (default) — `_` falls through to fluid-blank as a lookup' },
-      { id: 'on',  description: 'Enabled — one LLM call classifies the surrounding text against the FEATURES registry; on hit, the matched setting is applied' },
+      { id: 'off', description: 'Disabled — `_` falls through to fluid-blank as a lookup' },
+      { id: 'on',  description: 'Enabled (default) — one LLM call classifies the surrounding text against the FEATURES registry; on hit, the matched setting is applied' },
     ],
   },
   {
@@ -544,8 +544,8 @@ export const FEATURES: readonly FeatureSpec[] = [
     description: 'Personal identity data injected into fluid-blank as context tokens',
     menuTip: 'Inject ~/.cues/IDENTITY.md fields (first name, email, etc.) as identity-context tokens into fluid-blank for personalised lookups.',
     values: [
-      { id: 'off',  description: 'Disabled (default) — IDENTITY.md never read' },
-      { id: 'safe', description: 'Tokens-only catalog sent to LLM; post-processor substitutes values after response. PII stays on the host.' },
+      { id: 'off',  description: 'Disabled — IDENTITY.md never read' },
+      { id: 'safe', description: 'Tokens-only catalog (default) sent to LLM; post-processor substitutes values after response. PII stays on the host.' },
       // `raw` mode (catalog values inlined into the prompt — PII
       // reaches the LLM provider) is implementation-complete but
       // intentionally NOT cycleable from the menu — flipping it should
@@ -569,8 +569,8 @@ export const FEATURES: readonly FeatureSpec[] = [
     description: 'Blanks expose their current values as ambient tokens for fluid-blank',
     menuTip: 'Expose context-eligible blanks (stocks, weather, crypto, …) as ambient tokens fluid-blank can reach without typing the keyword. See docs/features/blank-as-context.md.',
     values: [
-      { id: 'off',  description: 'Disabled (default) — blanks only fire on the keyword-trigger path' },
-      { id: 'safe', description: 'Tokens-only catalog; post-processor substitutes live values after response. Bench-validated at 100% on Cerebras + Groq.' },
+      { id: 'off',  description: 'Disabled — blanks only fire on the keyword-trigger path' },
+      { id: 'safe', description: 'Tokens-only catalog (default); post-processor substitutes live values after response. Bench-validated at 100% on Cerebras + Groq.' },
       // Same exposure rule as identity-context — raw is implemented but
       // kept off the menu. Requires identity-context-mode: raw too
       // (mode-gate composition pinned in docs/architecture/blank-as-context.md).

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/config-loader.test.ts
+++ b/packages/opencues-runtime/src/modules/config-loader.test.ts
@@ -117,18 +117,23 @@ some prose
     expect(parseOpenCuesMd('---\nambient-context-mode: on\n---').ambientContextMode).toBe('on');
   });
 
-  it('identity-context-mode defaults to off and only accepts safe/raw', () => {
-    // Same fail-closed contract as ambient-context-mode — the privacy
-    // model leans on `off` being the default + on unrecognised values
-    // not silently flipping the gate. See docs/architecture/sentinels.md.
-    expect(parseOpenCuesMd('---\n---').identityContextMode).toBe('off');
+  it('identity-context-mode: absent → safe (new default June 2026), explicit invalid → off (fail-closed)', () => {
+    // Two-tier semantics:
+    //   ABSENT key             → `safe` (shipped-seed default; tokens-only,
+    //                            no PII leak, no-op for users without IDENTITY.md).
+    //   Explicit valid value   → use it.
+    //   Explicit invalid value → `off` (fail-closed — the privacy gate must
+    //                            not silently flip on a typo).
+    // See docs/architecture/identity-context.md.
+    expect(parseOpenCuesMd('---\n---').identityContextMode).toBe('safe');
     expect(parseOpenCuesMd('---\nidentity-context-mode: off\n---').identityContextMode).toBe('off');
     expect(parseOpenCuesMd('---\nidentity-context-mode: safe\n---').identityContextMode).toBe('safe');
     expect(parseOpenCuesMd('---\nidentity-context-mode: raw\n---').identityContextMode).toBe('raw');
     // Case-insensitive.
     expect(parseOpenCuesMd('---\nidentity-context-mode: SAFE\n---').identityContextMode).toBe('safe');
     expect(parseOpenCuesMd('---\nidentity-context-mode: Raw\n---').identityContextMode).toBe('raw');
-    // Anything else stays off — typos / unexpected values fail closed.
+    // Anything else fails closed to off — typos / unexpected values must
+    // not silently flip the gate to safe (the new default).
     expect(parseOpenCuesMd('---\nidentity-context-mode: on\n---').identityContextMode).toBe('off');
     expect(parseOpenCuesMd('---\nidentity-context-mode: yes\n---').identityContextMode).toBe('off');
     expect(parseOpenCuesMd('---\nidentity-context-mode: true\n---').identityContextMode).toBe('off');

--- a/packages/opencues-runtime/src/modules/config-loader.ts
+++ b/packages/opencues-runtime/src/modules/config-loader.ts
@@ -255,8 +255,8 @@ export const DEFAULT_OPENCUES_STATE: OpenCuesState = {
   tipsMode: 'on',
   cursorNavigate: 'inactive',
   ambientContextMode: 'off',
-  identityContextMode: 'off',
-  blankContextMode: 'off',
+  identityContextMode: 'safe',
+  blankContextMode: 'safe',
   blankTriggerMode: 'immediate',
   navKeymap: 'auto',
   anthropicSubscription: 'prefer',
@@ -319,20 +319,35 @@ export function parseOpenCuesMd(content: string): OpenCuesState {
   // runtime — `opencues seed-configs` rewrites legacy
   // `sentinels-mode` / `user-context-mode` to `identity-context-mode`
   // on first install (see seed-configs.cjs:PRE-SEED MIGRATE).
-  const identityRaw = get('identity-context-mode', 'off').toLowerCase();
+  //
+  // Two-tier semantics (June 2026):
+  //   ABSENT key             → `safe` (the shipped-seed default).
+  //   Explicit valid value   → use it (`off` / `safe` / `raw`).
+  //   Explicit invalid value → `off` (fail-closed — the privacy gate
+  //                            should not silently flip on a typo).
+  // Users with an empty IDENTITY.md see no behavioural diff under
+  // `safe` — the catalog is empty so no tokens reach the prompt.
+  const identityHasKey = get('identity-context-mode', '__ABSENT__') !== '__ABSENT__';
+  const identityRaw = get('identity-context-mode', 'safe').toLowerCase();
   const identityContextMode: 'off' | 'safe' | 'raw' =
     identityRaw === 'safe' ? 'safe'
     : identityRaw === 'raw' ? 'raw'
-    : 'off';
-  // Blank-as-context scalar — independent of identity-context-mode but
-  // mode-gate composed: blankContextMode='raw' requires identityContextMode='raw'
-  // (silently downgrades to 'safe' otherwise so the user doesn't get
-  // surprised by a values-leak after flipping identity-context off).
-  const blankContextRaw = get('blank-context-mode', 'off').toLowerCase();
+    : identityRaw === 'off' ? 'off'
+    : identityHasKey ? 'off'   // explicit but unrecognised value → fail-closed
+    : 'safe';                  // truly absent → new default
+  // Blank-as-context scalar — same two-tier semantics as
+  // identity-context-mode above. Mode-gate composed: blankContextMode='raw'
+  // requires identityContextMode='raw' (silently downgrades to 'safe'
+  // otherwise so the user doesn't get surprised by a values-leak after
+  // flipping identity-context off).
+  const blankContextHasKey = get('blank-context-mode', '__ABSENT__') !== '__ABSENT__';
+  const blankContextRaw = get('blank-context-mode', 'safe').toLowerCase();
   let blankContextMode: 'off' | 'safe' | 'raw' =
     blankContextRaw === 'safe' ? 'safe'
     : blankContextRaw === 'raw' ? 'raw'
-    : 'off';
+    : blankContextRaw === 'off' ? 'off'
+    : blankContextHasKey ? 'off' // explicit but unrecognised → fail-closed
+    : 'safe';                    // absent → new default
   if (blankContextMode === 'raw' && identityContextMode !== 'raw') blankContextMode = 'safe';
   const blankTriggerMode: 'immediate' | 'spaced' =
     get('blank-trigger-mode', 'immediate').toLowerCase() === 'spaced' ? 'spaced' : 'immediate';

--- a/packages/opencues-runtime/src/modules/resolver.test.ts
+++ b/packages/opencues-runtime/src/modules/resolver.test.ts
@@ -1077,7 +1077,10 @@ describe('Resolver identity-context skip for keyword-bound slots (symmetric with
     const hlState = new HighlightState();
     const dynDefs = new DynDefs();
     const loader = new ConfigLoader(adapter, { settingsFile: '/proj/CUES.md' });
-    if (opts.mode && opts.mode !== 'off') {
+    // Write the mode unconditionally — June 2026 default flipped from
+    // off → safe, so an absent key now resolves to `safe` (not `off`).
+    // Tests that want `off` MUST write it explicitly.
+    if (opts.mode) {
       loader.applyOpenCuesScalar('identity-context-mode', opts.mode);
     }
 


### PR DESCRIPTION
## Summary

Three semantic-`_` surfaces now default to **enabled**:

| Scalar | Was | Now | What it does |
|---|---|---|---|
| `fluid-config-mode` | `off` | `on` | Semantic `_` → settings-change classifier. `enable debug logging _`, `switch to cerebras _` etc. flip the matching OPENCUES.md scalar + drop a satellite pair. Routes ONLY to FEATURES registry scalars — never user blanks. One ~200-300ms LLM call per `_` (Cerebras prefix-cached, bench-validated 100% precision). |
| `identity-context-mode` | `off` | `safe` | `~/.cues/IDENTITY.md` fields advertised to the fluid-blank LLM as identity-context tokens; runtime post-processor substitutes real values *after* the response. PII never reaches provider logs. Users without an IDENTITY.md see no behavioural diff (empty catalog). |
| `blank-context-mode` | `off` | `safe` | Script-backed blanks (stocks, weather, crypto, …) expose their current values as ambient tokens. `buy more apple if _` reaches AAPL without typing the `apple` keyword. Tokens-only catalog; values substituted post-response. |

## Rollout

Three tiers, each covering a gap the others can't:

1. **`defaults/OPENCUES.md`** ships explicit values → fresh installs configured out of the box.
2. **`DEFAULT_OPENCUES_STATE`** in `config-loader.ts` sets `identityContextMode: 'safe'` + `blankContextMode: 'safe'` as the absent-key fallback → existing users whose OPENCUES.md doesn't declare these typed scalars pick up the new defaults automatically.
3. **`seed-configs.cjs` self-heal 3.0c** appends `fluid-config-mode: on` + `blank-context-mode: safe` to existing OPENCUES.md when the keys are absent. `fluid-config-mode` is read via the settings-map path (absent === off), so this is the only path that covers existing users for that scalar. **Existing values are never overwritten — only absent keys are appended.**

## Two-tier semantics for the typed scalars

- Absent key             → new default (`safe`).
- Explicit valid value   → use it (`off` / `safe` / `raw`).
- Explicit invalid value → `off` (fail-closed — a typo must not silently flip the privacy gate to a more permissive state).

## Test plan

- [x] 1667/1667 runtime unit tests pass.
- [x] `config-loader` test updated for the two-tier semantics.
- [x] `resolver` identity-context test setup now writes the mode unconditionally (absent ≠ off anymore).
- [x] `feature-registry` "(default)" annotations flipped on the three scalars.
- [x] Self-heal idempotency verified: existing user values preserved; only absent keys appended; second run is a no-op.

`@opencues/runtime` 0.3.17 → 0.3.18 + CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)