### PR TITLE
fix(runtime): BlankIntent typed-SET/STEP renders a clean final-state buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — BlankIntent typed-SET/STEP leaves a clean final-state buffer (runtime 0.4.5)
+
+`volume 40 _` set the volume correctly but rendered `volume 40 40%` — the typed value word (`40`) sat between the keyword and `_`, the volume blank's `blankReplace: keep` splice consumed only `volume` + `_`, and the read-back was appended, orphaning the input value. Now typed-SET/STEP render the **final state** in the same `<label> <value>` shape config-intent uses (`voice mode off _` → `voice-mode off`): `volume 40 _` → `volume 40%`, `volume up _` → `volume 46%`. The value shown is the **read-back** (post-clamp), so `volume 150 _` lands as `volume 100%`. Plain GET (`volume _`) is unchanged. `applyAsyncFill` gained an optional `typedAction` param that prepends the keyword to the fill and widens the consumed range to swallow the typed value; threaded from the SET/STEP branch through `doDispatch`. Verified live on CC + OC and pinned by three new deterministic buffer-contract tests in `blank-fill.blank-intent.test.ts` (the prior tests asserted the value *changed* but never the buffer text — the gap that let this ship).
+
 ### Fixed — chrome: drop dead `restcountries.com` host permission (chrome 0.2.35)
 
 The countries blank moved to a bundled offline dataset (restcountries.com fully deprecated, June 2026), but the chrome extension still declared `https://restcountries.com/*` in `manifest.json` host_permissions and `FETCH_ALLOWED_ORIGINS` in `sw-auth.ts`. Both are now removed — the origin is never fetched, so the permission was dead surface a reviewer would flag at store-submission time. Lockstep `manifest.json` + `package.json` bump (0.2.34 → 0.2.35).

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/blank-fill.blank-intent.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.blank-intent.test.ts
@@ -171,6 +171,31 @@ async function setupSettable(gate?: Gate) {
   bf.subscribe();
   return { adapter, loader, bf };
 }
+
+// A SECOND settable blank (different keyword, step, AND a blankSuffix) to
+// prove the typed-SET final-state render is blank-generic, not volume-
+// specific: it keys on slot.keyword + the read-back, never a hard-coded name.
+const BRIGHTNESS_CUE = `---
+type: blank
+name: brightness
+blankKeywords: brightness
+blankProximity: 3
+blankStep: 10
+blankSuffix: %
+blankScript: ./brightness.sh
+---
+`;
+async function setupBrightness(gate?: Gate) {
+  const adapter = new MockAdapter({
+    cwd: '/proj',
+    files: { '/mock/CUES.md': TIPS, '/proj/blanks/brightness/BLANK.md': BRIGHTNESS_CUE },
+  });
+  const loader = new ConfigLoader(adapter);
+  await loader.load();
+  const bf = new BlankFill(adapter, loader, undefined, undefined, undefined, undefined, undefined, gate);
+  bf.subscribe();
+  return { adapter, loader, bf };
+}
 const setArgs = (spy: ReturnType<typeof vi.spyOn>) =>
   spy.mock.calls.map(c => (c[0] as { args: string[] }).args);
 
