### PR TITLE
fix(core): transform-blank fills a matching placeholder instead of appending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — transform-blank fused mode: "add <field> <value>" fills a matching placeholder instead of appending a label line (core 0.3.43)
+
+A transform command issued at the BOTTOM of a long document — e.g. a resignation letter ending `…+44 7700 900123 add recipient name Karen _` over a body that opens `Dear [Recipient Name],` — was **nondeterministic** on the fused path (cerebras and the other capable generalists). The model sometimes filled the placeholder (`Dear Karen,`) and sometimes **appended a literal `Recipient Name: Karen` line at the end, leaving `[Recipient Name]` untouched**. "Iterating on bits from the bottom" of a template hit this constantly.
+
+Root cause: the fused `FUSED_SYSTEM` prompt had an ADD/APPEND rule but **no placeholder-fill rule**, so "add …" followed the append rule. The 3-pass `P2_APPLY_SYSTEM` prompt (groq's path) already had a FILL PLACEHOLDER rule (#12a) — so groq filled and cerebras drifted. Fix: port a **FILL PLACEHOLDER** rule into the fused prompt with explicit **precedence over ADD/APPEND** — when the instruction supplies a value for a named field and a matching placeholder (`[Recipient Name]`, `[Name]`, `[Date]`, `___`, …) already exists, replace it in place by keyword overlap, no matter how far the placeholder sits from the trailing `_`. A genuine "add a paragraph about X" with no matching placeholder still appends (regression-checked).
+
+Verified on the real cerebras gpt-oss-120b fused path: the exact failing letter now fills the placeholder **12/12 runs** (was intermittent), all four placeholder-label variants (`[Recipient Name]` / `[Name]` / `[Your Name]` / `___`) fill, and the append-a-paragraph case still appends. Pinned by `transform-blank-placeholder-fill.test.ts` (prompt-contract guard on both prompts + fill-substitute plumbing) and three `targeted-placeholder-fill-*` benchmark cases (two fill + one append-regression, all PASS through the pinned judge). Full core suite green (1043 + 177).
+
 ### Fixed — multi-paragraph CJK sentence-cues: long all-Japanese paragraphs are now cued, highlighted, navigable, and cycleable (core 0.3.42 / runtime 0.3.27)
 
 Follow-up to the multi-paragraph fix below. On a realistic translated buffer (three Japanese paragraphs, the last a single ~180-char sentence) the later all-Japanese text still wasn't dimmed/selected. Four independent failures, each downstream of "CJK + long sentences," each fixed and verified end-to-end on Claude Code (Cerebras gpt-oss-120b):

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/transform-blank-placeholder-fill.test.ts
+++ b/packages/opencues-core/src/sources/transform-blank-placeholder-fill.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the FILL-PLACEHOLDER behaviour of TransformBlankSource.
+ *
+ * Bug (June 2026): a transform command issued at the BOTTOM of a long
+ * document ("…+44 7700 900123 add recipient name Karen _") over a buffer
+ * containing a matching placeholder at the TOP ("Dear [Recipient Name],")
+ * was nondeterministic on the FUSED path (cerebras): the model sometimes
+ * FILLED the placeholder ("Dear Karen,") and sometimes APPENDED a literal
+ * "Recipient Name: Karen" line, leaving the placeholder untouched. Root
+ * cause: the fused prompt had an ADD/APPEND rule but NO placeholder-fill
+ * rule — the 3-pass APPLY prompt (groq path) already had one (rule #12a),
+ * so groq filled and cerebras drifted. Fix: port a FILL PLACEHOLDER rule
+ * into FUSED_SYSTEM with precedence over ADD/APPEND, matching the chosen
+ * "prefer filling the placeholder" behaviour.
+ *
+ * These are deterministic pins:
+ *   1. PROMPT CONTRACT — both prompts (fused + 3-pass APPLY) must carry a
+ *      placeholder-fill rule with precedence over append. A mock can't
+ *      validate prompt CONTENT (it returns canned output), so this guard
+ *      is what stops the rule being silently deleted; the real accuracy
+ *      validation is the LLM bench (tests/benchmarks/transform-blank,
+ *      `targeted-placeholder-*` cases).
+ *   2. PLUMBING — a fill-shaped fused response is carried through getCues
+ *      as a whole-buffer substitute (placeholder filled, command stripped),
+ *      not dropped or mangled.
+ */
+
+import { describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { TransformBlankSource, FUSED_SYSTEM, P2_APPLY_SYSTEM } from './transform-blank-source';
+import { getProvider } from '../llm-provider';
+import type { HttpAdapter, CueContext } from '../types';
+
+function mockAdapter(responses: string[]): { adapter: HttpAdapter; calls: number } {
+  const state = { calls: 0 };
+  const adapter: HttpAdapter = {
+    post: async (_url, _body) => {
+      const text = responses[state.calls] ?? '';
+      state.calls++;
+      return JSON.stringify({ choices: [{ message: { content: text } }] });
+    },
+  };
+  return { adapter, get calls() { return state.calls; } };
+}
+
+describe('TransformBlank — FILL PLACEHOLDER prompt contract', () => {
+  it('FUSED_SYSTEM carries a placeholder-fill rule with precedence over append', () => {
+    assert.match(FUSED_SYSTEM, /FILL PLACEHOLDER/,
+      'fused prompt must name the FILL PLACEHOLDER rule');
+    assert.match(FUSED_SYSTEM, /takes precedence over ADD\/APPEND/i,
+      'fill rule must declare precedence over the append rule');
+    // The canonical failing instruction must appear as a worked example so
+    // the model has a concrete fill-not-append anchor.
+    assert.match(FUSED_SYSTEM, /add recipient name Karen/,
+      'fused prompt must include the recipient-name fill example');
+    assert.match(FUSED_SYSTEM, /Dear Karen,/,
+      'fused example must show the placeholder filled, not appended');
+  });
+
+  it('3-pass APPLY prompt still carries its FILL PLACEHOLDER rule (the bug-class twin)', () => {
+    assert.match(P2_APPLY_SYSTEM, /FILL PLACEHOLDER/,
+      '3-pass APPLY prompt must keep its placeholder-fill rule');
+  });
+});
+
+describe('TransformBlank — FILL PLACEHOLDER plumbing (fused)', () => {
+  const letter = [
+    'Dear [Recipient Name],',
+    '',
+    'I am writing to formally resign, effective [Date].',
+    '',
+    'Sincerely,',
+    'Wilfred add recipient name Karen _',
+  ].join('\n');
+
+  const filled = [
+    'Dear Karen,',
+    '',
+    'I am writing to formally resign, effective [Date].',
+    '',
+    'Sincerely,',
+    'Wilfred',
+  ].join('\n');
+
+  it('carries a fill-shaped fused response through as a whole-buffer substitute', async () => {
+    const fusedResponse = [
+      'VERDICT: TRANSFORM',
+      'INSTRUCTION: add recipient name Karen',
+      `TARGET: ${letter.replace(' add recipient name Karen _', '')}`,
+      `FULL_REWRITE: ${filled}`,
+    ].join('\n');
+    const { adapter } = mockAdapter([fusedResponse]);
+
+    const source = new TransformBlankSource({
+      httpAdapter: adapter,
+      provider: getProvider('cerebras')!,
+      endpoint: 'https://api.cerebras.ai/v1/chat/completions',
+      apiKey: 'x',
+      model: 'gpt-oss-120b', // cerebras → fused
+    });
+
+    const words = letter.split(/\s+/).filter(Boolean);
+    const ctx: CueContext = {
+      text: letter,
+      words,
+      blankIndices: words.map((w, i) => (w === '_' ? i : -1)).filter(i => i >= 0),
+    };
+    const result = await source.getCues(ctx);
+
+    assert.strictEqual(result.results.length, 1, 'one substitute expected');
+    const alts = result.results[0].alternatives;
+    assert.strictEqual(alts[0], letter, 'alternatives[0] is the original buffer');
+    assert.strictEqual(alts[1], filled, 'alternatives[1] is the filled buffer');
+    // The placeholder is gone and the command tokens are stripped.
+    assert.doesNotMatch(alts[1], /\[Recipient Name\]/, 'placeholder must be filled');
+    assert.doesNotMatch(alts[1], /add recipient name Karen/, 'command must be stripped');
+    assert.doesNotMatch(alts[1], /Recipient Name:\s*Karen/i, 'value must NOT be appended as a label line');
+    assert.match(alts[1], /Dear Karen,/, 'greeting filled in place');
+  });
+});

--- a/packages/opencues-core/src/sources/transform-blank-source.ts
+++ b/packages/opencues-core/src/sources/transform-blank-source.ts
@@ -795,7 +795,7 @@ REWRITE: hii my name is *wilfred*.`;
 // only show up on long buffers (the reported case was ~1.3k chars).
 const FUSED_NONE_RETRY_FLOOR = 400;
 
-const FUSED_SYSTEM = `Read the input and produce a structured edit result.
+export const FUSED_SYSTEM = `Read the input and produce a structured edit result.
 
 The input is a sentence with an underscore (_) signalling either an IMPERATIVE INSTRUCTION the user wants applied to surrounding text, OR a command to manage a continuously-running agent task, OR a lookup placeholder (none of those).
 
@@ -821,7 +821,9 @@ NONE rules — bail when ANY apply:
 
 GENERATIVE — when the imperative asks to CREATE/GENERATE ("write a poem", "compose an email", "give me 5 startup ideas") AND the input is ONLY that instruction plus _ (no other body text), VERDICT=TRANSFORM, TARGET is empty, FULL_REWRITE contains the generated content.
 
-ADD / APPEND OVER A BODY — when a CREATE/ADD instruction ("add a paragraph about X", "write a conclusion", "add a section on Y", "append a note about Z", "include a disclaimer") FOLLOWS or SURROUNDS existing body text, that body IS the TARGET — NOT a generative no-target request. VERDICT=TRANSFORM, TARGET = the existing body verbatim, and FULL_REWRITE = the existing body PRESERVED VERBATIM with the newly generated content appended at the end on a new paragraph (\\n\\n). Generate the requested content; do not drop, summarise, or replace the body. The presence of body text is decisive: instruction + body → append (body preserved in FULL_REWRITE); instruction alone → generative (FULL_REWRITE is only the generated content). Never bail to NONE just because the body is long or unrelated to the add phrase.
+FILL PLACEHOLDER (takes precedence over ADD/APPEND below) — when the instruction supplies a VALUE for a named FIELD ("add recipient name Karen", "set date to Monday", "company Acme", "add my name Wilfred", "manager Karen") AND the TARGET already contains a matching placeholder — a bracketed/templated slot (\`[Recipient Name]\`, \`[Your Name]\`, \`[Name]\`, \`[Date]\`, \`[Company]\`, \`[Position]\`, \`{{name}}\`, \`<name>\`, \`___\`, \`xxx\`) or a "Label:" line with an empty value — REPLACE that placeholder IN PLACE with the value and remove the instruction. Do NOT append a new line; do NOT leave the placeholder. Match by keyword overlap between the field word(s) in the instruction and the placeholder text: "recipient name" → \`[Recipient Name]\` (or the closest name slot, e.g. \`[Name]\` / \`[Your Name]\`), "company"/"employer" → \`[Company]\`, "date"/"last day"/"end date" → \`[Date]\` / \`[Last Working Day]\`, "position"/"role"/"title" → \`[Position]\` / \`[Your Role]\`, "name" → the name slot. The value to insert is the instruction's trailing tokens after the field name. Only when NO placeholder plausibly matches does the ADD/APPEND rule below apply. This holds no matter how far the placeholder sits from the trailing _ (e.g. greeting at the top, command at the bottom of a long letter).
+
+ADD / APPEND OVER A BODY — when a CREATE/ADD instruction ("add a paragraph about X", "write a conclusion", "add a section on Y", "append a note about Z", "include a disclaimer") FOLLOWS or SURROUNDS existing body text AND no matching placeholder exists (see FILL PLACEHOLDER above), that body IS the TARGET — NOT a generative no-target request. VERDICT=TRANSFORM, TARGET = the existing body verbatim, and FULL_REWRITE = the existing body PRESERVED VERBATIM with the newly generated content appended at the end on a new paragraph (\\n\\n). Generate the requested content; do not drop, summarise, or replace the body. The presence of body text is decisive: instruction + body → append (body preserved in FULL_REWRITE); instruction alone → generative (FULL_REWRITE is only the generated content). Never bail to NONE just because the body is long or unrelated to the add phrase.
 
 AGENT TASK COMMANDS — FULL_REWRITE empty for all of these:
 - TASK_ARM: input has "agentically <X>" → INSTRUCTION = X (without "agentically").
@@ -839,7 +841,7 @@ APPLY RULES when VERDICT=TRANSFORM with non-empty TARGET:
 7. CONDITIONAL — apply ONLY where the condition holds ("change boy to girl but not in second sentence").
 8. PRESERVE PARAGRAPHS — \\n\\n breaks survive verbatim.
 9. FULL_REWRITE contains ONLY what the user should see — instruction phrase + _ deleted, all surrounding context preserved verbatim or transformed per the instruction.
-10. ADDITION instructions ("add", "append", "include", "write a <section/paragraph/conclusion>") do NOT replace the TARGET — keep the TARGET verbatim and append the new content at the end on a new paragraph (\\n\\n). The body survives; only new text is added.
+10. ADDITION instructions ("add", "append", "include", "write a <section/paragraph/conclusion>") do NOT replace the TARGET — keep the TARGET verbatim and append the new content at the end on a new paragraph (\\n\\n). The body survives; only new text is added. EXCEPTION: if the instruction supplies a VALUE for a named FIELD and a matching placeholder already exists in the TARGET, FILL that placeholder in place instead of appending (see FILL PLACEHOLDER above) — "add recipient name Karen" over a buffer containing \`[Recipient Name]\` fills the slot, it does NOT append a "Recipient Name: Karen" line.
 
 EXAMPLES:
 
@@ -898,6 +900,18 @@ TARGET: Build a responsive website with HTML, CSS, and JavaScript, with a homepa
 FULL_REWRITE: Build a responsive website with HTML, CSS, and JavaScript, with a homepage and a contact form.
 
 Security is a priority: serve the site over HTTPS, validate and sanitize all form inputs, guard against SQL injection and XSS, and store any credentials using strong, salted hashing.
+
+INPUT: Dear [Recipient Name],
+
+I am writing to formally resign, effective [Date]. add recipient name Karen _
+VERDICT: TRANSFORM
+INSTRUCTION: add recipient name Karen
+TARGET: Dear [Recipient Name],
+
+I am writing to formally resign, effective [Date].
+FULL_REWRITE: Dear Karen,
+
+I am writing to formally resign, effective [Date].
 
 INPUT: agentically correct spelling _
 VERDICT: TASK_ARM

--- a/tests/benchmarks/transform-blank/cases.ts
+++ b/tests/benchmarks/transform-blank/cases.ts
@@ -1045,6 +1045,41 @@ export const CASES: TransformCase[] = [
     },
   },
   {
+    // June 2026 bug: command at the BOTTOM of a letter must FILL a matching
+    // placeholder at the TOP, not append a "Recipient Name: Karen" line.
+    id: 'targeted-placeholder-fill-1',
+    category: 'targeted',
+    input: 'Dear [Recipient Name],\n\nI am writing to formally resign, effective [Date].\n\nSincerely,\nWilfred add recipient name Karen _',
+    expected: {
+      finalText: 'Dear Karen,\n\nI am writing to formally resign, effective [Date].\n\nSincerely,\nWilfred',
+      note: 'Fill the [Recipient Name] slot in place; keep [Date] untouched; do NOT append a label line.',
+    },
+  },
+  {
+    // Generic placeholder label ([Name], not [Recipient Name]) — keyword
+    // overlap ("name") must still target it.
+    id: 'targeted-placeholder-fill-2',
+    category: 'targeted',
+    input: 'Hi [Name],\n\nThanks for your interest. set name Karen _',
+    expected: {
+      finalText: 'Hi Karen,\n\nThanks for your interest.',
+      finalTextAlternates: ['Hi Karen,\n\nThanks for your interest. '],
+      note: 'Generic [Name] slot filled via keyword overlap; command stripped.',
+    },
+  },
+  {
+    // The genuine APPEND case must NOT regress into a fill attempt:
+    // "add a paragraph about X" over a body with no matching placeholder
+    // still appends.
+    id: 'targeted-placeholder-fill-3-append-regression',
+    category: 'targeted',
+    input: 'Build a responsive website with HTML and CSS, with a homepage and a contact form. add a paragraph about security _',
+    expected: {
+      finalText: 'Build a responsive website with HTML and CSS, with a homepage and a contact form.\n\nSecurity is a priority: serve the site over HTTPS, validate and sanitize all form inputs, and guard against SQL injection and XSS.',
+      note: 'No placeholder present → ADD/APPEND still applies. Generated wording open-ended; judge grades on body-preservation + a relevant security paragraph appended.',
+    },
+  },
+  {
     id: 'targeted-2',
     category: 'targeted',
     input: 'uppercase the brand names _ i bought apple and samsung phones online last week',


### PR DESCRIPTION
## Summary

A transform command issued at the **bottom** of a long document — e.g. your resignation letter ending `…+44 7700 900123 add recipient name Karen _` over a body opening `Dear [Recipient Name],` — was **nondeterministic** on the fused path (cerebras + the other capable generalists). The model sometimes filled the placeholder (`Dear Karen,`) and sometimes **appended a literal `Recipient Name: Karen` line at the end, leaving `[Recipient Name]` untouched**. "Iterating on bits from the bottom" of a template hit this constantly.

## Root cause

The fused `FUSED_SYSTEM` prompt had an **ADD/APPEND** rule but **no placeholder-fill rule**, so `add …` followed the append path. The 3-pass `P2_APPLY_SYSTEM` prompt (groq's path) *already* had a `FILL PLACEHOLDER` rule (#12a) — so **groq filled and cerebras drifted**. Same bug class, one prompt missing the rule.

## Fix

Port a **FILL PLACEHOLDER** rule into `FUSED_SYSTEM` with explicit **precedence over ADD/APPEND**, plus a worked example. When the instruction supplies a value for a named field and a matching placeholder (`[Recipient Name]`, `[Name]`, `[Date]`, `___`, …) already exists, replace it in place by keyword overlap — regardless of how far the placeholder sits from the trailing `_`. A genuine `add a paragraph about X` with no matching placeholder still appends.

Behavior chosen: **prefer filling the placeholder** (per maintainer decision).

## Validation

Driven against the **real cerebras gpt-oss-120b fused path** (the production source class, not a bench-only prompt):

- The exact failing letter now fills the placeholder **12/12 runs** (was intermittent / appended).
- All four placeholder-label variants fill: `[Recipient Name]` / `[Name]` (previously failed) / `[Your Name]` / `___`.
- The append-a-paragraph case **still appends** (no regression).
- The 3 new bench cases PASS through the pinned Groq judge.

## Tests

- `packages/opencues-core/src/sources/transform-blank-placeholder-fill.test.ts` (new) — prompt-contract guard on **both** prompts (fused + 3-pass APPLY) so the rule can't be silently deleted, plus a deterministic fill-substitute plumbing test.
- `tests/benchmarks/transform-blank/cases.ts` — three `targeted-placeholder-fill-*` cases (two fill + one append-regression).
- Full core suite green: **1043 (node:test) + 177 (vitest)**, typecheck clean.

## Note on versioning

Bumps core `0.3.42 → 0.3.43`. PR #184 also bumps core to `0.3.43`; whichever merges second is a trivial rebase to `0.3.44` (package.json version + CHANGELOG header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
