### PR TITLE
perf(core): Anthropic prompt caching — send system as a cache_control block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Performance — Anthropic prompt caching: ~90% cheaper input on cached system prompts (core 0.3.37)
+
+Every OpenCues system prompt is static per session (the cerebras prefix-cache relies on this), but the **Anthropic** provider was sending `system` as a plain string — which Anthropic never caches. So anthropic-routed buckets (auditors / agent-rewrite default to Sonnet; any bucket a user points at Claude) re-billed the full system prompt on every call. `ANTHROPIC.buildRequest` now sends `system` as a content-block array with a single `cache_control: { type: 'ephemeral' }` breakpoint, so the static prefix is cached and subsequent calls within the 5-minute TTL bill the prefix at ~10% of input price. The per-call user message sits after the breakpoint and stays uncached (correct — it's the only varying part).
+
+Measured (Sonnet, the ~3k-token fluid prompt, warm): input billing **3801 → 393 token-equiv (~90% cheaper)**, confirmed end-to-end through the production `buildProviderRequest` path (`cache_read_input_tokens=3787`, `input_tokens=11`). **This is a COST win, not a latency win** — at our prompt sizes the cached read doesn't change wall-clock (1720ms vs 1795ms, noise); it only cuts the bill. (Anthropic differs from cerebras here, where prefix caching *is* a 4× latency win.)
+
+**Model-dependent and harmless when it doesn't engage:** Sonnet / Opus / Fable cache from ~1k tokens, so all our 3–3.8k-token prompts cache there; Haiku-4-5 (the anthropic default for cues/blanks) has an effective floor of ~4–5k tokens, so our prompts mostly *don't* cache on it — but an unmet `cache_control` is silently ignored (no error, normal price, no write premium), so the change is strictly safe everywhere. Pinned by provider unit tests (system is a one-block array with the ephemeral breakpoint; user message uncached). Follow-up (deferred): a two-block split so FluidBlank's appended identity/blank-context catalogs sit *after* the breakpoint, keeping the big stable prefix cached even when a catalog changes.
+
 ### Performance — ConfigIntent's two LLM calls no longer stack: ~473ms → ~290ms per config command (core 0.3.36)
 
 The dedicated SUMMON span call (0.3.35) ran *after* the classifier, so a config command paid two serial round-trips. Two changes collapse that:

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/llm-provider.test.ts
+++ b/packages/opencues-core/src/llm-provider.test.ts
@@ -444,11 +444,16 @@ describe('anthropic provider — Messages API (different shape from OpenAI)', ()
       { apiKey: 'k' },
     );
     const body = JSON.parse(built.body);
-    assert.strictEqual(body.system, 'You are terse.');
+    // System is sent as a content-block array carrying a cache_control
+    // breakpoint (Anthropic prompt caching). The user message stays in
+    // `messages`, AFTER the cached prefix.
+    assert.deepStrictEqual(body.system, [
+      { type: 'text', text: 'You are terse.', cache_control: { type: 'ephemeral' } },
+    ]);
     assert.deepStrictEqual(body.messages, [{ role: 'user', content: 'explain X' }]);
   });
 
