### PR TITLE
fix(core): FluidBlank MODE field — empty-answer bleed + identity-binding regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — FluidBlank MODE field no longer corrupts the buffer or breaks identity-context binding (core 0.3.38)
+
+The agentic suite caught two regressions from the FILL/WIPE `MODE` field (0.3.33):
+
+- **Empty-ANSWER bleed → "MODE: WIPE" spliced into the buffer.** `parseFused`'s answer regex used `[\s\S]*?`, which crosses newlines. With the trailing `MODE:` line now in the output, an *empty* `ANSWER:` made the regex capture the next line — the literal `MODE: WIPE` — and splice it into the buffer, replacing the user's text. The answer capture is now single-line (`.*?`), matching the SPAN/SUMMON parsers: an empty answer parses to `null` and bails cleanly. Pinned by a regression test (`ANSWER:` empty + `MODE: WIPE` → no results).
+
+- **MODE rules suppressed identity-context token emission.** The MODE-rules paragraph lived at the tail of `FUSED_SYSTEM_PROMPT`, i.e. *before* the identity/blank-context catalog (which is appended at assembly time). With the rules wedged between the examples and the catalog, the model stopped emitting an ANSWER for safe-mode identity lookups — `i work at _` returned nothing instead of `[COMPANY]` (agentic scenario 54). Fix: the rules are extracted to a `MODE_RULES` constant and appended **after** the catalog blocks, so the model reads the catalog right after the examples (as it did pre-0.3.33). Validated on cerebras: identity binding 4/4 (was 2/4), FILL/WIPE 6/6 (French/Spanish copulas correctly FILL), fluid-blank-ambient bench back to 176/176. The OUTPUT-FORMAT `MODE:` line is now self-contained (no dangling "see MODE RULES" reference).
+
+Root cause both times: the fused prompt is sensitive to *where* an instruction sits relative to the per-call catalog, and the ambient bench has no identity-context cases so it never flagged it — the agentic harness did. End-to-end verified: scenarios 53 / 54 / 58 (identity-context), 09 (fluid-blank), 11 (copula), 102 (config-intent) all green on opencode.
+
 ### Performance — Anthropic prompt caching: ~90% cheaper input on cached system prompts (core 0.3.37)
 
 Every OpenCues system prompt is static per session (the cerebras prefix-cache relies on this), but the **Anthropic** provider was sending `system` as a plain string — which Anthropic never caches. So anthropic-routed buckets (auditors / agent-rewrite default to Sonnet; any bucket a user points at Claude) re-billed the full system prompt on every call. `ANTHROPIC.buildRequest` now sends `system` as a content-block array with a single `cache_control: { type: 'ephemeral' }` breakpoint, so the static prefix is cached and subsequent calls within the 5-minute TTL bill the prefix at ~10% of input price. The per-call user message sits after the breakpoint and stays uncached (correct — it's the only varying part).

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.37",
+  "version": "0.3.38",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/fluid-blank-source.test.ts
+++ b/packages/opencues-core/src/sources/fluid-blank-source.test.ts
@@ -340,6 +340,22 @@ describe('FluidBlankSource — model-decided MODE field', () => {
     assert.strictEqual(r.spanEnd, 7 + 'capital of france _'.length);
   });
 
+  it('empty ANSWER followed by a MODE line bails — never splices "MODE: WIPE" into the buffer (regression)', async () => {
+    // Agentic scenario 54 caught this: the model emitted an empty ANSWER,
+    // and the answer regex (`[\s\S]*?`) bled across the newline and captured
+    // the trailing "MODE: WIPE" line as the answer — which then got spliced
+    // into the buffer, replacing the user's text with the literal string
+    // "MODE: WIPE". An empty answer must parse to null and bail.
+    const src = new FluidBlankSource({
+      ...baseConfig,
+      httpAdapter: makeMockAdapter([
+        'SPAN: i work at _\nANSWER:\nMODE: WIPE',
+      ]),
+    });
+    const result = await src.getCues(ctxFromText('i work at _'));
+    assert.deepStrictEqual(result.results, []);
+  });
+
   it('falls back to the heuristic when the model omits MODE', async () => {
     // No MODE line — the runtime uses determineReplaceMode('capital of
     // france _') === 'WIPE'. (Mirrors a weaker label-format model.)

--- a/packages/opencues-core/src/sources/fluid-blank-source.ts
+++ b/packages/opencues-core/src/sources/fluid-blank-source.ts
@@ -173,7 +173,7 @@ NEVER invent a bracket-token from the "covers:" hint. The covers list contains s
 Output exactly three lines, nothing else:
 SPAN: <the contiguous substring of the input including _, OR the literal word NONE>
 ANSWER: <the value that should replace the SPAN; empty when SPAN=NONE>
-MODE: <FILL or WIPE — see MODE RULES>
+MODE: <WIPE if the whole input is a terse lookup phrase the ANSWER replaces; FILL if the ANSWER fills a gap in a sentence and the surrounding words stay>
 
 SPAN RULES:
 1. SPAN is an exact contiguous substring of the input, including the underscore.
@@ -418,9 +418,22 @@ INPUT: UK _
 label: Country
 </UNTRUSTED_FIELD_CONTEXT>
 SPAN: UK _
-ANSWER: United Kingdom
+ANSWER: United Kingdom`;
 
-MODE (the third output line — classify by SHAPE, so it holds in any language): WIPE when the input is a terse standalone lookup phrase whose whole text is replaced by the ANSWER ("capital of france _" → Paris, "unicode for ampersand _" → U+0026) — this is the common case. FILL when the input is a sentence and the ANSWER drops into the gap, keeping the surrounding words: _ after a copula/equation/question ("the cube root of 27 is _" → 3, "3 + 4 = _" → 7) or _ mid-sentence with the ANSWER restating the clause ("Water boils at _ degrees Celsius"). SPAN=NONE → FILL.`;
+/**
+ * MODE rules for the third output line. Kept SEPARATE from
+ * FUSED_SYSTEM_PROMPT and appended AFTER the identity/blank-context catalog
+ * blocks at assembly time (see getCues). Position is load-bearing: when this
+ * paragraph sat *before* the catalog (its original #170 home, since the
+ * catalog is appended after the base prompt), it suppressed ANSWER emission
+ * for catalog lookups — `i work at _` returned no ANSWER at all (agentic
+ * scenario 54). Moving it AFTER the catalog lets the model read the catalog
+ * right after the examples (as it did pre-#170) and restores token binding,
+ * while still steering FILL/WIPE language-invariantly (French/Spanish
+ * copulas → FILL). Validated: 4/4 identity binding + 6/6 FILL/WIPE on
+ * cerebras.
+ */
+export const MODE_RULES = `MODE RULES — classify by SHAPE, holds in any language: WIPE when the input is a terse standalone lookup phrase the ANSWER replaces ("capital of france _" → Paris). FILL when the input is a sentence and the ANSWER fills a gap keeping the surrounding words: _ after a copula/equation/question ("the cube root of 27 is _" → 3; "la capital de españa es _") or _ mid-sentence ("Water boils at _ degrees Celsius"). SPAN=NONE → FILL.`;
 
 /**
  * Decide whether the user wants the answer to FILL the `_` (preserve the
@@ -978,7 +991,11 @@ export class FluidBlankSource implements CueSource {
       // background and stopped pairing it with the input. Identity +
       // blank-context catalogs ARE safe in system because they carry
       // session-stable reference data, not per-call binding hints.
-      const fullSystem = `${FUSED_SYSTEM_PROMPT}${userCatalogBlock}${blankContextBlock}`;
+      // MODE_RULES go LAST — AFTER the catalog blocks — so the model reads
+      // the catalog right after the examples (preserving token binding) and
+      // the FILL/WIPE steering doesn't wedge between examples and catalog.
+      // See MODE_RULES doc comment for why position matters.
+      const fullSystem = `${FUSED_SYSTEM_PROMPT}${userCatalogBlock}${blankContextBlock}\n\n${MODE_RULES}`;
       const fusedUser = `INPUT: ${effectiveText}${ambientBlock}`;
       // Per-feature override: `fluid-blank-max-tokens:` in OPENCUES.md.
       // 512 default is bench-tuned for short-factual answers.
@@ -1339,7 +1356,16 @@ function normalizeMode(raw: string | undefined | null): 'FILL' | 'WIPE' | null {
 
 function parseFused(raw: string): FusedResult {
   const spanMatch = raw.match(/^SPAN:\s*(.*?)$/m);
-  const answerMatch = raw.match(/^ANSWER:\s*([\s\S]*?)\s*$/m);
+  // Single-line capture (`.*?`, not `[\s\S]*?`). Fluid answers are always a
+  // single line (a terse value or one restated clause), and since the fused
+  // output now carries a trailing `MODE:` line (added with the FILL/WIPE
+  // field), a multi-line `[\s\S]*?` capture would BLEED across the newline:
+  // an EMPTY `ANSWER:` followed by `MODE: WIPE` made the regex grab
+  // "MODE: WIPE" as the answer and splice it into the buffer. Bounding the
+  // capture to the answer's own line makes an empty answer parse as "" →
+  // null → a clean bail, never a destructive literal. (The strict-JSON path
+  // is unaffected — JSON parsing has no such bleed.)
+  const answerMatch = raw.match(/^ANSWER:[ \t]*(.*?)[ \t]*$/m);
   const modeMatch = raw.match(/^MODE:\s*(.*?)$/m);
   const spanRaw = spanMatch ? spanMatch[1].trim() : '';
   const ansRaw = answerMatch ? answerMatch[1].trim() : '';


### PR DESCRIPTION
The agentic suite caught two regressions from the FILL/WIPE `MODE` field (#170 / 0.3.33). Both are fixed here.

## 1. Empty-ANSWER bleed → buffer corruption

`parseFused`'s answer regex used `[\s\S]*?` (crosses newlines). With the trailing `MODE:` line now in the output, an **empty** `ANSWER:` made the regex capture the *next* line — the literal `MODE: WIPE` — and splice it into the buffer, **replacing the user's text with "MODE: WIPE"**.

```
FluidBlank: substituting "i work at _" → "MODE: WIPE" (mode=WIPE, ...)   ← the bug, from the log
```

Fix: answer capture is now single-line (`.*?`), matching the SPAN/SUMMON parsers. An empty answer parses to `null` and bails cleanly. Regression test added (`ANSWER:` empty + `MODE: WIPE` → no results).

## 2. MODE rules suppressed identity-context binding

The MODE-rules paragraph lived at the **tail of `FUSED_SYSTEM_PROMPT`** — i.e. *before* the identity/blank-context catalog, which is appended at assembly time. Wedged between the examples and the catalog, it made the model stop emitting an ANSWER for safe-mode identity lookups:

```
WITHOUT MODE (pre-#170):  i work at _ → [COMPANY]   my company is _ → [COMPANY]
WITH MODE (broken):       i work at _ → (no ANSWER)  my company is _ → (no ANSWER)
```

Fix: extract the rules to a `MODE_RULES` constant and append them **after** the catalog blocks, so the model reads the catalog right after the examples (as it did pre-#170). The OUTPUT-FORMAT `MODE:` line is now self-contained (no dangling "see MODE RULES").

## Validation (cerebras + agentic on opencode)

| check | before | after |
|---|---|---|
| identity binding (`i work at _`, company, pronouns, phone, linkedin) | 2/4 | **4/4** |
| FILL/WIPE effective (EN/FR/ES/DE) | — | **6/6** (FR/ES copulas → FILL) |
| fluid-blank-ambient bench | 176/176 | **176/176** |
| agentic 53/54/58 (identity), 09 (fluid), 11 (copula), 102 (config-intent) | 54 ✗ | **all ✓** |

Core 1024 + runtime 1647 unit tests green.

## Root cause (worth noting)

Both regressions trace to the same thing: **the fused prompt is sensitive to *where* an instruction sits relative to the per-call catalog**, and the `fluid-blank-ambient` bench has no identity-context cases — so it never flagged it. The **agentic harness** did (this is exactly the cross-component-journey class of bug it exists for). The MODE field has now needed three position adjustments; if it regresses again it's a candidate for moving to a dedicated call (the non-overloading pattern proven by ConfigIntent's SUMMON) or reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)