### PR TITLE
fix(core): ConfigIntent summon boundary recognises CJK/fullwidth stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — ConfigIntent no longer nukes non-Latin prior content (core 0.3.34)
+
+`summonPhraseStart` scopes what a fluid-config `_` settings command wipes — everything from the last sentence boundary before `_` to the end, so prior user content is preserved (`hii world. voice mode off _` keeps "hii world."). Its boundary regex only recognised ASCII terminators with a trailing space (`[.!?](?=\s)`), so a buffer whose prior content ends in a **CJK/fullwidth** stop — `こんにちは世界。voice mode off _` — found *no* boundary, returned 0, and **wiped the user's whole sentence** (the config-intent nuke landmine, language-dependent variant). The regex now also matches `。！？．` directly (these scripts don't put a space after the stop). The ASCII `(?=\s)` lookahead is unchanged, so the `gpt-5.4` model-version-dot guard still holds. Pinned by 4 CJK/fullwidth cases (Japanese/Korean `。`, fullwidth `！`/`？`).
+
+> Note: the fuller "let the model emit the command span (`SUMMON`) so the boundary is language-invariant for *any* script" approach was prototyped and **rejected on evidence** — adding the field to the (English, heavily-tuned) classifier prompt regressed INTENT recall from ~85% → ~60% on the fluid-config bench and the model emitted the field on only ~10% of cases. The classifier prompt is too sensitive to carry a second job; the deterministic regex fix covers the realistic cases (the command itself is always English, only the prior content varies) without touching classification accuracy. The `TASK_TRIGGER_GUARD` / `LIKELY_INTENT_KEYWORDS` English keyword lists were left as-is for the same reason: both are guards *downstream* of English-keyword subsystems (transform-blank's triggers, the config-intent classifier), so removing them in isolation buys no real language-invariance.
+
 ### Changed — FluidBlank's FILL/WIPE choice is the model's call, with a deterministic data-loss floor (core 0.3.33)
 
 The fluid-blank `_` lookup decides between FILL (substitute only `_`, keep the surrounding words) and WIPE (replace the whole lookup phrase). That choice used to be made entirely by `determineReplaceMode` — an **English-anchored regex** (`\b(?:is|are|was|were|am|be|equals)\b` / `=` / `:` / `?` before `_`). It only ever worked for English sentence shapes: a French "…est _" or Spanish "…es _" would fall through to WIPE and collapse the user's sentence to a bare value.

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/config-intent-source.test.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.test.ts
@@ -650,4 +650,19 @@ describe('summonPhraseStart — preserve prior content (no whole-buffer nuke)', 
     assert.strictEqual(summonPhraseStart('really? voice mode off _'), 'really? '.length);
     assert.strictEqual(summonPhraseStart('wow! tips off _'), 'wow! '.length);
   });
+
+  it('CJK / fullwidth sentence terminators delimit too (language-invariant data-loss fix)', () => {
+    // The settings command is English (the classifier is English-only) but
+    // the prior content can be any language. CJK scripts use 。！？ with no
+    // trailing space, so the old ASCII-only `(?=\s)` regex found no boundary
+    // and nuked the user's whole sentence. These must now be preserved.
+    const ja = 'こんにちは世界。voice mode off _';
+    assert.strictEqual(ja.slice(0, summonPhraseStart(ja)), 'こんにちは世界。');
+    const ko = '안녕하세요。tips off _';
+    assert.strictEqual(ko.slice(0, summonPhraseStart(ko)), '안녕하세요。');
+    const fw = 'メモ！voice mode off _'; // fullwidth ！
+    assert.strictEqual(fw.slice(0, summonPhraseStart(fw)), 'メモ！');
+    const fwq = '質問？tips on _'; // fullwidth ？
+    assert.strictEqual(fwq.slice(0, summonPhraseStart(fwq)), '質問？');
+  });
 });