@@ -247,6 +272,33 @@ describe('BlankFill × BlankIntent typed-SET', () => {
     await tick(); await tick(); await tick(); await tick();
     expect(adapter.getText()).toBe('volume 100');   // final state, not the typed 150
     expect(adapter.getText()).not.toContain('150');
+  });
+
+  // GENERALISATION: a DIFFERENT settable blank (brightness, with a
+  // blankSuffix) renders the same clean final state — proves the fix isn't
+  // volume-specific and that blankSuffix composes with the keyword prefix.
+  it('generalises to a second settable blank (brightness, with suffix)', async () => {
+    const { adapter } = await setupBrightness(async () => SET('70'));
+    adapter.stubBlankInvoke('brightness:set', '');
+    adapter.stubBlankInvoke('brightness:get', '70\n');
+    adapter.pushText('brightness 70 _');
+    await tick(); await tick(); await tick(); await tick();
+    expect(adapter.getText()).toBe('brightness 70%'); // keyword + read-back + suffix
+    expect(adapter.getText()).not.toMatch(/brightness\s+70\s+70/);
+  });
+
+  // EDGE: keyword not at position 0 ("set the volume to 40 _"). The typed
+  // value + intervening words between keyword and `_` are consumed; content
+  // BEFORE the keyword is preserved (consume-context semantics). Documents
+  // the actual behaviour for prefixed phrasings.
+  it('prefixed phrasing: consumes keyword→blank, preserves the lead-in', async () => {
+    const { adapter } = await setupSettable(async () => SET('40'));
+    adapter.stubBlankInvoke('volume:set', '');
+    adapter.stubBlankInvoke('volume:get', '40\n');
+    adapter.pushText('set the volume to 40 _');
+    await tick(); await tick(); await tick(); await tick();
+    expect(adapter.getText()).toBe('set the volume 40'); // lead-in kept, "to 40" consumed
+    expect(adapter.getText()).not.toMatch(/40\s+40/);    // no orphaned value
   });
 });
 

--- a/packages/opencues-runtime/src/modules/blank-fill.blank-intent.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.blank-intent.test.ts
@@ -221,6 +221,33 @@ describe('BlankFill × BlankIntent typed-SET', () => {
     expect(calls.some(a => a.includes('set'))).toBe(false);
     expect(calls.some(a => a.includes('get'))).toBe(true);
   });
