### PR TITLE
Blank routing: sentence-scoped shapes + shared cede predicate (SPEC 0.3 → 0.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — blank routing is sentence-scoped (`SPEC_VERSION` 0.3 → 0.4, `@opencues/core` → 0.8.0)
+
+Shaped-blank routing now matches the **sentence** containing `_`, not just
+the physical line. A keyword/shape claims a `_` when it leads its sentence —
+the segment after the last sentence terminator (`.`/`!`/`?` + whitespace, or
+a CJK `。`/`！`/`？`/`．`) or newline before `_`. So `let me check. volume _`
+fires the volume blank just like `notes\nvolume _` does; previously only a
+newline started a new routing segment. The whitespace lookahead keeps
+decimals (`3.5`) and versions (`gpt-5.4`) from splitting, and a command must
+still **lead** its sentence — a keyword mentioned mid-sentence does not fire.
+
+- **Shared boundary** — `segmentStart` (`packages/opencues-core/src/segment.ts`)
+  is the single sentence/line boundary, used by both shaped-blank routing
+  (`lineWithBlank`) and fluid-config's `summonPhraseStart`, so the two can't
+  drift. Bench: `tests/benchmarks/blank-routing` (deterministic A/B) — recall
+  47% → 100%, precision held at 100%.
+- **Shared cede predicate** — `blankClaimsUnderscore` centralises the
+  "does a blank claim this `_`?" check that FluidBlank / TransformBlank /
+  ConfigIntent each used to copy inline. ConfigIntent had drifted (didn't
+  skip shaped blanks), so an incidental keyword in prose made it cede and a
+  real settings command fell through to fluid-blank; now all three share one
+  predicate.
+- **Spec** — normative trigger text updated to "sentence" in
+  `spec/blank-spec.md` + `core.md`; `SPEC_VERSION` → `0.4` (omit-default
+  stays `0.1-alpha`); routing conformance fixture + `spec/CHANGELOG.md`
+  `[0.4.0-alpha]` updated. A `0.3-alpha` reader refuses `0.4-alpha` files.
+
 ### Changed — blank API slim-down: shapes route, dead dials removed (`SPEC_VERSION` 0.2 → 0.3)
 
 The blank trigger model is now deterministic, line-scoped `blankShapes`

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Cues Specification
 
-**Current version: `0.3` (draft)**
+**Current version: `0.4` (draft)**
 
 This document declares the **Cues spec** — the durable, host-agnostic format that
 describes word-cues and blank-fills. It is separate from any single

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/blank-shapes.test.ts
+++ b/packages/opencues-core/src/blank-shapes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import * as assert from 'node:assert';
-import { matchBlankShape } from './blank-shapes';
+import { matchBlankShape, blankClaimsUnderscore } from './blank-shapes';
 import { synthesizeKeywordShapes, type BlankConfig } from './cues-md';
 
 const VOLUME_SHAPES: BlankConfig['blankShapes'] = [
@@ -111,6 +111,45 @@ describe('matchBlankShape', () => {
 
   it('prose ending in a period that is NOT a command still cedes', () => {
     assert.strictEqual(matchBlankShape('i turned the volume down. what a day _', b), null);
+  });
+});
+
+// The SINGLE cede predicate shared by FluidBlank / TransformBlank /
+// ConfigIntent. Testing it once covers all three — that's the whole point of
+// centralising it (the June 2026 long-buffer bug was ConfigIntent carrying a
+// stale inline copy that diverged from the other two).
+describe('blankClaimsUnderscore (shared cede predicate)', () => {
+  const words = (t: string) => t.replace(/[​‌]/g, '').split(/\s+/).filter(Boolean);
+  const VB = new Map<string, Pick<BlankConfig, 'blankShapes' | 'blankKeywords'>>([
+    ['volume', { blankShapes: VOLUME_SHAPES, blankKeywords: ['volume'] }],
+  ]);
+
+  it('a shaped command claims its `_`', () => {
+    assert.strictEqual(blankClaimsUnderscore('volume 30 _', words('volume 30 _'), VB), true);
+    assert.strictEqual(blankClaimsUnderscore('volume _', words('volume _'), VB), true);
+  });
+
+  // THE REGRESSION (June 2026): a stray keyword in PROSE must NOT claim, so a
+  // following settings command still routes to ConfigIntent. The word "volume"
+  // sits in the woven `The volume is now 30%`, on the same line as `_`, but
+  // `volume` is a SHAPED blank → the legacy keyword cede is skipped, and the
+  // `_`'s segment ("voice mode off _") matches no shape → no claim.
+  it('a stray keyword in prose does NOT claim (shaped blank skips keyword cede)', () => {
+    const t = 'let me check the audio. The volume is now 30%. voice mode off _';
+    assert.strictEqual(blankClaimsUnderscore(t, words(t), VB), false);
+  });
+
+  it('a NON-shaped keyword blank still claims via keyword on the line (legacy)', () => {
+    const legacy = new Map<string, Pick<BlankConfig, 'blankShapes' | 'blankKeywords'>>([
+      ['notes', { blankKeywords: ['note'] }], // no shapes → legacy keyword cede applies
+    ]);
+    assert.strictEqual(blankClaimsUnderscore('note this down _', words('note this down _'), legacy), true);
+    // …but a stray "note" with the keyword on a PREVIOUS line does not.
+    assert.strictEqual(blankClaimsUnderscore('note above\nplain line _', words('note above\nplain line _'), legacy), false);
+  });
+
+  it('no `_` → no claim', () => {
+    assert.strictEqual(blankClaimsUnderscore('volume 30', words('volume 30'), VB), false);
   });
 });
 

--- a/packages/opencues-core/src/blank-shapes.test.ts
+++ b/packages/opencues-core/src/blank-shapes.test.ts
@@ -62,9 +62,9 @@ describe('matchBlankShape', () => {
     assert.deepStrictEqual(matchBlankShape('volume 50 _', bad), { blankName: 'volume', action: 'set', value: '50' });
   });
 
-  // LINE-SCOPED: a shape matches the LINE containing `_`, so a command on
-  // the last line claims even with prior content above — but prose that
-  // merely leads the line never matches (anchored grammar).
+  // SEGMENT-SCOPED: a shape matches the SENTENCE/line containing `_`, so a
+  // command on the last line claims even with prior content above — but prose
+  // that merely leads the segment never matches (anchored grammar).
   it('matches a command on the last line with prior content above', () => {
     assert.deepStrictEqual(
       matchBlankShape('some earlier notes here.\nvolume 30 _', b),
@@ -78,6 +78,39 @@ describe('matchBlankShape', () => {
 
   it('de-greedy: prose that only mentions the keyword mid-line never matches', () => {
     assert.strictEqual(matchBlankShape('the volume was lovely today _', b), null);
+  });
+
+  // SENTENCE-scoped: a command claims its `_` when it leads its SENTENCE, not
+  // just its physical line. A sentence terminator (`.`/`!`/`?` + space, or a
+  // CJK terminator) resets the anchor the same way a newline does — so the
+  // shaped-blank router agrees with fluid-config's `summonPhraseStart`.
+  it('matches a command after a sentence terminator on the SAME line', () => {
+    assert.deepStrictEqual(
+      matchBlankShape('let me check the audio. volume 30 _', b),
+      { blankName: 'volume', action: 'set', value: '30' },
+    );
+  });
+
+  it('matches after ! and ? terminators too', () => {
+    assert.strictEqual(matchBlankShape('done! volume up _', b)?.value, 'up');
+    assert.strictEqual(matchBlankShape('what now? volume _', b)?.action, 'get');
+  });
+
+  it('matches after a CJK terminator (no trailing space)', () => {
+    assert.strictEqual(matchBlankShape('こんにちは世界。volume 40 _', b)?.value, '40');
+  });
+
+  it('decimal/version dots do NOT split (precision held)', () => {
+    // "3.5" has no space after the dot, so it is NOT a boundary; the segment
+    // stays the whole line → leads with "the" → no match. (The set shape wants
+    // an integer anyway, so even a wrong split would cede cleanly.)
+    assert.strictEqual(matchBlankShape('the cost was 3.5 dollars volume _', b), null);
+    // But a real sentence end before the command DOES fire it.
+    assert.strictEqual(matchBlankShape('the cost was 3.5 dollars. volume _', b)?.action, 'get');
+  });
+
+  it('prose ending in a period that is NOT a command still cedes', () => {
+    assert.strictEqual(matchBlankShape('i turned the volume down. what a day _', b), null);
   });
 });
 

--- a/packages/opencues-core/src/blank-shapes.ts
+++ b/packages/opencues-core/src/blank-shapes.ts
@@ -12,6 +12,7 @@
 // this can never wrongly capture a query (a non-match is a clean cede).
 
 import type { BlankConfig } from './cues-md';
+import { segmentStart } from './segment';
 
 export interface BlankShapeMatch {
   /** Blank whose shape matched. */
@@ -23,17 +24,23 @@ export interface BlankShapeMatch {
 }
 
 /**
- * Strip zero-width markers, then return the LINE containing the (last) `_`,
- * trimmed. Shapes are LINE-scoped: a command like `weather oslo _` claims its
- * `_` even when there's prior content on earlier lines ("notes…\nweather oslo
- * _"). Returns null when there's no `_`. Anchoring to the line (not the whole
- * buffer) is what lets shapes replace the old line-scoped keyword window.
+ * Strip zero-width markers, then return the command SEGMENT containing the
+ * (last) `_`, trimmed. Shapes are SENTENCE-scoped: a command like `weather oslo
+ * _` claims its `_` when it leads its sentence — whether that sentence starts at
+ * a newline ("notes…\nweather oslo _") OR after a sentence terminator on the
+ * same line ("let me check. weather oslo _" → "weather oslo _"). The
+ * segment START comes from the shared `segmentStart` (the same boundary
+ * fluid-config's `summonPhraseStart` uses, so the two routers agree); the END
+ * stays at the next newline / buffer end. Returns null when there's no `_`.
+ * Anchoring to the sentence (not the whole buffer) is what lets shapes replace
+ * the old line-scoped keyword window without a stray keyword in prose hijacking
+ * a `_`.
  */
 function lineWithBlank(text: string): string | null {
   const s = text.replace(/[​‌]/g, '');
   const us = s.lastIndexOf('_');
   if (us === -1) return null;
-  const start = s.lastIndexOf('\n', us) + 1; // 0 when there's no preceding newline
+  const start = segmentStart(s, us); // last sentence terminator OR newline before `_`
   let end = s.indexOf('\n', us);
   if (end === -1) end = s.length;
   return s.slice(start, end).trim();

--- a/packages/opencues-core/src/blank-shapes.ts
+++ b/packages/opencues-core/src/blank-shapes.ts
@@ -13,6 +13,7 @@
 
 import type { BlankConfig } from './cues-md';
 import { segmentStart } from './segment';
+import { keywordInWindow, lineOfWords } from './keyword-window';
 
 export interface BlankShapeMatch {
   /** Blank whose shape matched. */
@@ -82,4 +83,52 @@ export function matchBlankShape(
     }
   }
   return null;
+}
+
+type ClaimBlank = Pick<BlankConfig, 'blankShapes' | 'blankKeywords'>;
+
+/**
+ * Does some keyword/shaped blank CLAIM this `_`? The SINGLE shared cede
+ * predicate for the three semantic-`_` sources (FluidBlank / TransformBlank /
+ * ConfigIntent): each returns `false` from `supports()` when this returns true,
+ * yielding the `_` to the blank. Centralised so the three can't drift — the
+ * June 2026 long-buffer bug was ConfigIntent carrying a stale inline copy that
+ * (unlike the other two) didn't skip shaped blanks, so an incidental keyword in
+ * prose (`The volume is now 30%`) on the `_`'s line made it cede and a real
+ * settings command (`voice mode off _`) silently fell through to fluid-blank.
+ *
+ *   - TYPE-BASED: a declared SHAPE matches the `_`'s segment (anchored grammar,
+ *     e.g. `volume 30 _`). Exact, so prose can never trigger it.
+ *   - LEGACY (non-shaped blanks only): a keyword sits on the same line as `_`
+ *     (shared `keywordInWindow`). Shaped blanks are governed solely by the
+ *     shape match above — a stray keyword in prose doesn't claim.
+ */
+export function blankClaimsUnderscore(
+  text: string,
+  words: readonly string[],
+  blanks: ReadonlyMap<string, ClaimBlank> | Readonly<Record<string, ClaimBlank>>,
+): boolean {
+  if (matchBlankShape(text, blanks)) return true;
+  const lower = words.map(w => w.toLowerCase());
+  const blankIndex = lower.indexOf('_');
+  if (blankIndex === -1) return false;
+  const lineOf = lineOfWords(text);
+  const entries: Iterable<ClaimBlank> =
+    blanks instanceof Map ? blanks.values() : Object.values(blanks);
+  for (const blk of entries) {
+    if (blk.blankShapes?.length) continue;
+    if (!blk.blankKeywords?.length) continue;
+    for (const phrase of blk.blankKeywords) {
+      const parts = phrase.toLowerCase().split(/\s+/);
+      for (let i = 0; i <= lower.length - parts.length; i += 1) {
+        let ok = true;
+        for (let j = 0; j < parts.length; j += 1) {
+          if (lower[i + j] !== parts[j]) { ok = false; break; }
+        }
+        if (!ok) continue;
+        if (keywordInWindow(i + parts.length - 1, blankIndex, { lineOf })) return true;
+      }
+    }
+  }
+  return false;
 }

--- a/packages/opencues-core/src/conformance.test.ts
+++ b/packages/opencues-core/src/conformance.test.ts
@@ -395,19 +395,32 @@ function routeWord(sources: Array<{ name: string; priority?: number; match?: str
 }
 
 /**
- * Spec blank routing algorithm — LINE-SCOPED shapes. A blank claims a `_`
- * when one of its keywords (or an explicit `blankShapes` pattern) leads the
- * LINE containing `_`, with `_` at the trailing edge. Keywords desugar to
- * the standard shape `^<kw>( <args>)? _$`. A command must lead its line;
- * prose that merely mentions a keyword mid-line does not fire. Mirrors
- * `matchBlankShape` + `synthesizeKeywordShapes` in the reference runtime.
- * Implemented inline so this runner validates the fixtures self-consistently;
- * a second runner SHOULD exercise the same fixtures against its dispatcher.
+ * Spec blank routing algorithm (0.4) — SENTENCE-SCOPED shapes. A blank claims a
+ * `_` when one of its keywords (or an explicit `blankShapes` pattern) leads the
+ * SENTENCE containing `_`, with `_` at the trailing edge. A sentence begins at
+ * the last sentence terminator (`.`/`!`/`?` + whitespace, or a CJK `。！？．`) OR
+ * newline before `_` — so `let me check. volume _` routes, not just
+ * `notes\nvolume _`. Keywords desugar to the standard shape `^<kw>( <args>)? _$`.
+ * A command must lead its sentence; prose that merely mentions a keyword
+ * mid-sentence does not fire. Mirrors `matchBlankShape` + `segmentStart` +
+ * `synthesizeKeywordShapes` in the reference runtime. Implemented inline (with
+ * its OWN boundary scan) so this runner validates the fixtures self-consistently
+ * — a second runner SHOULD exercise the same fixtures against its dispatcher.
  */
+function segmentStartConf(text: string, pos: number): number {
+  const re = /[.!?](?=\s)|[。！？．]|\n/g;
+  const upto = text.slice(0, pos);
+  let start = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(upto)) !== null) start = m.index + m[0].length;
+  while (start < text.length && /\s/.test(text.charAt(start))) start += 1;
+  return start;
+}
+
 function routeBlank(blanks: Array<{ name: string; blankKeywords?: string[]; blankShapes?: Array<{ pattern: string }> }>, text: string): string | null {
   const us = text.lastIndexOf('_');
   if (us === -1) return null;
-  const start = text.lastIndexOf('\n', us) + 1;
+  const start = segmentStartConf(text, us);
   let end = text.indexOf('\n', us);
   if (end === -1) end = text.length;
   const line = text.slice(start, end).trim().toLowerCase();

--- a/packages/opencues-core/src/index.ts
+++ b/packages/opencues-core/src/index.ts
@@ -282,3 +282,4 @@ export {
 } from './feature-registry';
 
 export { matchBlankShape, type BlankShapeMatch } from './blank-shapes';
+export { segmentStart } from './segment';

--- a/packages/opencues-core/src/segment.ts
+++ b/packages/opencues-core/src/segment.ts
@@ -1,0 +1,44 @@
+// segment.ts — the SINGLE source of truth for "where does the command segment
+// containing this `_` begin?", shared by the two routers that need it:
+//
+//   - blank-shapes.ts  (lineWithBlank)      — shaped-blank routing
+//   - config-intent-source.ts (summonPhraseStart) — fluid-config settings routing
+//
+// Why centralised: before this, the two disagreed. Shaped blanks anchored on
+// the PHYSICAL LINE (newline only), so `let me check the audio. volume _` did
+// NOT fire volume — "volume" wasn't at the line start. But fluid-config already
+// anchored on the SENTENCE (last `.`/`!`/`?` or newline), so the same buffer
+// shape routed for settings but not for blanks. Users reasonably read "line" as
+// "sentence". Routing both through this one predicate makes a command claim its
+// `_` whenever it leads a SENTENCE, not just a physical line — and the two
+// routers can never drift on what counts as a boundary.
+//
+// A boundary is: an ASCII terminator (`.`/`!`/`?`) FOLLOWED by whitespace (the
+// `(?=\s)` lookahead is what stops `gpt-5.4` / `3.5` decimals from splitting),
+// a CJK/fullwidth terminator (`。`/`！`/`？`/`．` — those scripts put no space
+// after the stop), or a newline. The strict anchored shape still has to match
+// the post-boundary segment, so a wrong split is always a clean cede, never
+// garbage.
+
+/** Boundary between command segments: sentence terminator (+ space for ASCII)
+ *  or newline. Kept as a literal so both call sites share the exact grammar. */
+const SEGMENT_BOUNDARY = /[.!?](?=\s)|[。！？．]|\n/g;
+
+/**
+ * Index in `text` where the command segment containing position `pos` begins —
+ * i.e. just past the last sentence terminator or newline before `pos`, with any
+ * leading whitespace skipped. Returns 0 when there is no boundary before `pos`.
+ *
+ * `pos` defaults to `text.length` (scan the whole buffer), which reproduces the
+ * original `summonPhraseStart` contract exactly. Callers routing a `_` pass the
+ * `_`'s index so boundaries after the `_` are ignored.
+ */
+export function segmentStart(text: string, pos: number = text.length): number {
+  const upto = pos >= text.length ? text : text.slice(0, pos);
+  const re = new RegExp(SEGMENT_BOUNDARY.source, 'g');
+  let start = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(upto)) !== null) start = m.index + m[0].length;
+  while (start < text.length && /\s/.test(text.charAt(start))) start += 1;
+  return start;
+}

--- a/packages/opencues-core/src/sources/config-intent-source.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.ts
@@ -59,6 +59,7 @@
 
 import { CueSource, CueContext, CueSourceResult, CueResult, HttpAdapter } from '../types';
 import { keywordInWindow, lineOfWords } from '../keyword-window';
+import { segmentStart } from '../segment';
 import { BlankConfig } from '../cues-md';
 import { describeLLMCall, dispatchChat, getProvider, listProviders, type ProviderAdapter } from '../llm-provider';
 import { classifyLlmError, type FluidBlankErrorReason } from './fluid-blank-source';
@@ -844,14 +845,13 @@ export interface ConfigIntentSourceConfig {
  * Japanese buffer like `こんにちは世界。voice mode off _` found no boundary
  * and wiped the user's whole sentence (a language-dependent data-loss bug).
  * A line break is always a boundary. No boundary found → 0.
+ *
+ * Delegates to the shared `segmentStart` (scanning the whole buffer) so this
+ * router and the shaped-blank router (`lineWithBlank`) anchor commands on the
+ * exact same sentence/line boundary — they can't drift.
  */
 export function summonPhraseStart(text: string): number {
-  const re = /[.!?](?=\s)|[。！？．]|\n/g;
-  let start = 0;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(text)) !== null) start = m.index + m[0].length;
-  while (start < text.length && /\s/.test(text.charAt(start))) start++;
-  return start;
+  return segmentStart(text);
 }
 
 export class ConfigIntentSource implements CueSource {

--- a/packages/opencues-core/src/sources/config-intent-source.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.ts
@@ -58,8 +58,8 @@
  */
 
 import { CueSource, CueContext, CueSourceResult, CueResult, HttpAdapter } from '../types';
-import { keywordInWindow, lineOfWords } from '../keyword-window';
 import { segmentStart } from '../segment';
+import { blankClaimsUnderscore } from '../blank-shapes';
 import { BlankConfig } from '../cues-md';
 import { describeLLMCall, dispatchChat, getProvider, listProviders, type ProviderAdapter } from '../llm-provider';
 import { classifyLlmError, type FluidBlankErrorReason } from './fluid-blank-source';
@@ -925,28 +925,14 @@ export class ConfigIntentSource implements CueSource {
     const blankIndex = lower.indexOf('_');
     if (blankIndex === -1) return false;
 
-    // Cede to keyword-bound BlankSource if a registered blank's keyword is
-    // on the same line as the `_` — the shared `keywordInWindow` keeps all
-    // three semantic-`_` sources + BlankFill + BlankSource on the same
-    // line-scoped boundary. See keyword-window.ts.
-    const lineOf = lineOfWords(context.text);
-    for (const blk of Object.values(this.blanks)) {
-      if (!blk.blankKeywords?.length) continue;
-      for (const phrase of blk.blankKeywords) {
-        const parts = phrase.toLowerCase().split(/\s+/);
-        for (let i = 0; i <= lower.length - parts.length; i++) {
-          let ok = true;
-          for (let j = 0; j < parts.length; j++) {
-            if (lower[i + j] !== parts[j]) { ok = false; break; }
-          }
-          if (!ok) continue;
-          const endIdx = i + parts.length - 1;
-          if (keywordInWindow(endIdx, blankIndex, { lineOf })) {
-            return false;
-          }
-        }
-      }
-    }
+    // Cede when a keyword/shaped blank claims this `_` (shape match, or a
+    // non-shaped blank's keyword on the same line). SHARED predicate —
+    // identical for FluidBlank / TransformBlank / ConfigIntent so they can't
+    // drift. The June 2026 long-buffer bug was ConfigIntent carrying a stale
+    // inline copy that didn't skip shaped blanks: an incidental "volume" in a
+    // woven `The volume is now 30%` made it cede, so `voice mode off _` fell
+    // through to fluid-blank instead of flipping the setting.
+    if (blankClaimsUnderscore(context.text, context.words, this.blanks)) return false;
 
     return true;
   }

--- a/packages/opencues-core/src/sources/fluid-blank-source.ts
+++ b/packages/opencues-core/src/sources/fluid-blank-source.ts
@@ -25,12 +25,11 @@
 
 import { CueSource, CueContext, CueSourceResult, CueResult, HttpAdapter, AmbientContext } from '../types';
 import { BlankConfig } from '../cues-md';
-import { keywordInWindow, lineOfWords } from '../keyword-window';
 import { useStrictJson, buildJsonResponseFormat, describeLLMCall, dispatchChat, getProvider, type ProviderAdapter } from '../llm-provider';
 import { renderIdentityContextCatalog, postProcessContext, type Identity, type ContextMode } from '../identity-context';
 import { renderBlankContextCatalog, mergeCatalogs, type BlankContextSnapshot, type BlankContextMode } from '../blank-context';
 import { resolveTypedSentinels, catalogScalarLookup, instanceTokenFnBridge, jsonFieldAccessor } from '../typed-sentinel';
-import { matchBlankShape } from '../blank-shapes';
+import { blankClaimsUnderscore } from '../blank-shapes';
 
 // ─── Ambient-context sanitization + injection ──────────────────────
 //
@@ -764,28 +763,11 @@ export class FluidBlankSource implements CueSource {
     // preserved untouched, which is strictly better than substituting
     // the entire sentence with an LLM-guessed answer.
     if (TASK_TRIGGER_GUARD.test(context.text)) return false;
-    // TYPE-BASED CEDE (shaped blanks): cede iff a declared SHAPE claims this
-    // `_` — exact grammar, so an anchored shape can't match prose. This is what
-    // stops fluid from wrongly ceding conversational input to a keyword blank.
-    if (matchBlankShape(context.text, this.blanks)) return false;
-    // LEGACY CEDE (non-shaped blanks only): a blank that hasn't migrated to
-    // shapes still cedes via keyword on the same line as `_`. Shaped blanks
-    // are skipped here — they're governed solely by the shape match above.
-    const lineOf = lineOfWords(context.text);
-    for (const blk of Object.values(this.blanks)) {
-      if (blk.blankShapes?.length) continue;
-      if (!blk.blankKeywords?.length) continue;
-      for (const phrase of blk.blankKeywords) {
-        const parts = phrase.toLowerCase().split(/\s+/);
-        for (let i = 0; i <= lower.length - parts.length; i++) {
-          let ok = true;
-          for (let j = 0; j < parts.length; j++) { if (lower[i + j] !== parts[j]) { ok = false; break; } }
-          if (!ok) continue;
-          const endIdx = i + parts.length - 1;
-          if (keywordInWindow(endIdx, blankIndex, { lineOf })) return false;
-        }
-      }
-    }
+    // Cede when a keyword/shaped blank claims this `_` (shape match, or a
+    // non-shaped blank's keyword on the same line). SHARED predicate —
+    // identical for FluidBlank / TransformBlank / ConfigIntent so they can't
+    // drift (see blankClaimsUnderscore).
+    if (blankClaimsUnderscore(context.text, context.words, this.blanks)) return false;
     return true;
   }
 

--- a/packages/opencues-core/src/sources/transform-blank-source.ts
+++ b/packages/opencues-core/src/sources/transform-blank-source.ts
@@ -31,7 +31,6 @@
 
 import { CueSource, CueContext, CueSourceResult, CueResult, HttpAdapter } from '../types';
 import { BlankConfig } from '../cues-md';
-import { keywordInWindow, lineOfWords } from '../keyword-window';
 import { describeLLMCall, dispatchChat, getProvider, type ProviderAdapter } from '../llm-provider';
 import { classifyLlmError, type FluidBlankErrorReason } from './fluid-blank-source';
 import { detectPartialTransform } from './transform-partial-detector';
@@ -55,7 +54,7 @@ import {
   instanceTokenFnBridge,
   jsonFieldAccessor,
 } from '../typed-sentinel';
-import { matchBlankShape } from '../blank-shapes';
+import { blankClaimsUnderscore } from '../blank-shapes';
 
 // ============================================================================
 // Prompts — ported verbatim from tests/benchmarks/transform-blank/
@@ -517,26 +516,11 @@ export class TransformBlankSource implements CueSource {
     const blankIndex = lower.indexOf('_');
     if (blankIndex === -1) return false;
 
-    // TYPE-BASED CEDE (shaped blanks): cede iff a declared SHAPE claims the `_`.
-    if (matchBlankShape(context.text, this.blanks)) return false;
-    // LEGACY CEDE (non-shaped blanks only): keyword on the same line as `_`
-    // until they migrate to shapes. Shaped blanks are governed solely by the
-    // shape above.
-    const lineOf = lineOfWords(context.text);
-    for (const blk of Object.values(this.blanks)) {
-      if (blk.blankShapes?.length) continue;
-      if (!blk.blankKeywords?.length) continue;
-      for (const phrase of blk.blankKeywords) {
-        const parts = phrase.toLowerCase().split(/\s+/);
-        for (let i = 0; i <= lower.length - parts.length; i++) {
-          let ok = true;
-          for (let j = 0; j < parts.length; j++) { if (lower[i + j] !== parts[j]) { ok = false; break; } }
-          if (!ok) continue;
-          const endIdx = i + parts.length - 1;
-          if (keywordInWindow(endIdx, blankIndex, { lineOf })) return false;
-        }
-      }
-    }
+    // Cede when a keyword/shaped blank claims this `_` (shape match, or a
+    // non-shaped blank's keyword on the same line). SHARED predicate —
+    // identical for FluidBlank / TransformBlank / ConfigIntent so they can't
+    // drift (see blankClaimsUnderscore).
+    if (blankClaimsUnderscore(context.text, context.words, this.blanks)) return false;
 
     // Always claim. EXTRACT is the authoritative classifier — if the
     // input isn't actually a transform, EXTRACT returns VERDICT: NONE

--- a/packages/opencues-core/src/spec-version.ts
+++ b/packages/opencues-core/src/spec-version.ts
@@ -25,7 +25,7 @@
  * permanent rule — old unannotated files keep working forever; the
  * default never moves forward).
  */
-export const SPEC_VERSION = '0.3' as const;
+export const SPEC_VERSION = '0.4' as const;
 
 export type SpecVersion = typeof SPEC_VERSION;
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -16,6 +16,41 @@ breaking.
 
 ---
 
+## [0.4.0-alpha] — 2026-06-30
+
+Spec bump: the blank routing boundary moves from the physical **line** to
+the **sentence**. A keyword/shape now claims a `_` when it leads the
+sentence containing `_`, where a sentence begins at the last sentence
+terminator (`.`/`!`/`?` + whitespace, or a CJK/fullwidth `。`/`！`/`？`/`．`)
+OR newline before `_`. Previously only a newline started a new routing
+segment, so a command after a sentence terminator on the same line
+(`let me check. volume _`) did not fire. The change is backward-compatible
+in practice — strictly *more* commands route, none that fired before stop —
+but the normative trigger text changed, so a `0.3-alpha` reader will refuse
+`spec: opencues/0.4-alpha` files per the "newer-spec-refuse" rule
+(`SPEC.md` § Version policy). The omit-default stays `0.1-alpha`.
+
+### Changed
+
+- **Blank trigger model** — `blankShapes` (and synthesized keyword shapes)
+  are matched against the SENTENCE containing `_`, not the physical line.
+  The segment begins at the last sentence terminator (`.`/`!`/`?` followed
+  by whitespace — the whitespace lookahead keeps decimals like `3.5` /
+  versions like `gpt-5.4` from splitting — or a CJK `。`/`！`/`？`/`．`) or
+  newline before `_`. A command must still lead its segment with `_` at the
+  trailing edge; a keyword merely mentioned mid-sentence does not fire.
+  (`spec/blank-spec.md` § Trigger model, `core.md` § Routing.)
+
+### Conformance
+
+- `spec/conformance/routing/blank-shapes.json` — added sentence-boundary
+  cases (`let me check. volume _` → volume, `done! weather oslo _` →
+  weather, CJK `世界。weather kyoto _` → weather) and negative cases
+  (`i turned the volume down. what a day _` → null; a connective before the
+  keyword, `first the lights. then weather tokyo _` → null).
+
+---
+
 ## [0.3.0-alpha] — 2026-06-29
 
 Spec bump: blank routing + frontmatter surface slim-down. The blank

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # OpenCues — Open Standard
 
-> **Status:** `0.3-alpha`. Expect changes.
+> **Status:** `0.4-alpha`. Expect changes.
 
 This directory holds three open file-format standards — **Cues**, **Blanks**, and **Auditors** — that any text editor, IDE, or LLM-pipeline can implement to interoperate. Each surface has its own spec file and its own conformance contract; a runtime can implement one and be conformant for that surface (you don't have to implement all three). Licensed under the same terms as this repository (see [`LICENSE`](../LICENSE)).
 

--- a/spec/auditor-spec.md
+++ b/spec/auditor-spec.md
@@ -1,6 +1,6 @@
 # auditor-spec — the Auditor file format & runtime contract
 
-> **Status:** `0.3-alpha`. Expect changes.
+> **Status:** `0.4-alpha`. Expect changes.
 
 An **auditor** is the third surface of the standard. Where a cue operates on one word and a blank operates on one `_` slot, an auditor operates on the **whole buffer**: it declares one concern (grammar, clarity, jargon flagging, PII redaction, tone) that an inline rewrite agent should attend to as the user types.
 

--- a/spec/blank-spec.md
+++ b/spec/blank-spec.md
@@ -1,6 +1,6 @@
 # blank-spec — the Blank file format & runtime contract
 
-> **Status:** `0.3-alpha`. Expect changes.
+> **Status:** `0.4-alpha`. Expect changes.
 
 A **blank** is the user→system surface: when a user writes `_` (underscore) in their text, the runtime substitutes a value sourced from somewhere — a list, a shell script, an in-process function. Blanks are how text touches the world: volume, weather, stock prices, dictionary entries, settings toggles. This document specifies the `BLANK.md` file format and what a conformant runtime MUST do with one.
 
@@ -36,7 +36,7 @@ Every blank is folder-shaped — there is no flat-file alternative. A declarativ
 A blank fires when **all** of these hold:
 
 1. The user's text contains `_` (the blank marker).
-2. One of the blank's `blankShapes` matches the LINE containing `_` (anchored, whole-line grammar). When a blank declares no `blankShapes`, the runtime synthesizes them from `blankKeywords`: a keyword claims a `_` on the SAME LINE (line-scoped), capturing any words between the keyword and `_` as the `get` arg. Either way, routing is deterministic and the command must lead its line with `_` at the trailing edge — prose that merely mentions a keyword mid-line does NOT fire.
+2. One of the blank's `blankShapes` matches the SENTENCE containing `_` (anchored, whole-segment grammar). When a blank declares no `blankShapes`, the runtime synthesizes them from `blankKeywords`: a keyword claims a `_` when it leads the SENTENCE (sentence-scoped), capturing any words between the keyword and `_` as the `get` arg. A sentence begins at the last sentence terminator (`.`/`!`/`?` followed by whitespace, or a CJK/fullwidth `。`/`！`/`？`/`．`) OR newline before `_` — so a command leading a new sentence on the same line (`let me check. volume _`) routes the same as one on its own line (`notes\nvolume _`). Either way, routing is deterministic and the command must lead its sentence with `_` at the trailing edge — prose that merely mentions a keyword mid-sentence does NOT fire.
 3. The runtime has loaded the blank source.
 
 Blanks fire deterministically. The `description:` field is documentation only — it does NOT control invocation. (Contrast with [SKILL.md](https://github.com/anthropics/skills), where `description` is the LLM's invocation hook.)
@@ -52,7 +52,7 @@ When `_` matches no blank, a runtime MAY provide a **fluid-blank fallback** (typ
 | Field | Type | Notes |
 |---|---|---|
 | `name` | string | Unique identifier. By convention, this is also the in-process class name when `impl:` is implicit. |
-| `blankKeywords` | comma-separated list **or** YAML list | Words that fire this blank when one **leads the line** containing `_` (line-scoped — see § Trigger model). Desugar into anchored `blankShapes`. |
+| `blankKeywords` | comma-separated list **or** YAML list | Words that fire this blank when one **leads the sentence** containing `_` (sentence-scoped — see § Trigger model). Desugar into anchored `blankShapes`. |
 
 A blank source MUST also declare **exactly one** binding profile (see § Binding profiles). Zero binding profiles = invalid (no behavior). More than one = invalid (ambiguous).
 
@@ -70,7 +70,7 @@ A blank source MUST also declare **exactly one** binding profile (see § Binding
 | `type` | `"blank"` | inferred from path | Discriminator. Files under `blanks/` are blanks by location; explicit `type: blank` is rarely needed. |
 | `priority` | number | `50` | Higher wins on routing ties when multiple blanks could claim the same `_` slot (rare — usually disambiguated by `blankKeywords`). Range 0–100 by convention. |
 | `enabled` | boolean | `true` | `false` = blank is parsed but not registered. Use the master `BLANKS.md` `disable: [<id>]` to skip a blank from a project layer without modifying the source file itself. |
-| `blankShapes` | JSON list of `{pattern, action, valueGroup?}` | derived from `blankKeywords` | Anchored regex grammar that routes a `_` deterministically. Each shape's `pattern` is matched (case-insensitive) against the LINE containing `_`; on match the blank claims it with `action` (`"get"` / `"set"` / `"step"`) and the value from capture group `valueGroup`. e.g. `[{"pattern":"^volume\\s+(\\d+)\\s*_$","action":"set","valueGroup":1}]`. When omitted, the runtime synthesizes shapes from `blankKeywords` (+ `blankStep` for set/step). See § Routing. |
+| `blankShapes` | JSON list of `{pattern, action, valueGroup?}` | derived from `blankKeywords` | Anchored regex grammar that routes a `_` deterministically. Each shape's `pattern` is matched (case-insensitive) against the SENTENCE containing `_` (segment after the last sentence terminator / newline before `_`); on match the blank claims it with `action` (`"get"` / `"set"` / `"step"`) and the value from capture group `valueGroup`. e.g. `[{"pattern":"^volume\\s+(\\d+)\\s*_$","action":"set","valueGroup":1}]`. When omitted, the runtime synthesizes shapes from `blankKeywords` (+ `blankStep` for set/step). See § Routing. |
 | `blankStep` | number | none | Increment size for numeric blanks (set/step `up`/`down`). Also adds set/step shapes when `blankShapes` is synthesized from keywords. |
 | `blankSuffix` | string | `""` | Appended to the displayed value (`"%"`, `"°C"`, `"$"`). |
 | `integration` | string | none | Additive output template with a `{value}` slot (`"volume is now {value}"`). The runtime renders the blank's output through it, weaving connective text around the value. Add-only — it only shapes the inserted value, never surrounding text. |
@@ -314,7 +314,7 @@ All methods are async. The `keyword` argument carries which `blankKeywords` entr
 
 - **`blankSatellite: true`** — `get` MAY return `<selector>\t<satellite>` (tab-separated). The runtime MUST splice both as adjacent words. Cycling targets the selector; satellite is updated via `set <selector> <value>`.
 - **`blankDismissible: true`** — runtime MUST append `_` to the cycling list. Selecting it sets a "dismissed" flag for that slot; runtime MUST NOT re-populate until the user explicitly cycles away.
-- **`blankShapes`** — each `{pattern, action, valueGroup?}` is matched (case-insensitive) against the LINE containing `_`; the first match claims it. `valueGroup` (1-based) extracts the `set`/`step` value. A blank with shapes is routed solely by them; the keyword window does not apply.
+- **`blankShapes`** — each `{pattern, action, valueGroup?}` is matched (case-insensitive) against the SENTENCE containing `_` (the segment after the last sentence terminator / newline before `_`); the first match claims it. `valueGroup` (1-based) extracts the `set`/`step` value. A blank with shapes is routed solely by them; the keyword window does not apply.
 - **`blankStep`, `blankSuffix`** — numeric step size + display unit. Runtime MUST honor for numeric blanks.
 
 ---

--- a/spec/conformance/routing/README.md
+++ b/spec/conformance/routing/README.md
@@ -29,7 +29,7 @@ Blank-routing scenarios use a different shape:
 
 ```json
 {
-  "description": "Blank shapes route the line containing _ (keywords desugar to shapes)",
+  "description": "Blank shapes route the sentence containing _ (keywords desugar to shapes)",
   "blanks": [
     { "name": "volume",  "blankKeywords": ["volume"] },
     { "name": "weather", "blankKeywords": ["weather"] }
@@ -51,7 +51,7 @@ Blank-routing scenarios use a different shape:
 | [`per-word-dispatch.json`](./per-word-dispatch.json) | Each word goes to exactly one source — the highest priority match. |
 | [`priority-tiebreak.json`](./priority-tiebreak.json) | Equal-priority sources fall back to declaration order. |
 | [`catch-all-fallback.json`](./catch-all-fallback.json) | DEFAULT source claims words no DOMAIN source matched. |
-| [`blank-shapes.json`](./blank-shapes.json) | `blankShapes` (or synthesized keyword shapes) route the line containing `_`; a command must lead its line. |
+| [`blank-shapes.json`](./blank-shapes.json) | `blankShapes` (or synthesized keyword shapes) route the sentence containing `_`; a command must lead its sentence (terminator/newline boundary). |
 
 ## What's covered
 
@@ -59,7 +59,7 @@ Blank-routing scenarios use a different shape:
 - Multi-source priority resolution
 - DOMAIN vs DEFAULT (catch-all) semantics
 - Declaration-order tiebreak on equal priority
-- Blank-shape line-scoped dispatch (command leads its line; mid-line keyword mention does not fire)
+- Blank-shape sentence-scoped dispatch (command leads its sentence — terminator or newline boundary; mid-sentence keyword mention does not fire)
 
 ## What's not covered (deliberately)
 

--- a/spec/conformance/routing/blank-shapes.json
+++ b/spec/conformance/routing/blank-shapes.json
@@ -1,14 +1,24 @@
 {
-  "description": "Blank shapes route the line containing _. Keywords desugar to shapes (a keyword claims a _ on its line, capturing any words between as the get arg). A command must LEAD its line with _ at the trailing edge; prose that merely mentions a keyword mid-line does not fire.",
+  "description": "Blank shapes route the SENTENCE containing _ (0.4). Keywords desugar to shapes (a keyword claims a _ when it leads its sentence, capturing any words between as the get arg). A sentence begins at the last terminator (./!/? + space, or CJK 。！？．) OR newline before _. A command must LEAD its sentence with _ at the trailing edge; prose that merely mentions a keyword mid-sentence does not fire.",
   "blanks": [
     { "name": "volume",  "blankKeywords": ["volume"] },
     { "name": "weather", "blankKeywords": ["weather"] }
   ],
   "expectations": [
-    { "text": "volume _",              "routesTo": "volume"  },
-    { "text": "weather paris _",       "routesTo": "weather" },
-    { "text": "weather in oslo _",     "routesTo": "weather" },
-    { "text": "the volume was loud _", "routesTo": null      },
-    { "text": "i love the weather today _", "routesTo": null }
+    { "text": "volume _",                       "routesTo": "volume"  },
+    { "text": "weather paris _",                "routesTo": "weather" },
+    { "text": "weather in oslo _",              "routesTo": "weather" },
+    { "text": "the volume was loud _",          "routesTo": null      },
+    { "text": "i love the weather today _",     "routesTo": null      },
+
+    { "text": "some notes here\nvolume _",      "routesTo": "volume"  },
+
+    { "text": "let me check. volume _",         "routesTo": "volume"  },
+    { "text": "done with that! weather oslo _", "routesTo": "weather" },
+    { "text": "what now? volume _",             "routesTo": "volume"  },
+    { "text": "こんにちは世界。weather kyoto _",    "routesTo": "weather" },
+
+    { "text": "i turned the volume down. what a day _", "routesTo": null },
+    { "text": "first the lights. then weather tokyo _", "routesTo": null }
   ]
 }

--- a/spec/core.md
+++ b/spec/core.md
@@ -1,6 +1,6 @@
 # core — shared rules across cue-spec and blank-spec
 
-> **Status:** `0.3-alpha`. Expect changes.
+> **Status:** `0.4-alpha`. Expect changes.
 
 This document covers concerns shared by `cue-spec.md`, `blank-spec.md`, and `auditor-spec.md`: the project search-path, the master `CUES.md` / `BLANKS.md` / `AUDITORS.md` files at the root, host compatibility, hot-reload, routing, and the promotion path from runtime-specific knobs to standard fields.
 
@@ -178,7 +178,7 @@ Resolution algorithm:
 2. On priority ties, declaration order wins (sources from earlier search-path entries first; then file-system order within a directory).
 3. If no source claims the word, the word produces no cue (it's not navigable).
 
-For blanks, routing is by `blankShapes` — anchored whole-line grammar matched against the line containing `_` (keywords desugar to shapes; a keyword claims a `_` on its line). Tie resolution: by source priority (declaration order if equal). The fluid-blank fallback (when implemented) handles `_` that no shape claims. Runtimes that ship a transform-blank surface alongside fluid-blank SHOULD ensure their fluid-blank fallback refuses inputs that look like transform-blank task triggers — otherwise a mistyped task command falls through to the lookup pipeline and gets hallucinated as an answer (see [`@opencues/runtime`'s `SPEC.md` § Task-trigger guard](../packages/opencues-runtime/SPEC.md#task-trigger-guard) for the OpenCues runtime's implementation).
+For blanks, routing is by `blankShapes` — anchored whole-segment grammar matched against the SENTENCE containing `_` (keywords desugar to shapes; a keyword claims a `_` when it leads its sentence — the segment after the last sentence terminator (`.`/`!`/`?` + whitespace, or CJK `。！？．`) or newline before `_`). Tie resolution: by source priority (declaration order if equal). The fluid-blank fallback (when implemented) handles `_` that no shape claims. Runtimes that ship a transform-blank surface alongside fluid-blank SHOULD ensure their fluid-blank fallback refuses inputs that look like transform-blank task triggers — otherwise a mistyped task command falls through to the lookup pipeline and gets hallucinated as an answer (see [`@opencues/runtime`'s `SPEC.md` § Task-trigger guard](../packages/opencues-runtime/SPEC.md#task-trigger-guard) for the OpenCues runtime's implementation).
 
 ---
 

--- a/spec/cue-spec.md
+++ b/spec/cue-spec.md
@@ -1,6 +1,6 @@
 # cue-spec — the Cue file format & runtime contract
 
-> **Status:** `0.3-alpha`. Expect changes.
+> **Status:** `0.4-alpha`. Expect changes.
 
 A **cue** is the LLM→user surface: while a user types plain text, a cue source proposes alternatives for words it recognises. The user can cycle through them with a keyboard input (or any runtime-defined trigger). This document specifies the `CUE.md` file format and what a conformant runtime MUST do with one.
 

--- a/spec/identity-context-spec.md
+++ b/spec/identity-context-spec.md
@@ -1,6 +1,6 @@
 # identity-context-spec — the `IDENTITY.md` file format & sentinel token contract
 
-> **Status:** `0.3-alpha`. Expect changes.
+> **Status:** `0.4-alpha`. Expect changes.
 
 `IDENTITY.md` is the **user's personal-data catalog**. Each frontmatter
 field derives a canonical bracket-token (a *sentinel*) the LLM can

--- a/tests/benchmarks/blank-routing/README.md
+++ b/tests/benchmarks/blank-routing/README.md
@@ -1,0 +1,46 @@
+# blank-routing — sentence-aware shaped-blank routing bench
+
+Deterministic A/B benchmark (no LLM) for the segment-boundary change in
+`@opencues/core`'s shaped-blank router.
+
+## What it measures
+
+Shaped blanks (`volume 30 _`, `weather oslo _`, …) route by matching an anchored
+grammar against the **segment** containing `_`. Originally that segment was the
+physical **line** (newline-delimited), so a command written after a sentence
+terminator on the same line — `let me check the audio. volume 30 _` — did **not**
+fire: "volume" wasn't at the line start. fluid-config already anchored on the
+**sentence** (`summonPhraseStart`), so the two routers disagreed and users
+(reasonably) read "line" as "sentence".
+
+The change routes both through one shared `segmentStart`: a command claims its
+`_` when it leads its **sentence** (last `.`/`!`/`?`+space, CJK `。！？．`, or
+newline). This bench scores the OLD (newline-only) vs NEW (sentence-aware)
+boundary on the same labeled corpus to prove the change **recovers recall**
+without **trading precision**.
+
+## Run
+
+```bash
+npx tsx tests/benchmarks/blank-routing/sentence-boundary.ts
+```
+
+Exits non-zero if NEW ever scores below OLD on precision OR recall — so it
+doubles as a regression gate, not just a report.
+
+## Result (30 labeled cases)
+
+|            | OLD (newline) | NEW (sentence) |
+|------------|---------------|----------------|
+| precision  | 100.0%        | 100.0%         |
+| recall     | 47.1%         | **100.0%**     |
+
+Recall gains land entirely in `sentence-same-line` (0/6 → 6/6),
+`cjk-terminator` (0/2 → 2/2), and `decimal-then-cmd` (0/1 → 1/1). Precision
+categories (`prose-precision`, `sentence-then-prose`, `connective-prefix`,
+`decimal-guard`, `prev-line`) cede clean under both boundaries — decimals
+(`3.5`, `gpt-5.4`) don't split, and a connective before the keyword
+(`then weather tokyo _`) still cedes because a command must LEAD its sentence.
+
+Re-run after any edit to `segmentStart` (`packages/opencues-core/src/segment.ts`)
+or `lineWithBlank` (`blank-shapes.ts`).

--- a/tests/benchmarks/blank-routing/sentence-boundary.ts
+++ b/tests/benchmarks/blank-routing/sentence-boundary.ts
@@ -1,0 +1,172 @@
+// Benchmark: sentence-aware shaped-blank routing (A/B vs the old newline-only
+// boundary). Deterministic — no LLM. Measures whether anchoring a command at
+// the last SENTENCE terminator (or newline) instead of just the newline:
+//   (a) RECOVERS recall — commands written after a `.`/`!`/`?` on the same line
+//       now fire ("let me check the audio. volume 30 _"), and
+//   (b) HOLDS precision — prose that merely mentions a keyword, and decimals /
+//       versions ("3.5", "gpt-5.4"), still cede cleanly.
+//
+// Run: npx tsx tests/benchmarks/blank-routing/sentence-boundary.ts
+//
+// The NEW boundary is `segmentStart` from @opencues/core (the same predicate
+// fluid-config's summonPhraseStart uses). The OLD boundary is reproduced inline
+// so the two can be scored on the identical corpus.
+
+import { segmentStart } from '../../../packages/opencues-core/src/segment';
+import { synthesizeKeywordShapes, type BlankShape } from '../../../packages/opencues-core/src/cues-md';
+
+type Boundary = (text: string, pos: number) => number;
+
+// OLD: physical-line only — scan back to the last newline before `_`.
+const oldBoundary: Boundary = (text, pos) => text.lastIndexOf('\n', pos) + 1;
+// NEW: sentence terminator OR newline (the shipped change).
+const newBoundary: Boundary = (text, pos) => segmentStart(text, pos);
+
+const BLANKS: ReadonlyMap<string, BlankShape[]> = new Map([
+  ['volume', [
+    { pattern: '^volume\\s*_$', action: 'get' },
+    { pattern: '^volume\\s+(\\d+)\\s*%?\\s*_$', action: 'set', valueGroup: 1 },
+    { pattern: '^set\\s+volume\\s+(?:to\\s+)?(\\d+)\\s*%?\\s*_$', action: 'set', valueGroup: 1 },
+    { pattern: '^volume\\s+(up|down)\\s*_$', action: 'step', valueGroup: 1 },
+  ]],
+  ['weather', synthesizeKeywordShapes(['weather', 'forecast'], false)],
+]);
+
+// Faithful re-implementation of matchBlankShape with a pluggable boundary.
+function route(text: string, boundary: Boundary): string | null {
+  const s = text.replace(/[​‌]/g, '');
+  const us = s.lastIndexOf('_');
+  if (us === -1) return null;
+  const start = boundary(s, us);
+  let end = s.indexOf('\n', us);
+  if (end === -1) end = s.length;
+  const seg = s.slice(start, end).trim();
+  if (!seg.includes('_')) return null;
+  for (const [name, shapes] of BLANKS) {
+    for (const shape of shapes) {
+      let re: RegExp;
+      try { re = new RegExp(shape.pattern, 'i'); } catch { continue; }
+      if (re.test(seg)) return name;
+    }
+  }
+  return null;
+}
+
+interface Case { text: string; expect: string | null; cat: string; }
+
+const CORPUS: Case[] = [
+  // bare command (both should fire)
+  { text: 'volume _', expect: 'volume', cat: 'bare' },
+  { text: 'volume 30 _', expect: 'volume', cat: 'bare' },
+  { text: 'volume up _', expect: 'volume', cat: 'bare' },
+  { text: 'weather oslo _', expect: 'weather', cat: 'bare' },
+  { text: 'forecast _', expect: 'weather', cat: 'bare' },
+
+  // command on its own line, prior content above (both should fire)
+  { text: 'some notes here\nvolume 30 _', expect: 'volume', cat: 'newline' },
+  { text: 'todo list:\nweather paris _', expect: 'weather', cat: 'newline' },
+  { text: 'line one\nline two\nvolume _', expect: 'volume', cat: 'newline' },
+
+  // THE FIX: command after a sentence terminator on the SAME line
+  { text: 'let me check the audio. volume 30 _', expect: 'volume', cat: 'sentence-same-line' },
+  { text: 'one sec. weather oslo _', expect: 'weather', cat: 'sentence-same-line' },
+  { text: 'done with that! volume up _', expect: 'volume', cat: 'sentence-same-line' },
+  { text: 'what now? volume _', expect: 'volume', cat: 'sentence-same-line' },
+  { text: 'turning things down. set volume to 20 _', expect: 'volume', cat: 'sentence-same-line' },
+  { text: 'first the lights. weather tokyo _', expect: 'weather', cat: 'sentence-same-line' },
+
+  // A connective word BEFORE the keyword still cedes — the command must LEAD
+  // its sentence; sentence-awareness doesn't strip "then"/"and"/etc. (clean
+  // cede to fluid-blank, never garbage). Documents the boundary's limit.
+  { text: 'first the lights. then weather tokyo _', expect: null, cat: 'connective-prefix' },
+  { text: 'ok and volume 30 _', expect: null, cat: 'connective-prefix' },
+
+  // CJK terminator (no trailing space) — also same-line recovery
+  { text: 'こんにちは世界。volume 40 _', expect: 'volume', cat: 'cjk-terminator' },
+  { text: '準備中です。weather kyoto _', expect: 'weather', cat: 'cjk-terminator' },
+
+  // decimal / version dots must NOT split (and command is buried → cede)
+  { text: 'the cost was 3.5 dollars volume _', expect: null, cat: 'decimal-guard' },
+  { text: 'gpt-5.4 is fast volume _', expect: null, cat: 'decimal-guard' },
+  // …but a real sentence end before the command DOES fire it
+  { text: 'it cost 3.5 dollars. volume _', expect: 'volume', cat: 'decimal-then-cmd' },
+
+  // prose that merely mentions a keyword — must cede (precision)
+  { text: 'the volume was lovely today _', expect: null, cat: 'prose-precision' },
+  { text: 'the volume of the box is _', expect: null, cat: 'prose-precision' },
+  { text: 'what should i set the volume to _', expect: null, cat: 'prose-precision' },
+  { text: 'i love checking the weather _', expect: null, cat: 'prose-precision' },
+  { text: 'how much is amd stock _', expect: null, cat: 'prose-precision' },
+
+  // sentence ends, then a NON-command sentence — must cede (precision)
+  { text: 'i turned it down. what a lovely day _', expect: null, cat: 'sentence-then-prose' },
+  { text: 'done. anyway moving on _', expect: null, cat: 'sentence-then-prose' },
+  { text: 'checked the forecast. it looks nice _', expect: null, cat: 'sentence-then-prose' },
+
+  // keyword on a PREVIOUS line, command line is prose — must cede
+  { text: 'volume notes\njust a plain line _', expect: null, cat: 'prev-line' },
+];
+
+function score(boundary: Boundary) {
+  let tp = 0, fp = 0, fn = 0, tn = 0;
+  const byCat: Record<string, { fire: number; total: number; wrong: number }> = {};
+  for (const c of CORPUS) {
+    const got = route(c.text, boundary);
+    const slot = (byCat[c.cat] ??= { fire: 0, total: 0, wrong: 0 });
+    slot.total += 1;
+    if (c.expect === null) {
+      if (got === null) tn += 1; else { fp += 1; slot.wrong += 1; }
+    } else if (got === c.expect) { tp += 1; slot.fire += 1; }
+    else if (got === null) { fn += 1; }
+    else { fp += 1; slot.wrong += 1; } // fired the wrong blank
+  }
+  const precision = tp + fp === 0 ? 1 : tp / (tp + fp);
+  const recall = tp + fn === 0 ? 1 : tp / (tp + fn);
+  return { tp, fp, fn, tn, precision, recall, byCat };
+}
+
+const pct = (n: number) => (n * 100).toFixed(1) + '%';
+
+const oldS = score(oldBoundary);
+const newS = score(newBoundary);
+
+console.log('\nSentence-aware shaped-blank routing — A/B over ' + CORPUS.length + ' labeled cases\n');
+console.log('                         OLD (newline only)   NEW (sentence-aware)');
+console.log('  precision              ' + pct(oldS.precision).padEnd(20) + pct(newS.precision));
+console.log('  recall                 ' + pct(oldS.recall).padEnd(20) + pct(newS.recall));
+console.log('  TP / FP / FN / TN      ' +
+  `${oldS.tp}/${oldS.fp}/${oldS.fn}/${oldS.tn}`.padEnd(20) +
+  `${newS.tp}/${newS.fp}/${newS.fn}/${newS.tn}`);
+
+console.log('\n  per-category recall (fired / should-fire), * = improved by NEW:');
+const cats = [...new Set(CORPUS.map(c => c.cat))];
+for (const cat of cats) {
+  const expectFire = CORPUS.filter(c => c.cat === cat && c.expect !== null).length;
+  const o = oldS.byCat[cat]?.fire ?? 0;
+  const n = newS.byCat[cat]?.fire ?? 0;
+  const fpN = newS.byCat[cat]?.wrong ?? 0;
+  const star = n > o ? ' *' : '';
+  const fpNote = fpN > 0 ? `  [FALSE-FIRE: ${fpN}]` : '';
+  if (expectFire > 0) {
+    console.log(`    ${cat.padEnd(22)} ${o}/${expectFire}  →  ${n}/${expectFire}${star}${fpNote}`);
+  } else {
+    // precision categories: report false-fires (lower is better)
+    const oFp = oldS.byCat[cat]?.wrong ?? 0;
+    console.log(`    ${cat.padEnd(22)} cede ${oFp === 0 ? 'clean' : oFp + ' false'}  →  cede ${fpN === 0 ? 'clean' : fpN + ' false'}${fpN > oFp ? ' *REGRESSED*' : ''}`);
+  }
+}
+
+const recallGain = newS.recall - oldS.recall;
+const precisionDelta = newS.precision - oldS.precision;
+console.log('\n  Δ recall    ' + (recallGain >= 0 ? '+' : '') + pct(recallGain));
+console.log('  Δ precision ' + (precisionDelta >= 0 ? '+' : '') + pct(precisionDelta) +
+  (precisionDelta < 0 ? '   ⚠️  PRECISION REGRESSED' : '   (held)'));
+console.log('');
+
+// Non-zero exit if the change ever trades precision for recall — a guard so this
+// doubles as a regression gate, not just a report.
+if (newS.precision < oldS.precision || newS.recall < oldS.recall) {
+  console.error('FAIL: NEW boundary regressed precision or recall vs OLD.');
+  process.exit(1);
+}
+console.log('PASS: recall up, precision held.\n');


### PR DESCRIPTION
## What

Two routing fixes + the spec bump they require.

**1. Sentence-scoped shaped-blank routing.** A command claims its `_` when it leads its **sentence**, not just its physical line. `let me check the audio. volume _` now fires the volume blank — before, only `notes\nvolume _` (a newline) started a new routing segment. The boundary (`segmentStart`, `packages/opencues-core/src/segment.ts`) is the last sentence terminator (`.`/`!`/`?` + whitespace, or CJK `。！？．`) or newline before `_`, shared with fluid-config's `summonPhraseStart` so the two routers can't drift.

**2. One shared cede predicate.** The "does a blank claim this `_`?" check was copy-pasted across FluidBlank / TransformBlank / ConfigIntent. ConfigIntent had drifted — it still ceded on a shaped blank's keyword anywhere on the line — so after `volume 30 _` wove to `The volume is now 30%`, appending `voice mode off _` on the same line made ConfigIntent see the stray "volume" and cede, and the settings command fell through to fluid-blank instead of flipping voice-mode. Extracted `blankClaimsUnderscore`; all three now route through it. Drift is structurally impossible (mirrors the `keyword-window.ts` centralisation).

## Why

Users read "line" as "sentence" — the shaped-blank router was the only one anchoring on the physical line (fluid-config already used sentence boundaries), so the two disagreed on the same buffer. The cede drift was the same root cause: triplicated logic, one copy fell behind in the #216 migration.

## Spec

The trigger model is normative — `spec/blank-spec.md` + `core.md` said "the LINE containing `_` … must lead its line" in five places. Sentence-scoping changes that claim, so **`SPEC_VERSION` 0.3 → 0.4**:

- normative text → "sentence" (blank-spec.md § Trigger model, core.md § Routing)
- all six `spec/*.md` status banners → `0.4-alpha`; `SPEC.md` current-version line; omit-default stays `0.1-alpha`
- `conformance.test.ts` `routeBlank` reference impl updated (its own independent boundary scan) + `spec/conformance/routing/blank-shapes.json` gains sentence cases (same-line terminator, CJK, connective-prefix negatives)
- `spec/CHANGELOG.md` `[0.4.0-alpha]` + root `CHANGELOG.md`; `@opencues/core` 0.7.0 → 0.8.0

A `0.3-alpha` reader refuses `0.4-alpha` files per the newer-spec-refuse rule. Backward-compatible in practice — strictly *more* commands route, none that fired before stop.

## Benchmark

`tests/benchmarks/blank-routing/sentence-boundary.ts` — deterministic A/B over 30 labeled cases:

| | OLD (newline) | NEW (sentence) |
|---|---|---|
| precision | 100.0% | 100.0% |
| recall | 47.1% | **100.0%** |

Recall gains land in same-line-terminator (0/6→6/6), CJK (0/2→2/2), decimal-then-command (0/1→1/1). Decimals (`3.5`), versions (`gpt-5.4`), and connective prefixes (`then weather…`) cede clean under both. The bench exits non-zero if NEW ever drops below OLD.

## Validation

- core 945 node-test + 180 vitest (incl. conformance routing fixtures + the new cede regression in `blank-shapes.test.ts`), runtime 1673 — all green
- version-bump + legacy-names lints clean
- Verified live on OpenCode: `let me check the audio. volume _` fires; `The volume is now 30%. voice mode off _` flips voice-mode (no longer cedes to fluid-blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)