### PR TITLE
fix(chrome): next-field _ after Tab populates (reset resolver dedupe baseline on focus change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — chrome normal-input: a `_` in the next form field after Tab now populates (runtime 0.3.29 / chrome 0.2.26)
+
+On a multi-field form (e.g. Luma RSVP), filling one field with `_` (ambient-context populate), then Tab to the next field and typing `_`, silently did nothing — but deleting and retyping the `_` worked. Root cause: the Resolver's same-text dedupe (`_lastInputText`, built for OpenCode re-emitting identical buffers) is keyed on the last buffer the resolver saw. Chrome's normal-input mode hosts MANY independent fields per page; across a Tab focus change, two different fields legitimately hold the SAME text (a bare `_`), so the second field's `_` was `=== _lastInputText` and the resolver early-returned BEFORE the blank gate ran. Delete+retype worked because it passed through `""`, breaking the dedupe.
+
+`Resolver.resetState()` already clears `_lastInputText`, and `resetSharedBufferState` already calls `resolver?.resetState()` — but chrome's `resetBufferState` (run on every `publishTarget` focus change) never passed the resolver in (it's constructed locally, not part of `shared`). Fix: thread the live resolver into `resetSharedBufferState` so the per-buffer baseline resets on focus change, exactly like `lastSeenText` already does. Pinned by a new resolver scenario test (`resetState() clears the dedupe baseline — same _ resolves again after a focus change`). CC is unaffected (single buffer, no mid-session focus changes between fields).
+
 ### Fixed — multi-paragraph CJK sentence-cues: long all-Japanese paragraphs are now cued, highlighted, navigable, and cycleable (core 0.3.42 / runtime 0.3.27)
 
 Follow-up to the multi-paragraph fix below. On a realistic translated buffer (three Japanese paragraphs, the last a single ~180-char sentence) the later all-Japanese text still wasn't dimmed/selected. Four independent failures, each downstream of "CJK + long sentences," each fixed and verified end-to-end on Claude Code (Cerebras gpt-oss-120b):

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.23",
+  "version": "0.2.26",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.23",
+  "version": "0.2.26",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/packages/opencues-runtime/adapters/chrome/v1/boot.ts
+++ b/packages/opencues-runtime/adapters/chrome/v1/boot.ts
@@ -531,7 +531,21 @@ export function boot(host: HostInfo): BootResult {
     resetBufferState() {
       // Wipe set + rationale lives in boot-common.ts's
       // `resetSharedBufferState` so every band stays in lockstep.
-      resetSharedBufferState(shared);
+      //
+      // Pass the live Resolver so its per-buffer state resets too. This
+      // matters specifically for chrome's normal-input mode, where ONE
+      // page hosts MANY independent fields and focus moves between them
+      // via Tab. The Resolver's same-text dedupe (`_lastInputText`,
+      // resolver.ts) is keyed on the last buffer it saw — built for
+      // OpenCode re-emitting identical content. Across a focus change,
+      // two different fields legitimately hold the SAME text (a bare
+      // `_`): without resetting the baseline, the second field's `_` is
+      // `=== _lastInputText` and the resolver early-returns BEFORE the
+      // blank gate ever runs — so the second field silently never
+      // populates, while delete+retype (which passes through `""`) does.
+      // The Resolver isn't part of `shared` (constructed locally), so
+      // thread it in explicitly. (June 2026 — Luma multi-field forms.)
+      resetSharedBufferState({ ...shared, resolver: liveResolver ?? undefined });
       // Reset lastSeen so the next collectRenderDirectives doesn't
       // diff against a stale snapshot from the prior buffer. This
       // piece is local to the chrome boot closure (each band tracks

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.3.27",
+  "version": "0.3.29",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/resolver.test.ts
+++ b/packages/opencues-runtime/src/modules/resolver.test.ts
@@ -457,6 +457,34 @@ describe('Resolver — same-text dedupe (regression: double LLM call on `_` trig
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  it('resetState() clears the dedupe baseline — same `_` resolves again after a focus change', async () => {
+    // Regression for the June 2026 Luma bug: chrome's normal-input mode
+    // hosts MANY independent fields per page. Tabbing field→field with a
+    // bare `_` in each meant the second field's `_` was `=== _lastInputText`
+    // (the first field's `_`) and got deduped — silently never populating,
+    // while delete+retype (passing through "") worked. The fix resets the
+    // resolver's per-buffer baseline on focus change (resetBufferState →
+    // resetState). This pins that resetState lets an identical buffer
+    // resolve again.
+    const { adapter, resolver } = setupResolver([]);
+    const spy = vi.spyOn(resolver, 'resolveAndApply');
+    resolver.subscribe();
+
+    // Field A: type `_` → resolves.
+    adapter.pushText('_');
+    await new Promise(r => setTimeout(r, 50));
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Focus change to field B (same content) WITHOUT a reset would dedupe.
+    // Simulate the focus-change reset the adapter performs on publishTarget.
+    resolver.resetState();
+
+    // Field B: identical `_` must resolve again (baseline cleared).
+    adapter.pushText('_');
+    await new Promise(r => setTimeout(r, 50));
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
   it('genuinely different text fires resolveAndApply twice — dedupe is text-equality only', async () => {
     const { adapter, resolver } = setupResolver([]);
     const spy = vi.spyOn(resolver, 'resolveAndApply');


### PR DESCRIPTION
## Summary

On a multi-field form (Luma RSVP), filling one field with `_` (ambient-context populate), then **Tab** to the next field and typing `_`, silently did nothing — yet **delete + retype** the same `_` worked.

## Diagnosis (live probes)

Two temporary probes on the real page showed:
1. The input event **reaches** the runtime for the next field with the correct `_` (`hasUnderscore=true`, right `target`).
2. It **passes** the trust gate (`src=user→user`) and calls `notifyTextChange`.
3. But the Resolver early-returns **before** the blank gate (no `_ trigger`, no `gate BLOCKED`).

That pointed at the Resolver's same-text **dedupe** (`if (text === prev) return`, built for OpenCode re-emitting identical buffers, keyed on `_lastInputText`). Chrome's normal-input mode hosts **many independent fields per page**; across a Tab focus change, two different fields legitimately hold the **same** text (a bare `_`), so the second field's `_` was `=== _lastInputText` (field 1's `_`) → deduped. Delete+retype works because it passes through `""`, breaking the dedupe.

## Fix

`Resolver.resetState()` already clears `_lastInputText`, and `resetSharedBufferState` already calls `resolver?.resetState()` — but chrome's `resetBufferState` (run on every `publishTarget` focus change) never passed the resolver in (it's constructed locally, not part of `shared`). Fix: thread the live resolver into `resetSharedBufferState`, exactly like `lastSeenText` already resets there.

One line of behavior, fully aligned with the existing per-buffer reset machinery. **CC is unaffected** (single buffer, no mid-session field-to-field focus changes).

## Tests

- New resolver scenario test: `resetState() clears the dedupe baseline — same _ resolves again after a focus change`.
- Chrome v1 band tests (24) + resolver dedupe tests (5) green; runtime typecheck clean.

## Versioning

runtime `0.3.27 → 0.3.29`, chrome `0.2.23 → 0.2.26` (lockstep). Numbers chosen forward of the other open chrome/runtime PRs (#184/#187) to avoid collisions; rebase as needed on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
