### PR TITLE
fix(install): fork install resilient to missing user-blank sandbox deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — fork install no longer refuses over an optional feature's missing transitive deps (`@opencues/runtime` 0.5.0 → 0.5.1, `@opencues/claude-code` 0.2.3 → 0.2.4)
+
+A fresh CC install (`opencues install claude-code`) hard-failed validation with `boot-smoke FAILED for require("…/user-blanks/registry.js")` whenever the fork's `node_modules` lacked the JS-user-blank sandbox's transitive deps (`acorn`, `acorn-walk`, `isolated-vm`) — which the fork-assembly copies dist but not deps, so it always lacks them. Two structural causes, both fixed:
+
+1. **`esm-rewrite.ts` top-level-imported `acorn`/`acorn-walk`** — so requiring `registry.js` pulled acorn at module-load time and threw when it was absent. This is the same bug class CLAUDE.md documents for `isolated-vm` in `node-loader` (top-level native/heavy import that should be lazy). Fixed by making the acorn imports type-only + lazy-`require()`ing them inside `rewriteEsmToCjsShim` (mirrors `node-loader`'s `getIvm`). **`registry.js` — and the whole runtime — now LOADS without acorn**; only an actual JS user-blank rewrite needs the parser, and its absence disables that one blank (registry's try/catch), not the runtime. Verified: `check-runtime-loads-on-bun.sh` now reports the registry loads cleanly (was "load failed"); the rewrite still works when acorn is present.
+2. **CC's `validateFork` treated user-blanks as REQUIRED.** Split the boot-smoke probes into required (core runtime — refuse the fork on failure, the #117 dist-copy guard) vs **optional** (`user-blanks/registry.js` — warn + ship). A degradable feature can no longer refuse the whole install. Mirrors the "optional" classification already in `check-runtime-loads-on-bun.sh`.
+
+Result: `opencues install claude-code` now succeeds + validates on a fork without the sandbox deps (built-in + `.sh` blanks unaffected; JS user-blanks degrade gracefully). Full runtime suite green (1731); user-blank tests 74/74.
+
 ### Added — typed-sentinel language (opt-in `sentinel-language: typed`) (`@opencues/core` 0.5.1 → 0.6.0, `@opencues/runtime` 0.4.7 → 0.5.0)
 
 Identity-/blank-context sentinel tokens can now use a **typed, parameterized, nestable grammar** instead of the flat `[TOKEN]` form. Gated behind a new `sentinel-language: bare | typed` scalar (default `bare` — every existing user is byte-identical; only an explicit `typed` opts in).