--- a/packages/opencues-core/src/sources/config-intent-source.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.ts
@@ -749,14 +749,17 @@ export interface ConfigIntentSourceConfig {
  * `[0, len)` and a buffer like `hii world. voice mode off _` lost
  * "hii world." entirely (the config-intent nuke landmine).
  *
- * Heuristic: the last sentence terminator (`.`/`!`/`?`) followed by
- * whitespace, or a line break, before `_`. No boundary found → 0 (the
- * whole buffer is the summon; behaviour unchanged from before). The
- * `(?=\s)` lookahead keeps model-version dots ("gpt-5.4") from being
- * mistaken for sentence ends.
+ * Heuristic: the last sentence terminator before `_`. ASCII terminators
+ * (`.`/`!`/`?`) require a trailing whitespace via the `(?=\s)` lookahead
+ * (so model-version dots like "gpt-5.4" aren't mistaken for sentence
+ * ends); CJK/fullwidth terminators (`。`/`！`/`？`/`．`) match directly
+ * because those scripts don't put a space after the stop — without them a
+ * Japanese buffer like `こんにちは世界。voice mode off _` found no boundary
+ * and wiped the user's whole sentence (a language-dependent data-loss bug).
+ * A line break is always a boundary. No boundary found → 0.
  */
 export function summonPhraseStart(text: string): number {
-  const re = /[.!?](?=\s)|\n/g;
+  const re = /[.!?](?=\s)|[。！？．]|\n/g;
   let start = 0;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) start = m.index + m[0].length;


### PR DESCRIPTION
## What

`summonPhraseStart` decides where a fluid-config `_` settings command begins, so the runtime wipes only the command and **preserves the user's prior content** (`hii world. voice mode off _` keeps "hii world."). Its boundary regex only matched ASCII terminators followed by whitespace (`[.!?](?=\s)`). A buffer whose prior content ends in a **CJK / fullwidth** stop —

```
こんにちは世界。voice mode off _
```

— matched nothing, returned `0`, and **wiped the whole sentence** including the Japanese text. That's the config-intent nuke landmine, in a language-dependent variant.

The fix: the regex now also matches `。！？．` directly (CJK/fullwidth scripts don't put a space after the stop). The ASCII `(?=\s)` lookahead is untouched, so the `gpt-5.4` model-version-dot guard still holds.

| Input | Before | After |
|---|---|---|
| `こんにちは世界。voice mode off _` | wipes everything ❌ | keeps `こんにちは世界。` ✅ |
| `안녕하세요。tips off _` | wipes everything ❌ | keeps `안녕하세요。` ✅ |
| `hello world. voice mode off _` | keeps `hello world. ` | unchanged ✅ |
| `use gpt-5.4 for cues _` | start 0 | unchanged ✅ |

Pinned by 4 new CJK/fullwidth test cases.

## Why this and not the model-driven version

This was item #4 of the "minimise opinions, rely on the model" pass. The philosophically-aligned version is to have the classifier **emit the command span** (`SUMMON`) so the boundary is language-invariant for *any* script (Thai has no sentence punctuation at all). I prototyped that and **rejected it on evidence**:

- Adding the `SUMMON` field to the (English, heavily-tuned) classifier prompt regressed **INTENT recall ~85% → ~60%** on the fluid-config bench (measured against the production prompt directly, cerebras-gpt-oss, deterministic temp 0 + seed 42). Same failure shape as #2's first cut, but trimming + tail-positioning the instruction only recovered to ~61%.
- The model emitted the field on only **~10%** of cases — so even ignoring the regression, the span would rarely be available.

The classifier prompt is too sensitive to carry a second job. The deterministic regex fix covers the realistic cases — the **command itself is always English** (the classifier only recognises English settings vocabulary), so only the *prior content* varies in language, and CJK is the dominant non-Latin, no-trailing-space case.

`TASK_TRIGGER_GUARD` / `LIKELY_INTENT_KEYWORDS` (the other half of the deferred #3) were left as-is for the same structural reason: both are guards *downstream* of English-keyword subsystems, so making them "language-invariant" in isolation buys nothing real — true multilingual support there is a much larger, separate effort (making transform-blank's triggers + the config-intent classifier themselves language-invariant).

## Tests

Full core suite green (1012 node + 177 vitest). No prompt change → no bench risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)