### PR TITLE
fix(chrome): drop dead restcountries.com host permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — chrome: drop dead `restcountries.com` host permission (chrome 0.2.35)
+
+The countries blank moved to a bundled offline dataset (restcountries.com fully deprecated, June 2026), but the chrome extension still declared `https://restcountries.com/*` in `manifest.json` host_permissions and `FETCH_ALLOWED_ORIGINS` in `sw-auth.ts`. Both are now removed — the origin is never fetched, so the permission was dead surface a reviewer would flag at store-submission time. Lockstep `manifest.json` + `package.json` bump (0.2.34 → 0.2.35).
+
 ## [2026-06-25] — checkpoint
 
 Snapshot tag (`v2026.06.25`). Headline: **BlankIntent** ships behind `blank-intent-mode` (OFF by default) — an LLM invocation gate for keyword script-blanks with line-scoped Phase-1, typed get/set/step, and a single shared keyword-window predicate across all five claim/cede sites; plus the **countries** blank moving to a bundled offline dataset. Packages at this checkpoint: `@opencues/core` 0.5.1, `@opencues/runtime` 0.4.4. (All packages remain `private` — this is a source checkpoint, not an npm publish; the npm handover is tracked in `docs/launch/npm-handover.md`.)

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",
@@ -21,7 +21,6 @@
     "https://api.open-meteo.com/*",
     "https://hacker-news.firebaseio.com/*",
     "https://api.coingecko.com/*",
-    "https://restcountries.com/*",
     "https://api.dictionaryapi.dev/*",
     "https://status.claude.com/*",
     "https://api.github.com/*"

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/src/sw-auth.ts
+++ b/integrations/chrome/src/sw-auth.ts
@@ -43,7 +43,6 @@ export const FETCH_ALLOWED_ORIGINS: readonly string[] = [
   'https://api.open-meteo.com',
   'https://hacker-news.firebaseio.com',
   'https://api.coingecko.com',
-  'https://restcountries.com',
   'https://api.dictionaryapi.dev',
   'https://status.claude.com',
   'https://api.github.com',


### PR DESCRIPTION
## What

The countries blank moved to a bundled offline dataset in the 2026-06-25 checkpoint (restcountries.com [fully deprecated its REST API](https://github.com/opencues/opencues) in June 2026 — every path 301-redirects to a deprecation notice). But the **chrome extension** was left still declaring the dead origin:

- `integrations/chrome/manifest.json` — `https://restcountries.com/*` in `host_permissions`
- `integrations/chrome/src/sw-auth.ts` — `'https://restcountries.com'` in `FETCH_ALLOWED_ORIGINS`

Nothing fetches that origin anymore, so it's dead permission surface — exactly the kind of thing a Chrome Web Store reviewer flags at submission ("requests a host permission it never uses").

## Change

- Remove both refs.
- Lockstep `manifest.json` + `package.json` bump **0.2.34 → 0.2.35** per the chrome version-lockstep rule (any PR touching `integrations/chrome/src/**` bumps both).
- CHANGELOG `[Unreleased]` entry.

## Verification

- `npm run build` (chrome): typecheck clean, 188/188 vitest pass, bundle rebuilt.
- `grep restcountries integrations/chrome/{src,manifest.json}` → no matches.

Note: the historical narrative comments in `packages/opencues-runtime/src/blanks/countries{,-data}.ts` (explaining *why* the data is now bundled) are intentionally kept. The `defaults/blanks/countries/BLANK.md` prose still mentioning REST Countries is fixed separately in the docs-drift PR (#204).

🤖 Generated with [Claude Code](https://claude.com/claude-code)