+
+  // BUFFER CONTRACT (the regression these tests exist for). The dispatch
+  // tests above proved the value changes; this pins what the user SEES.
+  // The bug: the typed value word ("40") sat between keyword and `_`, the
+  // `keep`-mode splice consumed only "volume" + "_", and the read-back was
+  // appended — leaving "volume 40 40". Fix renders the config-intent-style
+  // final state "<keyword> <read-back>", consuming the typed value.
+  it('SET renders "<keyword> <read-back>" — the typed value is NOT orphaned', async () => {
+    const { adapter } = await setupSettable(async () => SET('40'));
+    adapter.stubBlankInvoke('volume:set', '');      // set emits nothing
+    adapter.stubBlankInvoke('volume:get', '40\n');  // read-back
+    adapter.pushText('volume 40 _');
+    await tick(); await tick(); await tick(); await tick();
+    expect(adapter.getText()).toBe('volume 40');
+    // The bug shape — orphaned input word + appended read-back — must not appear.
+    expect(adapter.getText()).not.toMatch(/volume\s+40\s+40/);
+  });
+
+  it('SET shows the READ-BACK value, not the typed input (clamp fidelity)', async () => {
+    const { adapter } = await setupSettable(async () => SET('150'));
+    adapter.stubBlankInvoke('volume:set', '');
+    adapter.stubBlankInvoke('volume:get', '100\n'); // script clamped 150 → 100
+    adapter.pushText('volume 150 _');
+    await tick(); await tick(); await tick(); await tick();
+    expect(adapter.getText()).toBe('volume 100');   // final state, not the typed 150
+    expect(adapter.getText()).not.toContain('150');
+  });
 });
 
 describe('BlankFill × BlankIntent typed-STEP', () => {
@@ -254,6 +281,19 @@ describe('BlankFill × BlankIntent typed-STEP', () => {
     await tick(); await tick(); await tick(); await tick();
     const calls = setArgs(spawnSpy);
     expect(calls.some(a => a.includes('set') && a.includes('100'))).toBe(true);
+  });
+
+  it('STEP renders "<keyword> <read-back>" — the direction word is NOT orphaned', async () => {
+    // Buffer contract for STEP (mirrors the SET buffer tests). `volume up _`
+    // must render the final state "volume <value>", consuming the "up"
+    // direction word — not leave "volume up 60".
+    const { adapter } = await setupSettable(async () => STEP('up'));
+    adapter.stubBlankInvoke('volume:set', '');
+    adapter.stubBlankInvoke('volume:get', '60\n');
+    adapter.pushText('volume up _');
+    await tick(); await tick(); await tick(); await tick();
+    expect(adapter.getText()).toBe('volume 60');
+    expect(adapter.getText()).not.toContain('up'); // direction word consumed
   });
 
   it('STEP with a non-numeric current value degrades to a plain get (no set)', async () => {

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -393,7 +393,7 @@ export class BlankFill {
       // is already reserved above, so a re-scan during the gate's latency
       // won't double-dispatch. (`continue` inside this closure becomes
       // `return` — it's a function body now, not the loop.)
-      const doDispatch = (): void => {
+      const doDispatch = (typedAction?: 'set' | 'step'): void => {
 
       // Context words: every word except the matched keyword span and the blank.
       // Index-based filter (vs v1's string-match) handles multi-word keywords
@@ -473,7 +473,7 @@ export class BlankFill {
           // see `_pendingScripts.has(dedupKey)` and skip even after the
           // cached value is fresh.
           this._pendingScripts.delete(dedupKey);
-          this.applyAsyncFill(slot, entry.output);
+          this.applyAsyncFill(slot, entry.output, typedAction);
           return;
         }
       }
@@ -597,7 +597,7 @@ export class BlankFill {
             this._resultCache.delete(oldest);
           }
         }
-        this.applyAsyncFill(slot, stdout);
+        this.applyAsyncFill(slot, stdout, typedAction);
       }).catch(err => {
         this._pendingScripts.delete(dedupKey);
         this._loadingAnimator().stop(slot.index, 'blank-fill');
@@ -656,10 +656,12 @@ export class BlankFill {
           const stepSize = typeof stepRaw === 'number' ? stepRaw
             : (typeof stepRaw === 'string' && /^\d+$/.test(stepRaw) ? parseInt(stepRaw, 10) : null);
           const isSettable = stepSize !== null;
+          let typedAction: 'set' | 'step' | undefined;
           if (decision.action === 'set' && decision.value && /^\d+$/.test(decision.value.trim()) && isSettable) {
             this.adapter.log('debug', `BlankFill: BlankIntent SET ${slot.blankName} → ${decision.value} (then read back)`);
             await this.runBlankSet(slot.blankName, decision.value.trim(), gateBlank as Record<string, unknown>);
             if (this._lastInputText !== gateText) { this._pendingScripts.delete(dedupKey); return; }
+            typedAction = 'set';
           } else if (decision.action === 'step'
               && (decision.value === 'up' || decision.value === 'down')
               && isSettable) {
@@ -675,9 +677,10 @@ export class BlankFill {
               this.adapter.log('debug', `BlankFill: BlankIntent STEP ${slot.blankName} ${decision.value} → ${current}±${stepSize}=${next} (then read back)`);
               await this.runBlankSet(slot.blankName, String(next), gateBlank as Record<string, unknown>);
               if (this._lastInputText !== gateText) { this._pendingScripts.delete(dedupKey); return; }
+              typedAction = 'step';
             }
           }
-          doDispatch();
+          doDispatch(typedAction);
         })();
       } else {
         doDispatch();
@@ -774,7 +777,7 @@ export class BlankFill {
    * adapter.pushText (calls onChange), since this runs outside any
    * dispatch.
    */
-  private applyAsyncFill(slot: BlankSlot, fillValue: string): void {
+  private applyAsyncFill(slot: BlankSlot, fillValue: string, typedAction?: 'set' | 'step'): void {
     const currentText = this.adapter.getText();
     const cleaned = currentText.replace(/[\u200B\u200C]/g, '');
     const words = splitWords(cleaned);
@@ -837,6 +840,16 @@ export class BlankFill {
       primaryFill = primaryFill + blank.blankSuffix;
     }
 
+    // Typed-SET/STEP final-state render. Mirror config-intent's
+    // "<setting> <value>" display: keep the keyword as the label and show
+    // the read-back value as its value, so "volume 40 _" → "volume 40%".
+    // The value shown is the read-back (post-clamp), not the typed input,
+    // so "volume 150 _" lands as "volume 100%". The typed value word(s)
+    // between keyword and `_` are consumed by the clearEnd override below.
+    if (typedAction) {
+      primaryFill = `${slot.keyword} ${primaryFill}`;
+    }
+
     // New unified `blankReplace` field, when set explicitly, supersedes
     // the legacy flag path (consumeAll/consumeContext/clearKeywords).
     // Resolves via the fluid heuristic when set to 'auto'. Existing
@@ -881,10 +894,16 @@ export class BlankFill {
       return;
     }
 
-    const { clearEnd, expansion } = explicitMode !== null
+    const baseRange = explicitMode !== null
       ? computeFillRangeForMode(blank ?? {}, slot, explicitMode)
       : computeFillRange(blank ?? {}, slot);
-    this.adapter.log('info', `BlankFill: substituting "${slot.keyword} _" → "${preview(primaryFill, 60)}" (blank=${slot.blankName}${lines.length > 1 ? `, ${lines.length} alt(s)` : ''}${isDismissible ? ', dismissible' : ''})`);
+    // Typed-SET/STEP consumes keyword + typed value words (the fill above
+    // already re-includes the keyword as its label), so the value word
+    // isn't orphaned: "volume 40 _" → "volume 40%", not "volume 40 40%".
+    const { clearEnd, expansion } = typedAction
+      ? { clearEnd: slot.index - 1, expansion: undefined as string | undefined }
+      : baseRange;
+    this.adapter.log('info', `BlankFill: substituting "${slot.keyword} _" → "${preview(primaryFill, 60)}" (blank=${slot.blankName}${typedAction ? `, typed-${typedAction}` : ''}${lines.length > 1 ? `, ${lines.length} alt(s)` : ''}${isDismissible ? ', dismissible' : ''})`);
     this.adapter.emitEvent?.('blank.substituted', {
       blankName: slot.blankName,
       keyword: slot.keyword,


### PR DESCRIPTION
## The bug

`volume 40 _` **set the volume correctly** but rendered **`volume 40 40%`** on screen.

Root cause: the typed value word (`40`) sits *between* the keyword and `_`. The volume blank is `blankReplace: keep`, so its splice consumed only `volume` + `_` and **appended** the read-back value — orphaning the typed `40`.

This was invisible to the test suite because the existing typed-SET scenario (and unit tests) asserted *"the volume value changed"* — never the resulting buffer text.

## The fix

Typed-SET/STEP now render the **final state** in the same `<label> <value>` shape config-intent uses (`voice mode off _` → `voice-mode off`), consuming the typed value:

| Input | Before | After |
|---|---|---|
| `volume 40 _` | `volume 40 40%` | `volume 40%` |
| `volume up _` | `volume up 46%` | `volume 46%` |
| `volume 150 _` | `volume 150 100%` | `volume 100%` |

The displayed value is the **read-back** (post-clamp), not the typed input — so `volume 150 _` faithfully shows the clamped `volume 100%`. Plain GET (`volume _`) is unchanged.

### Implementation
`applyAsyncFill` gains an optional `typedAction?: 'set' \| 'step'` param. When set, it (1) prepends the keyword to the fill (`40%` → `volume 40%`) and (2) widens the consumed range (`clearEnd = slot.index - 1`) to swallow the typed value word(s). Threaded from the SET/STEP branch through `doDispatch` to both `applyAsyncFill` call sites. Everything else (read-back, clamping, span-as-unit, events) is reused unchanged.

## Tests

- **3 new deterministic buffer-contract tests** in `blank-fill.blank-intent.test.ts` — assert the exact buffer (`volume 40` / `volume 100` / `volume 60`) and that the orphaned-value shape never appears. These close the gap that let the bug ship.
- Full runtime suite green: **1722/1722**.
- Verified live on **CC** (`volume 40%`, `volume 100%` clamp) and **OC** (`volume 42%`, `volume 48%` step, `volume 100%` clamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)