-  it('buildRequest: multiple system messages are joined with \\n\\n', () => {
+  it('buildRequest: multiple system messages are joined with \\n\\n inside the cached block', () => {
     const built = buildProviderRequest(
       'anthropic',
       {
@@ -462,7 +467,33 @@ describe('anthropic provider — Messages API (different shape from OpenAI)', ()
       { apiKey: 'k' },
     );
     const body = JSON.parse(built.body);
-    assert.strictEqual(body.system, 'Rule 1\n\nRule 2');
+    assert.deepStrictEqual(body.system, [
+      { type: 'text', text: 'Rule 1\n\nRule 2', cache_control: { type: 'ephemeral' } },
+    ]);
+  });
+
+  it('buildRequest: prompt caching — system carries a single ephemeral cache_control breakpoint; user message is uncached', () => {
+    const built = buildProviderRequest(
+      'anthropic',
+      {
+        model: 'claude-sonnet-4-6',
+        messages: [
+          { role: 'system', content: 'big stable system prompt' },
+          { role: 'user', content: 'per-call input that must NOT be cached' },
+        ],
+      },
+      { apiKey: 'k' },
+    );
+    const body = JSON.parse(built.body);
+    // Exactly one breakpoint, on the system block — everything up to and
+    // including it is the cached prefix; the user turn comes after.
+    assert.ok(Array.isArray(body.system));
+    assert.strictEqual(body.system.length, 1);
+    assert.deepStrictEqual(body.system[0].cache_control, { type: 'ephemeral' });
+    // The volatile user message is a plain string in messages — never marked.
+    assert.deepStrictEqual(body.messages, [
+      { role: 'user', content: 'per-call input that must NOT be cached' },
+    ]);
   });
 
   it('buildRequest: max_tokens defaulted to 1024 when caller omits it', () => {

--- a/packages/opencues-core/src/llm-provider.ts
+++ b/packages/opencues-core/src/llm-provider.ts
@@ -932,7 +932,23 @@ const ANTHROPIC: ProviderAdapter = {
       messages: nonSystem,
     };
     if (systemMessages.length > 0) {
-      body.system = systemMessages.map((m) => m.content).join('\n\n');
+      const systemText = systemMessages.map((m) => m.content).join('\n\n');
+      // Send `system` as a content-block array with a cache_control
+      // breakpoint so Anthropic caches the (static) system prefix. On
+      // subsequent calls within the 5-minute ephemeral TTL the cached
+      // prefix bills at ~10% of input price (measured: ~90% cheaper input
+      // on sonnet for our ~3k-token prompts). The per-call user message
+      // sits AFTER the breakpoint and stays uncached — correct, it's the
+      // only part that varies. Harmless below a model's cache floor
+      // (sonnet/opus cache from ~1k tokens; haiku-4-5's effective floor is
+      // ~4-5k, so our 3-3.8k prompts mostly don't cache there): an
+      // unmet cache_control is silently ignored — no error, normal price,
+      // no write premium (writes only bill extra when caching actually
+      // happens). This is a COST optimisation, not latency — at our prompt
+      // sizes the cached read doesn't change wall-clock, only the bill.
+      body.system = [
+        { type: 'text', text: systemText, cache_control: { type: 'ephemeral' } },
+      ];
     }
     // Claude 4.x models reject `temperature` outright (Anthropic API change,
     // June 2026). See `modelRejectsTemperature` for the full matrix.


### PR DESCRIPTION
## What

OpenCues system prompts are static per session, but `ANTHROPIC.buildRequest` sent `system` as a plain **string** — which Anthropic never caches. So any bucket routed to Claude (auditors / agent-rewrite default to Sonnet) re-billed the full system prompt on every call. Now `system` is a content-block array with a single ephemeral `cache_control` breakpoint:

```js
body.system = [{ type: 'text', text: systemText, cache_control: { type: 'ephemeral' } }];
```

The static prefix caches; subsequent calls within the 5-min TTL bill it at ~10% of input price. The per-call user message sits **after** the breakpoint and stays uncached (correct — it's the only varying part).

## Benchmark (Sonnet, ~3k-token fluid prompt, warm)

| | input billing | latency |
|---|---|---|
| string `system` (before) | 3801 tokens | 1720ms |
| `cache_control` array (after) | **393 token-equiv (~90% cheaper)** | 1795ms (noise) |

Confirmed end-to-end through the production `buildProviderRequest` path: `cache_read_input_tokens=3787`, `input_tokens=11`.

**This is a COST win, not a latency win.** At our prompt sizes the cached read doesn't change wall-clock — it only cuts the bill. (Anthropic differs from cerebras, where prefix caching *is* a 4× latency win — that's why the earlier "warmth" framing turned out to mean cost here, not speed.)

## Model-dependent, harmless when it doesn't engage

Measured cache floors on this API:

| model | effective floor | our 3–3.8k-token prompts |
|---|---|---|
| Sonnet / Opus / Fable | ~1k tokens | **cache** ✅ |
| Haiku-4-5 (anthropic default for cues/blanks) | ~4–5k tokens | mostly **don't** cache |

An unmet `cache_control` is silently ignored by Anthropic — no error, normal price, **no write premium** (writes only bill extra when caching actually happens). So the change is strictly safe on every model; it just doesn't help below a model's floor.

## Tests

Provider unit tests updated/added: `system` is a one-block array carrying the ephemeral breakpoint; the user message stays uncached. Full core suite green (1023). (Runtime's `brightness-blank.sh` smoke test flakes on a 5s timeout reading system brightness in the headless sandbox — unrelated; passes on isolated re-run.)

## Follow-up (deferred)

A two-block `system` split so FluidBlank's appended identity/blank-context catalogs sit *after* the breakpoint — keeps the big stable prefix cached even when a catalog changes. Not needed for v1 (safe mode keeps catalogs stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)