### PR TITLE
fix(chrome): cycling a multi-paragraph transform on Gmail stops piling up blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — chrome: cycling a multi-paragraph transform on Gmail no longer piles up blank lines (chrome 0.2.25)
+
+Cycling a whole-body transform-blank result (e.g. an English↔Japanese resignation letter) in a Gmail compose box made blank lines accumulate every cycle — observed climbing from a clean body to 20+ trailing empty lines over a few cycles. Root cause, captured from the live DOM: Gmail appends its own trailing `<div><br></div>` placeholder after each `insertHTML`; the runtime then reads that back (`walkPlainText` counts the trailing block as a `\n`), bakes it into the next cycle's text, re-emits it as another trailing block, Gmail appends ANOTHER placeholder — a compounding read↔write feedback loop. (The English↔Japanese length difference just made it visually obvious; it is not a character-length bug.)
+
+Fix: `replaceAllText` now trims a trailing blank-line run (`/\n+$/`) before writing, for the contenteditable path. Each write emits no trailing blanks, so the editor's single placeholder can't accumulate. Interior blank lines (paragraph breaks) are untouched; an empty body stays empty. Pinned by two new cases in `replace-all-text-undo.test.ts` (trailing run trimmed; interior break preserved). Verified no regression across the Playwright editor matrix (generic CE, Lexical, ProseMirror, realistic-flow — 9/10; the Draft.js harness has a pre-existing `_block.getKey` init error unrelated to this change). Also fixed the Playwright harness build, which was failing on boot-common's `node:fs`/`node:path` imports — the harness now stubs them (`src/stubs/node-builtin-stub.ts`), mirroring production's `external`.
+
 ### Fixed — multi-paragraph CJK sentence-cues: long all-Japanese paragraphs are now cued, highlighted, navigable, and cycleable (core 0.3.42 / runtime 0.3.27)
 
 Follow-up to the multi-paragraph fix below. On a realistic translated buffer (three Japanese paragraphs, the last a single ~180-char sentence) the later all-Japanese text still wasn't dimmed/selected. Four independent failures, each downstream of "CJK + long sentences," each fixed and verified end-to-end on Claude Code (Cerebras gpt-oss-120b):

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.23",
+  "version": "0.2.25",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.23",
+  "version": "0.2.25",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -1216,6 +1216,20 @@ export function replaceAllText(text: string): void {
     writeNormalInputValue(target, text);
     return;
   }
+  // Drop a TRAILING blank-line run before writing. Without this, a
+  // contenteditable that appends its own trailing placeholder block on
+  // paste (Gmail adds a `<div><br></div>` after an insertHTML) creates a
+  // compounding feedback loop: the runtime reads the buffer back
+  // (walkPlainText counts the trailing block as a `\n`), bakes that into
+  // the next cycle's text, re-emits it as another trailing `<div><br></div>`,
+  // the editor appends ANOTHER placeholder, and the blank lines grow every
+  // cycle ("cycling on Gmail adds lots of newlines", June 2026 — observed
+  // climbing from a clean body to 20+ trailing blank lines over a few
+  // English↔Japanese transform cycles). Trimming the trailing run caps it:
+  // each write emits no trailing blanks, so the editor's one placeholder
+  // can't accumulate. Interior blank lines (paragraph breaks) are
+  // untouched. Empty body is preserved as empty.
+  text = text.replace(/\n+$/, '');
   target.focus();
   log.info('[opencues] replaceAllText: newLen=' + text.length + ', preDomLen=' + (target.textContent?.length ?? 0));
   const sel = window.getSelection();

--- a/integrations/chrome/src/replace-all-text-undo.test.ts
+++ b/integrations/chrome/src/replace-all-text-undo.test.ts
@@ -178,6 +178,45 @@ describe('replaceAllText — undo-stack shape', () => {
     expect(isolatedDelete).toBe(false);
   });
 
