### PR TITLE
fix(core): transform-blank generative output uses real line breaks, not slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — transform-blank generative output uses real line breaks, not " / " (core 0.3.45 / chrome 0.2.28)
+
+A generated poem on claude.ai came out as one line with literal slashes — `Whispered tides of moonlit night, / silver verses on the sea, / …` — instead of line-broken verses. The log confirmed the LLM itself emitted the ` / ` (not the renderer): the fused `FUSED_SYSTEM` generative example used ` / ` as the poem line separator, so the model sometimes copied it ("write a poem" → slashes) and sometimes used real newlines ("draft a poem" → correct). Fix: the example now uses actual newlines, and the GENERATIVE rule explicitly says structure with real line breaks (poems/lists/emails) and NEVER ` / ` or literal `\n` text. (The 3-pass generative prompt already used real newlines.) Verified on cerebras: "write a poem" / "write a poem about the sea" / "give me 3 startup ideas" all emit 0 slashes and proper newlines, 3/3. Managed editors (claude.ai/ProseMirror, Gmail) render the newlines via the existing `replaceAllText` `<br>`/`<p>` path.
+
 ### Changed — chrome rebuilt on the per-sentence + CJK-render runtime/core (chrome 0.2.24)
 
 No chrome-specific source change — the bump rebundles `@opencues/{core,runtime}` at core 0.3.43 / runtime 0.3.28 so chrome ships the per-sentence sentence-cue dispatch and the host-agnostic render fixes (`coord-map`, `defSpanLive`, the `DynDefs.set` managed-span ownership guard). `manifest.json` + `package.json` bumped in lockstep so a reload in `chrome://extensions` shows the new version string and confirms the fresh bundle loaded. Chrome's normal-`<input>` no-cycling profile still prunes sentence-cues at registration (they're cycleable); contenteditable surfaces get them.

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/transform-blank-source.ts
+++ b/packages/opencues-core/src/sources/transform-blank-source.ts
@@ -819,7 +819,7 @@ NONE rules — bail when ANY apply:
 - idiom that looks like an instruction but isn't ("change of plans _ we meet at 3pm")
 - META-TRIGGER for FluidBlank to answer using ambient context — bail to NONE when the ENTIRE input is a short generic answer-request with no real content to transform. Patterns: bare "_", "answer _", "this _", "answer this _", "fill _", "fill in _", "the answer _", "what is the answer _", "what is the question _", "what is the label _". These have no TARGET text — the user is signalling that the surrounding FORM FIELD (which only FluidBlank sees) carries the question. Don't fabricate a conversational response.
 
-GENERATIVE — when the imperative asks to CREATE/GENERATE ("write a poem", "compose an email", "give me 5 startup ideas") AND the input is ONLY that instruction plus _ (no other body text), VERDICT=TRANSFORM, TARGET is empty, FULL_REWRITE contains the generated content.
+GENERATIVE — when the imperative asks to CREATE/GENERATE ("write a poem", "compose an email", "give me 5 startup ideas") AND the input is ONLY that instruction plus _ (no other body text), VERDICT=TRANSFORM, TARGET is empty, FULL_REWRITE contains the generated content. Structure with REAL LINE BREAKS (actual newlines) — poems break each line on its own line, lists put each item on its own line, emails use blank lines between paragraphs. NEVER use " / " (slash) or "\\n" literal text as a line separator; emit the actual newline.
 
 FILL PLACEHOLDER (takes precedence over ADD/APPEND below) — when the instruction supplies a VALUE for a named FIELD ("add recipient name Karen", "set date to Monday", "company Acme", "add my name Wilfred", "manager Karen") AND the TARGET already contains a matching placeholder — a bracketed/templated slot (\`[Recipient Name]\`, \`[Your Name]\`, \`[Name]\`, \`[Date]\`, \`[Company]\`, \`[Position]\`, \`{{name}}\`, \`<name>\`, \`___\`, \`xxx\`) or a "Label:" line with an empty value — REPLACE that placeholder IN PLACE with the value and remove the instruction. Do NOT append a new line; do NOT leave the placeholder. Match by keyword overlap between the field word(s) in the instruction and the placeholder text: "recipient name" → \`[Recipient Name]\` (or the closest name slot, e.g. \`[Name]\` / \`[Your Name]\`), "company"/"employer" → \`[Company]\`, "date"/"last day"/"end date" → \`[Date]\` / \`[Last Working Day]\`, "position"/"role"/"title" → \`[Position]\` / \`[Your Role]\`, "name" → the name slot. The value to insert is the instruction's trailing tokens after the field name. Only when NO placeholder plausibly matches does the ADD/APPEND rule below apply. This holds no matter how far the placeholder sits from the trailing _ (e.g. greeting at the top, command at the bottom of a long letter).
 
@@ -891,7 +891,9 @@ INPUT: write a poem about the sea _
 VERDICT: TRANSFORM
 INSTRUCTION: write a poem about the sea
 TARGET:
-FULL_REWRITE: Waves whisper to the shore, / endless rhythm, salt-bright air, / the sea holds every story.
+FULL_REWRITE: Waves whisper to the shore,
+endless rhythm, salt-bright air,
+the sea holds every story.
 
 INPUT: Build a responsive website with HTML, CSS, and JavaScript, with a homepage and a contact form. add a paragraph about security _
 VERDICT: TRANSFORM


### PR DESCRIPTION
## Summary

A generated poem on claude.ai came out as one line with literal slashes instead of line-broken verses:

```
Whispered tides of moonlit night, / silver verses on the sea, / each line a gentle ripple, / …
```

## Root cause (from the log, not the renderer)

The LLM **itself** emitted the ` / ` — it's in the model's `FULL_REWRITE`, not added by claude.ai's ProseMirror. The fused `FUSED_SYSTEM` generative example used ` / ` as the poem line separator:

```
FULL_REWRITE: Waves whisper to the shore, / endless rhythm, salt-bright air, / the sea holds every story.
```

So the model copied it inconsistently — "write a poem" → slashes, "draft a poem" → real newlines (both seen in the same session's log).

## Fix

- The generative poem example now uses **actual newlines**.
- The GENERATIVE rule explicitly says: structure with **real line breaks** (poems/lists/emails) and **never** ` / ` or literal `\n` text.
- The 3-pass generative prompt already used real newlines (haiku example), so only the fused path needed it.

## Verified

cerebras, 3/3: "write a poem", "write a poem about the sea", "give me 3 startup ideas" — all emit **0 slashes + proper newlines**. Managed editors (claude.ai/ProseMirror, Gmail) render the newlines via the existing `replaceAllText` `<br>`/`<p>` path. transform-blank tests (54) + typecheck green.

core `0.3.44 → 0.3.45`, chrome `0.2.27 → 0.2.28` (bundles the prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
