### PR TITLE
fix(core): sentence-cue segmenter splits CJK text at 。！？

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — sentence-cues segment CJK text at the ideographic full stop (core 0.3.39)
+
+`segmentSentences` only recognised ASCII terminators with a trailing-space rule (`[.!?]+(?=\s|$)`). CJK scripts use `。！？` with no space after the stop, so a Japanese/Chinese paragraph collapsed into **one giant "sentence"** — and the sentence-cue highlight on Claude Code selected the whole block (observed live: a ~460-char Japanese buffer highlighted as `[0,464]` instead of the first sentence). The segmenter now also splits on CJK/fullwidth terminators `。！？．` directly (no trailing space required, like ConfigIntent's CJK summon boundary in 0.3.34); the CJK comma `、` is deliberately not a terminator. ASCII behaviour is byte-identical (the `gpt-5.4` / `e.g.` / URL-dot mid-token guard is unchanged), so the English sentence-cues bench is unaffected. Pinned by 3 CJK tests (ideographic `。`, comma-is-not-a-terminator, fullwidth `！`/`？`).
+
 ### Changed — chrome 0.2.23: rebuild on core 0.3.38
 
 Version bump for the chrome extension to ship a fresh bundle baking in the core changes from this cycle (provider capability model, FluidBlank FILL/WIPE + MODE fixes, ConfigIntent language-invariant command boundary + parallel span, Anthropic prompt caching). No chrome `src/` changes — `manifest.json` + `package.json` bumped in lockstep so a reload in `chrome://extensions` is confirmable.

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/sentence-cue-source.test.ts
+++ b/packages/opencues-core/src/sources/sentence-cue-source.test.ts
@@ -91,6 +91,32 @@ describe('segmentSentences', () => {
     const spans = segmentSentences(text, text.split(/\s+/));
     assert.strictEqual(spans.length, 3);
   });
+
+  it('splits CJK sentences at the ideographic full stop 。 (no trailing space)', () => {
+    // Regression: a Japanese paragraph used to collapse into ONE giant
+    // "sentence" (the regex only knew ASCII .!? + a trailing-space rule,
+    // which CJK doesn't use) — so the sentence-cue highlight selected the
+    // whole block. Observed live on Claude Code.
+    const text = 'HTMLを使用します。サイトはモバイルです。次の文です。';
+    const spans = segmentSentences(text, text.split(/\s+/));
+    assert.strictEqual(spans.length, 3);
+    assert.strictEqual(spans[0].text, 'HTMLを使用します。');
+    assert.strictEqual(spans[1].text, 'サイトはモバイルです。');
+    assert.strictEqual(spans[2].text, '次の文です。');
+  });
+
+  it('treats the CJK comma 、 as NOT a sentence terminator', () => {
+    const text = 'HTML、CSS を使用して、設計します。次は開発します。';
+    const spans = segmentSentences(text, text.split(/\s+/));
+    assert.strictEqual(spans.length, 2);
+    assert.strictEqual(spans[0].text, 'HTML、CSS を使用して、設計します。');
+  });
+
+  it('splits fullwidth ！ and ？ too', () => {
+    const text = 'すごい！本当に？はい。';
+    const spans = segmentSentences(text, text.split(/\s+/));
+    assert.strictEqual(spans.length, 3);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/opencues-core/src/sources/sentence-cue-source.ts
+++ b/packages/opencues-core/src/sources/sentence-cue-source.ts
@@ -62,10 +62,16 @@ export interface SentenceSpan {
 /**
  * Split a buffer into sentences with char + word offsets.
  *
- * Strategy: regex match runs of non-terminator chars followed by one
- * or more terminators (`.!?`) AND either whitespace or EOF. Trim each
- * match so leading/trailing whitespace stays in the buffer (offsets
- * map to the first / last non-whitespace char).
+ * Strategy: regex match runs of non-terminator chars followed by a
+ * terminator. ASCII terminators (`.!?`) must be followed by whitespace
+ * or EOF (so "gpt-5.4", "e.g.", and URL dots don't split mid-token);
+ * CJK / fullwidth terminators (`。！？．`) split directly because those
+ * scripts don't put a space after the stop — without them a Japanese /
+ * Chinese paragraph collapsed into ONE giant "sentence" and the
+ * sentence-cue highlight selected the whole block instead of the first
+ * sentence (same language-dependent class as ConfigIntent's CJK summon
+ * boundary). The CJK comma `、` is deliberately NOT a terminator. Trim
+ * each match so leading/trailing whitespace stays in the buffer.
  *
  * Known limitations (intentional v1 simplifications):
  *  - Abbreviations ("Mr.", "Dr.", "e.g.") split mid-word.
@@ -78,7 +84,7 @@ export interface SentenceSpan {
 export function segmentSentences(buffer: string, words: ReadonlyArray<string>): SentenceSpan[] {
   if (!buffer) return [];
   const spans: SentenceSpan[] = [];
-  const re = /[^.!?]+(?:[.!?]+(?=\s|$)|$)/g;
+  const re = /[^.!?。！？．]+(?:[.!?]+(?=\s|$)|[。！？．]+|$)/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(buffer)) !== null) {
     const raw = m[0];


### PR DESCRIPTION
## What

Reported live on Claude Code: with Japanese text, sentence-cue selection grabs the whole paragraph instead of one sentence. The log confirmed it — a ~460-char Japanese buffer highlighted as `{start:0, end:464}` (one giant "sentence").

`segmentSentences` only recognised ASCII terminators with a trailing-space rule (`[.!?]+(?=\s|$)`). CJK scripts use `。！？` **with no space after the stop**, so the regex never split on them and treated the entire paragraph as one sentence.

Fix: the segmenter now also splits on CJK / fullwidth terminators `。！？．` directly (no trailing-space requirement) — the same language-dependent class as ConfigIntent's CJK summon boundary (0.3.34). The CJK comma `、` is deliberately *not* a terminator.

```
JA "HTMLを使用します。サイトはモバイルです。次の文です。"
  before → ["HTMLを使用します。サイトはモバイルです。次の文です。"]   (1 giant)
  after  → ["HTMLを使用します。", "サイトはモバイルです。", "次の文です。"]   ✅
```

## No ASCII regression

The added CJK chars never match in English text, so `[^.!?。！？．]+` and the new `[。！？．]+` branch are inert on ASCII — segmentation is **byte-identical** for English (verified: normal prose, the `gpt-5.4` mid-token quirk, URLs — all unchanged). The English sentence-cues bench is therefore unaffected (re-ran on cerebras: all categories at baseline).

## Tests

3 new CJK cases (ideographic `。` split, comma `、` is-not-a-terminator, fullwidth `！`/`？`). Core suite 1027 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)