+  it('generic contenteditable: trims a TRAILING blank-line run (no compounding newlines on cycle)', () => {
+    const target = makeContentEditable('seed');
+    publishTarget(target);
+    const spy = installMutationSpy(target);
+
+    // A body with content + a long trailing blank-line run — the shape
+    // that accumulates on Gmail when the read→write cycle feeds the
+    // editor's appended placeholder back in (June 2026 "lots of newlines").
+    replaceAllText('Dear Karen,\n\nBest,\nWilfred\n\n\n\n\n\n\n\n');
+
+    const insert = spy.ops.find(o => o.kind === 'execCommand' && o.cmd === 'insertHTML') as
+      | { kind: 'execCommand'; cmd: string; arg?: string } | undefined;
+    spy.restore();
+
+    expect(insert, 'generic path should write via insertHTML').toBeTruthy();
+    const html = insert!.arg ?? '';
+    // The interior paragraph break survives; the trailing blank run does NOT.
+    expect(html).toContain('<div>Dear Karen,</div>');
+    expect(html).toContain('<div>Wilfred</div>');
+    // No trailing empty-block run at the end of the emitted HTML.
+    expect(html).not.toMatch(/(<div><br><\/div>)+$/);
+    expect(html.endsWith('<div>Wilfred</div>')).toBe(true);
+  });
+
+  it('generic contenteditable: an interior blank line (paragraph break) is preserved', () => {
+    const target = makeContentEditable('seed');
+    publishTarget(target);
+    const spy = installMutationSpy(target);
+
+    replaceAllText('para one\n\npara two');
+
+    const insert = spy.ops.find(o => o.kind === 'execCommand' && o.cmd === 'insertHTML') as
+      | { kind: 'execCommand'; cmd: string; arg?: string } | undefined;
+    spy.restore();
+
+    // The empty line BETWEEN paragraphs must remain (one <div><br></div>).
+    expect(insert!.arg).toBe('<div>para one</div><div><br></div><div>para two</div>');
+  });
+
   it('managed editor (ProseMirror): keyboard-sim wipe is NOT used for the default path', () => {
     // ChatGPT / LinkedIn / claude.ai shape — has .ProseMirror class.
     const target = document.createElement('div');

--- a/integrations/chrome/src/stubs/node-builtin-stub.ts
+++ b/integrations/chrome/src/stubs/node-builtin-stub.ts
@@ -1,0 +1,14 @@
+// Bundle-time stub for node:fs / node:path in the PLAYWRIGHT harness
+// bundles. boot-common's checkRuntimeDrift (PR #47) does
+// `await import('node:fs')` + `node:path` for a direct-launch advisory
+// that's meaningless in a browser. The production chrome build marks
+// them `external` (esbuild.config.mjs) and relies on the dynamic-import
+// THROWING at runtime, caught by boot-common's own try/catch.
+//
+// In the test harness that rejection surfaced as an unhandled module
+// failure during the Draft.js/React harness init, so `window.__OC`
+// never got set and the page-load wait timed out. Resolving the import
+// to this empty stub instead means the dynamic import succeeds, the
+// advisory finds no usable fs/path methods, and its try/catch
+// silent-skips — same end state, no rejection noise.
+export default {};

--- a/integrations/chrome/tests/playwright/build.mjs
+++ b/integrations/chrome/tests/playwright/build.mjs
@@ -33,6 +33,13 @@ const commonOpts = {
   },
   alias: {
     '@opencues/core/node-http-adapter': resolve(chromeRoot, 'src/stubs/node-http-adapter-stub.ts'),
+    // boot-common dynamic-imports node:fs/node:path for a direct-launch
+    // advisory that's a no-op in the browser. Production marks them
+    // `external` (esbuild.config.mjs); the harness stubs them so the
+    // dynamic import resolves cleanly instead of rejecting (a rejection
+    // disrupted the Draft.js/React harness init before window.__OC was set).
+    'node:fs': resolve(chromeRoot, 'src/stubs/node-builtin-stub.ts'),
+    'node:path': resolve(chromeRoot, 'src/stubs/node-builtin-stub.ts'),
   },
 };
 


### PR DESCRIPTION
## Summary

Cycling a whole-body transform-blank result (your English↔Japanese resignation letter) in a **Gmail** compose box made blank lines accumulate every cycle — climbing from a clean body to **20+ trailing empty lines** over a few cycles.

## Root cause (captured from the live Gmail DOM)

A temporary probe logged the compose `innerHTML` per write. It showed two things:
1. Gmail appends its **own** trailing `<div><br></div>` placeholder after each `insertHTML`.
2. The runtime reads that back (`walkPlainText` counts the trailing block as a `\n`), bakes it into the next cycle's text, re-emits it as another trailing `<div><br></div>`, Gmail appends **another** — a compounding **read↔write feedback loop**.

The English↔Japanese swap just made it visually obvious (replacing long English with short Japanese leaves the old tail behind); it is **not** a character-length bug.

The same probe confirmed a plain `<div contenteditable>` round-trips cleanly (stable in headless Chromium via the production code path) — the accumulation is specific to Gmail appending placeholders.

## Fix

`replaceAllText` trims a trailing blank-line run (`/\n+$/`) before writing, on the contenteditable path. Each write emits no trailing blanks, so the editor's single placeholder can't accumulate. **Interior** paragraph breaks are untouched; an empty body stays empty.

## Verification

- **vitest**: 188/188 chrome unit tests pass, including 2 new `replace-all-text-undo.test.ts` cases (trailing run trimmed; interior break preserved).
- **Playwright matrix** (real Chromium): generic CE, Lexical, ProseMirror, realistic-flow — **9/10 pass**, confirming no regression on the other write paths. The Draft.js harness fails with a **pre-existing** Draft.js init error (`_block.getKey is not a function`) that fires before `__OC` loads — unrelated to this fix (Twitter's write path is untouched).
- This PR also **un-broke the Playwright harness build**, which was failing on boot-common's `node:fs`/`node:path` imports, by stubbing them (`src/stubs/node-builtin-stub.ts`) mirroring production's `external`. (Master's pw build was failing entirely; this restores it.)

## Versioning

Touches `chrome/src`, so manifest + package bump in lockstep: `0.2.23 → 0.2.25` (skipping `0.2.24`, which #184 also claims, to keep this build distinguishable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
