### PR TITLE
chore(chrome): bump to 0.2.23 — rebuild on core 0.3.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — chrome 0.2.23: rebuild on core 0.3.38
+
+Version bump for the chrome extension to ship a fresh bundle baking in the core changes from this cycle (provider capability model, FluidBlank FILL/WIPE + MODE fixes, ConfigIntent language-invariant command boundary + parallel span, Anthropic prompt caching). No chrome `src/` changes — `manifest.json` + `package.json` bumped in lockstep so a reload in `chrome://extensions` is confirmable.
+
 ### Fixed — FluidBlank MODE field no longer corrupts the buffer or breaks identity-context binding (core 0.3.38)
 
 The agentic suite caught two regressions from the FILL/WIPE `MODE` field (0.3.33):

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {


### PR DESCRIPTION
Version bump so the chrome extension ships a fresh bundle baking in this cycle's core changes (#169–#175: provider capability model, FluidBlank FILL/WIPE + MODE fixes, ConfigIntent language-invariant command boundary + parallel span, Anthropic prompt caching).

- No chrome `src/` changes — this is a bundle rebuild.
- `manifest.json` **and** `package.json` bumped in lockstep (0.2.22 → 0.2.23) per the repo rule, so a reload in `chrome://extensions` shows a new version string and is confirmable.
- Already built + deployed to the WSL mirror (`C:\Users\wilfred\AppData\Local\opencues-chrome`); `doctor` shows chrome at core 0.3.38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)