--- a/integrations/claude-code/bin/install.cjs
+++ b/integrations/claude-code/bin/install.cjs
@@ -725,18 +725,33 @@ function validateFork(fork) {
   // line). Keep in sync — when the patch starts requiring a new
   // submodule, append it here so a new install can't silently ship a
   // broken bundle.
-  const smokeProbes = [
+  // REQUIRED probes — a load failure here means the core runtime is broken
+  // (the #117 dist-copy bug class), so refuse the fork.
+  const requiredProbes = [
     '@opencues/runtime',
     '@opencues/runtime/dist/adapters/cc/v2.1/boot.js',
     '@opencues/runtime/dist/src/blanks/index.js',
     '@opencues/runtime/dist/src/security/spawn-sandbox.js',
     '@opencues/runtime/dist/src/security/sandbox-runner.js',
+  ];
+  // OPTIONAL probes — features that degrade gracefully when their (often
+  // native / heavy) transitive deps are absent. user-blanks (the JS
+  // sandbox) needs acorn + isolated-vm; a fork that copied dist but not
+  // those deps should still SHIP (built-in + .sh blanks keep working) —
+  // only JS user-blanks are disabled. registry.js is engineered to LOAD
+  // even when those deps are missing (esm-rewrite + node-loader lazy-
+  // require them), so this normally passes; if it ever doesn't, WARN and
+  // ship rather than refuse the whole fork. Mirrors the "optional"
+  // classification in scripts/check-runtime-loads-on-bun.sh.
+  const optionalProbes = [
     '@opencues/runtime/dist/src/user-blanks/registry.js',
   ];
-  for (const spec of smokeProbes) {
-    const probe = spawnSync(process.execPath, [
-      '-e', `require(${JSON.stringify(spec)})`,
-    ], { cwd: fork.root, env: process.env });
+  const probeLoad = (spec) => spawnSync(process.execPath, [
+    '-e', `require(${JSON.stringify(spec)})`,
+  ], { cwd: fork.root, env: process.env });
+
+  for (const spec of requiredProbes) {
+    const probe = probeLoad(spec);
     if (probe.status !== 0) {
       const stderr = (probe.stderr || '').toString().split('\n').slice(0, 4).join('\n');
       return {
@@ -745,6 +760,14 @@ function validateFork(fork) {
                 `setup.sh's copy step probably missed a new dist subdir; the recursive copy in setup.sh § 5 should cover ` +
                 `every dist/*/ subdir.\n  ${stderr.replace(/\n/g, '\n  ')}`,
       };
+    }
+  }
+  for (const spec of optionalProbes) {
+    const probe = probeLoad(spec);
+    if (probe.status !== 0) {
+      const stderr = (probe.stderr || '').toString().split('\n').slice(0, 2).join('\n');
+      console.warn(`  ⚠ optional module require(${JSON.stringify(spec)}) failed — JS user-blanks disabled on this fork ` +
+                   `(built-in + .sh blanks unaffected). Likely a missing transitive dep (acorn / isolated-vm).\n      ${stderr.replace(/\n/g, '\n      ')}`);
     }
   }
   return { ok: true };

--- a/integrations/claude-code/package.json
+++ b/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/claude-code",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "OpenCues for Claude Code — patches Claude Code's CLI via tweakcc to add real-time word alternatives, blanks, and cue-controls.",
   "compatibility": {

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/user-blanks/esm-rewrite.ts
+++ b/packages/opencues-runtime/src/user-blanks/esm-rewrite.ts
@@ -21,9 +21,31 @@
 // use spaces of equal length where possible) so error messages from
 // the embedded source still point at the user's original line.
 
-import { parse } from 'acorn';
-import { simple as walkSimple } from 'acorn-walk';
+// `acorn` + `acorn-walk` are imported TYPE-ONLY at module scope and
+// lazy-`require()`d inside `rewriteEsmToCjsShim` (INFOSEC F1 pattern,
+// mirroring node-loader's `getIvm` for isolated-vm). Requiring THIS
+// module must never pull acorn at load time: registry.js loads it
+// eagerly, and a host/fork that lacks acorn (Bun hosts, a CC fork whose
+// setup copied dist but not transitive deps) must still LOAD the runtime
+// — CC's `validateFork` boot-smoke + `check-runtime-loads-on-bun.sh`
+// both `require(registry.js)`. Only an actual JS user-blank rewrite needs
+// the parser; its absence degrades that one blank (registry.ts's
+// try/catch), it does not break the whole runtime.
 import type { Node } from 'acorn';
+
+let _acorn: typeof import('acorn') | null = null;
+let _acornWalk: typeof import('acorn-walk') | null = null;
+/** Lazy-load the acorn parser. Throws (caught by registry.ts) only when a
+ *  JS user-blank is actually rewritten on a host without acorn installed. */
+function loadAcorn(): { parse: typeof import('acorn').parse; walkSimple: typeof import('acorn-walk').simple } {
+  if (!_acorn || !_acornWalk) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    _acorn = require('acorn');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    _acornWalk = require('acorn-walk');
+  }
+  return { parse: _acorn!.parse, walkSimple: _acornWalk!.simple };
+}
 
 interface AcornProgram extends Node {
   body: Node[];
@@ -47,6 +69,7 @@ export interface RewriteResult {
 }
 
 export function rewriteEsmToCjsShim(source: string): RewriteResult {
+  const { parse, walkSimple } = loadAcorn();
   const warnings: string[] = [];
   let ast: AcornProgram;
   try {


### PR DESCRIPTION
## Problem

`opencues install claude-code` hard-failed validation with `boot-smoke FAILED for require("…/user-blanks/registry.js")` whenever the fork's `node_modules` lacked the JS-user-blank sandbox's transitive deps (`acorn`/`acorn-walk`/`isolated-vm`) — which fork-assembly copies dist but never deps, so it always lacks them. (Surfaced while deploying the typed-sentinel runtime to the CC fork.)

## Root cause (two structural)

1. **`esm-rewrite.ts` top-level-imported `acorn`/`acorn-walk`** → requiring `registry.js` pulled acorn at module-load and threw when absent. Same class as the documented `isolated-vm`-in-`node-loader` bug (top-level heavy import that should be lazy).
2. **CC `validateFork` treated user-blanks (an *optional*, gracefully-degrading feature) as REQUIRED** → a missing sandbox dep refused the whole fork.

## Fix

1. acorn imports → type-only + lazy-`require()` inside `rewriteEsmToCjsShim` (mirrors `node-loader`'s `getIvm`). `registry.js` + the whole runtime now LOAD without acorn; only an actual JS user-blank rewrite needs the parser, and its absence disables that one blank, not the runtime.
2. `validateFork` boot-smoke split into **required** (core runtime — the #117 dist-copy guard) vs **optional** (`registry.js` — warn + ship).

## Verification
- `check-runtime-loads-on-bun.sh`: registry now loads cleanly (was "load failed").
- Fresh `opencues install claude-code --rebuild` → **"installed + validated"**, no warning; fork `registry.js` loads cleanly.
- Runtime suite **1731** green; user-blank tests **74/74**; browser-safe + version-bump lints clean.

`@opencues/runtime` 0.5.0→0.5.1, `@opencues/claude-code` 0.2.3→0.2.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)