### PR TITLE
integration-weave: LLM contextual weaving of a blank's output (value never sent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — integration-weave: LLM contextual weaving of a blank's output (`@opencues/core` → 0.9.0, `@opencues/runtime` → 0.7.0, chrome → 0.2.44)
+
+A blank declaring `integration-weave: true` can weave its `integration:`
+exemplar into the surrounding prose with one LLM call, instead of the static
+`{value}` template — e.g. `getting ready.\nvolume 30 _` → *"Getting ready,
+the volume is now 30%."* **OFF by default** (`integration-weave-mode: off`),
+per-blank opt-in. The blank's **real value is never sent to the provider**:
+the LLM only sees the exemplar with `{value}` replaced by a sentinel token,
+and the runtime swaps the real value back in *after* the response. The fill
+**waits** for the weave then commits **once** (woven on success, static on
+any failure/timeout — `integration-weave-timeout-ms`, default 6s), and a
+staleness check drops the woven result if the buffer changed during the call.
+
+- New `blank.woven` event; `integration-weave-mode` in the FEATURES registry;
+  per-blank `integration-weave` frontmatter key. Wired into CC / chrome boot
+  + `buildSharedRuntime` (OC). **Reference-impl only — no `SPEC_VERSION`
+  bump:** a second implementation that ignores the keys renders the spec'd
+  static `{value}` template (graceful degrade).
+- Bench: `tests/benchmarks/integration-weave` (token-survival) — 100% on
+  cerebras + groq (the real value's sentinel survives the round-trip).
+
 ### Changed — blank routing is sentence-scoped (`SPEC_VERSION` 0.3 → 0.4, `@opencues/core` → 0.8.0)
 
 Shaped-blank routing now matches the **sentence** containing `_`, not just

--- a/defaults/OPENCUES.md
+++ b/defaults/OPENCUES.md
@@ -89,6 +89,20 @@ fluid-blank-mode: on
 word-cues-mode: on
 transform-blank-mode: on
 
+# integration-weave-mode — let a blank with `integration-weave: true` weave
+# its `integration:` output into the surrounding prose with one LLM call,
+# instead of the static `{value}` template. The blank's REAL value is never
+# sent to the provider: the LLM only sees the exemplar with `{value}` replaced
+# by a sentinel token, and the runtime swaps the real value back in AFTER the
+# response. Falls back to the static template on any failure, so a weave can
+# never block the fill or corrupt the buffer.
+#   off (default): `integration:` is a static `{value}` template, zero LLM.
+#   on           : opted-in blanks pay one ~300-700ms LLM call per fill to
+#                  weave the value into context (the static fill lands first,
+#                  then the woven version merges in).
+# See docs/architecture/blank-integration.md.
+integration-weave-mode: off
+
 # blank-trigger-mode — when `_` actually fires its blank.
 #   immediate (default): blank fires the moment `_` is inserted —
 #                        the original v0.1 behaviour, snappy but

--- a/docs/architecture/blank-integration.md
+++ b/docs/architecture/blank-integration.md
@@ -131,16 +131,21 @@ integration-weave: true
   caller, so the value never enters this module.
 - `BlankFill.maybeWeaveIntegration` (`blank-fill.ts`) — fires after the static
   commit, swaps the value in, three-way-merges (`word-diff.ts`).
-- Wired from `boot-common.ts` (shared bands) + `adapters/cc/v2.1/boot.ts` (CC
-  inline) via `buildBlankWeaver`. Native hosts fall back to NodeHttpAdapter;
-  chrome would pass `host.httpAdapter` (not yet wired — degrades to static).
+- Wired into every band via `buildBlankWeaver`: CC inline
+  (`adapters/cc/v2.1/boot.ts`), OC/gemini/shell via `boot-common.ts` (native
+  NodeHttpAdapter fallback), and chrome via `adapters/chrome/v1/boot.ts`
+  passing its fetch-based `host.httpAdapter` (NodeHttpAdapter is stubbed in the
+  browser bundle).
+- Emits a `blank.woven` event (`blankName` + `output`) when the weave commits.
 
-### Follow-ups
+### Tests + bench
 
-- Chrome httpAdapter wiring (currently degrades to static there).
-- A weaving-quality bench (register fidelity, token-survival rate across
-  providers) — the runtime contract (token preserved, value spliced, static
-  fallback) is unit-tested; LLM-quality is not yet benched.
+- Runtime contract (deterministic, mock weaver): token-swap +
+  static-fallback in `blank-weave.test.ts`; the clearOnEdit-wipe regression +
+  privacy guarantee in `blank-weave-fill.scenarios.test.ts`.
+- LLM quality: `tests/benchmarks/integration-weave/prod.ts` measures
+  token-survival across providers — cerebras + groq both 100% at the June 2026
+  baseline.
 
 ---
 

--- a/docs/architecture/blank-integration.md
+++ b/docs/architecture/blank-integration.md
@@ -95,16 +95,18 @@ integration-weave: true
 
 1. Blank fires deterministically (shape) → real value `22°C Clear`. **Stays local.**
 2. The exemplar's `{value}` → a sentinel token: `it's currently ⟦VALUE⟧`.
-3. The static fill commits **first** (instant, never-empty) — `…volume is now 32%`.
-4. In the background, ONE blanks-bucket LLM call receives the **prior buffer**
-   (context) + the **placeholder phrase** (with the token), and weaves it:
-   `Planning a trip to Oslo.\nweather oslo _` → `Right now it's ⟦VALUE⟧ there.`
-5. The runtime swaps `⟦VALUE⟧` → `22°C Clear` deterministically, then
-   **three-way-merges** the woven phrase into the live buffer (so edits made
-   during the call win): `…Right now it's 22°C Clear there.`
-6. On ANY failure (gate off, no key, LLM error, mangled token, user moved on)
-   the static fill from step 3 simply stays — a weave can never block the fill
-   or corrupt the buffer.
+3. The fill is held back and the **loading animation keeps running** while ONE
+   blanks-bucket LLM call (bounded by a ~6 s timeout) receives the **prior
+   buffer** (context) + the **placeholder phrase** (with the token) and weaves
+   it: `Planning a trip to Oslo.\nweather oslo _` → `Right now it's ⟦VALUE⟧ there.`
+4. The runtime swaps `⟦VALUE⟧` → `22°C Clear` deterministically and commits the
+   woven phrase **once**: `…Right now it's 22°C Clear there.` The buffer changes
+   a single time (loader → woven), never value-then-reflow.
+5. On ANY failure (gate off, no key, LLM error, mangled token, timeout) the
+   commit lands the **static template** instead (`…it's currently 22°C Clear`) —
+   still one change, never blocked, never corrupted.
+6. If the user edits during the wait, the fill is dropped (their edit wins) —
+   the same staleness contract every async blank fill already honours.
 
 ### Authoring + gating
 
@@ -129,8 +131,11 @@ integration-weave: true
   `FUSED_WEAVE_SYSTEM` prompt + `WEAVE_VALUE_TOKEN`. The weaver returns the
   woven phrase *still containing the token*; the value swap happens in the
   caller, so the value never enters this module.
-- `BlankFill.maybeWeaveIntegration` (`blank-fill.ts`) — fires after the static
-  commit, swaps the value in, three-way-merges (`word-diff.ts`).
+- `BlankFill.applyAsyncFill` (`blank-fill.ts`) — when a fill will weave, it
+  holds the static commit, keeps the loader running, awaits the weaver (bounded
+  by `WEAVE_TIMEOUT_MS`), then commits ONCE: the value spliced into the woven
+  phrase on success, or the static template (`commitStatic`) on failure/timeout.
+  A staleness check drops the fill if the buffer changed during the wait.
 - Wired into every band via `buildBlankWeaver`: CC inline
   (`adapters/cc/v2.1/boot.ts`), OC/gemini/shell via `boot-common.ts` (native
   NodeHttpAdapter fallback), and chrome via `adapters/chrome/v1/boot.ts`

--- a/docs/architecture/blank-integration.md
+++ b/docs/architecture/blank-integration.md
@@ -5,8 +5,9 @@ so the runtime can weave the value into the buffer with connective "fluff"
 instead of dropping a bare value. It is **add-only by construction** — it
 only ever shapes the *inserted value*, never the user's surrounding text.
 
-> Status: the **static** form (below) is shipped. The **LLM-driven** form
-> (§ Future direction) is designed but deliberately deferred.
+> Status: BOTH forms are shipped. The **static** form (below) is the default
+> and runs zero-LLM. The **LLM-woven** form (§ LLM contextual weaving) is
+> opt-in behind `integration-weave-mode: on` + per-blank `integration-weave: true`.
 
 ---
 
@@ -64,58 +65,82 @@ phrase around the value. There is no reading of "what came before."
 
 ---
 
-## Future direction: LLM-driven contextual weaving (deferred)
+## LLM contextual weaving (opt-in)
 
-The static frame can't adapt to surrounding prose. The intended evolution:
-**`integration:` becomes an *exemplar* — it indicates the shape/register of
-`{value}` — and an LLM that can see the surrounding text writes the connective
-fluff to integrate the value naturally.**
+The static frame can't adapt to surrounding prose. The opt-in evolution:
+**an LLM weaves the `integration:` exemplar into the surrounding text — but it
+never sees the real value.** The deterministic shape fetches the **data**; the
+LLM does the **presentation**; the runtime splices the data into the
+presentation deterministically afterward.
 
-The deterministic shape fetches the **data**; the LLM does the
-**presentation**, using the author's exemplar as a style guide. This keeps the
-"static data, format afterwards, the blank owns its presentation" philosophy —
-just with the formatting done per-context instead of by a fixed string.
+### The privacy/integrity invariant
 
-### Sketch
+The load-bearing property: **the value never reaches the provider.** The LLM
+weaves connective text around a sentinel **token**, and the runtime swaps the
+real value in for the token *after* the response — locally, in `BlankFill`.
+This buys two things the static template and a naive "send the value" design
+can't:
 
-1. Blank fires deterministically (shape) → real value `Oslo: 22°C Clear`.
-2. Blank declares an exemplar, e.g. `integration: it's a clear evening, about
-   18°C` — teaches register + shape, not a literal template.
-3. One LLM call receives **the buffer context** (the prose around the command),
-   **the value**, and **the exemplar**.
-4. It returns the value woven into the flow:
-   - `Planning a trip to Oslo.\nweather oslo _`
-     → `Planning a trip to Oslo.\nRight now it's 22°C and clear there.`
-   - `weather oslo _` alone → `It's currently 22°C and clear in Oslo.`
-5. Merge-protected (reuses the transform / three-way-merge machinery) so a
-   late LLM response never clobbers edits made during the call.
+1. **Privacy** — the value (a stock price, the weather, anything personal)
+   stays on the machine; it's never in the provider's logs.
+2. **Integrity** — the LLM can't hallucinate, reformat, translate, or drop the
+   value. It only writes fluff around a token; the runtime fills the token.
+
+### Flow
+
+```
+integration: it's currently {value}
+integration-weave: true
+```
+
+1. Blank fires deterministically (shape) → real value `22°C Clear`. **Stays local.**
+2. The exemplar's `{value}` → a sentinel token: `it's currently ⟦VALUE⟧`.
+3. The static fill commits **first** (instant, never-empty) — `…volume is now 32%`.
+4. In the background, ONE blanks-bucket LLM call receives the **prior buffer**
+   (context) + the **placeholder phrase** (with the token), and weaves it:
+   `Planning a trip to Oslo.\nweather oslo _` → `Right now it's ⟦VALUE⟧ there.`
+5. The runtime swaps `⟦VALUE⟧` → `22°C Clear` deterministically, then
+   **three-way-merges** the woven phrase into the live buffer (so edits made
+   during the call win): `…Right now it's 22°C Clear there.`
+6. On ANY failure (gate off, no key, LLM error, mangled token, user moved on)
+   the static fill from step 3 simply stays — a weave can never block the fill
+   or corrupt the buffer.
+
+### Authoring + gating
+
+- Per-blank: `integration-weave: true` (the `integration:` exemplar must keep
+  its `{value}` slot — that's the swap point).
+- Global: `integration-weave-mode: off | on` (off by default). Both must be set.
+- Provider: the **blanks** bucket (`blanks-llm-provider`). The `_` keystroke is
+  the consent gate, same as every other blank LLM call.
 
 ### Distinct from the other verbs
 
 | Verb | Role |
 |---|---|
-| blank + static integration | fixed frame, `{value}` substituted, 0 LLM (shipped) |
-| blank + LLM integration | value woven into surrounding prose via an exemplar (deferred) |
+| blank + static integration | fixed frame, `{value}` substituted, 0 LLM (default) |
+| blank + woven integration | value spliced into LLM-written fluff via a token; value never sent (opt-in) |
 | transform | rewrites the whole buffer by intent |
 | fluid | looks up a free-form answer |
 
-### Open design decisions (resolve before building)
+### Implementation
 
-1. **It's an LLM call** — opt-in per blank; trades the 0-latency static path
-   for context-aware weaving. Be deliberate about the cost.
-2. **Context scope** — with anchored shapes the command leads its line, so the
-   natural "around it" is the **prior buffer** (earlier lines/sentences), not
-   same-line text.
-3. **Exemplar format** — free example sentence (`it's a mild, clear evening`,
-   max LLM freedom) vs a `{value}`-bearing template the LLM may adapt
-   (`it's currently {value}`, more anchored). Leaning free-example.
+- `packages/opencues-runtime/src/modules/blank-weave.ts` — the weaver +
+  `FUSED_WEAVE_SYSTEM` prompt + `WEAVE_VALUE_TOKEN`. The weaver returns the
+  woven phrase *still containing the token*; the value swap happens in the
+  caller, so the value never enters this module.
+- `BlankFill.maybeWeaveIntegration` (`blank-fill.ts`) — fires after the static
+  commit, swaps the value in, three-way-merges (`word-diff.ts`).
+- Wired from `boot-common.ts` (shared bands) + `adapters/cc/v2.1/boot.ts` (CC
+  inline) via `buildBlankWeaver`. Native hosts fall back to NodeHttpAdapter;
+  chrome would pass `host.httpAdapter` (not yet wired — degrades to static).
 
-### Why deferred
+### Follow-ups
 
-The static form covers the common case at zero cost and zero risk. The
-LLM form is a genuine feature (call cost, prompt design, a bench for weaving
-quality) and was parked to keep the current simplification pass focused on
-*removing* machinery rather than adding it.
+- Chrome httpAdapter wiring (currently degrades to static there).
+- A weaving-quality bench (register fidelity, token-survival rate across
+  providers) — the runtime contract (token preserved, value spliced, static
+  fallback) is unit-tested; LLM-quality is not yet benched.
 
 ---
 

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "LLM-powered word alternatives for text editors",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "private": true,
   "description": "OpenCues Chrome MV3 extension — real-time word alternatives, blanks, and cue-controls in the browser.",
   "compatibility": {

--- a/integrations/chrome/vitest.config.ts
+++ b/integrations/chrome/vitest.config.ts
@@ -1,10 +1,12 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     include: ['src/**/*.test.ts'],
+    // Never discover into git worktrees (`.claude/worktrees/`).
+    exclude: [...configDefaults.exclude, '**/.claude/**', '**/worktrees/**'],
     globals: false,
   },
   // No resolve aliases needed — pnpm symlinks @opencues/core and

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/cues-md.ts
+++ b/packages/opencues-core/src/cues-md.ts
@@ -347,6 +347,15 @@ export interface BlankConfig {
    *  "fluff". ADD-ONLY by construction (it only shapes the inserted value, never
    *  deletes surrounding text). e.g. `integration: "volume is now {value}"`. */
   integration?: string;
+  /** Opt this blank into LLM contextual weaving of its `integration` exemplar
+   *  (requires `integration-weave-mode: on`). When set, the runtime sends the
+   *  exemplar — with `{value}` replaced by a sentinel TOKEN, never the real
+   *  value — plus the prior buffer to one blanks-bucket LLM call, which weaves
+   *  the placeholder phrase into the surrounding prose. The real value is
+   *  swapped in for the token deterministically AFTER the response, so it never
+   *  reaches the provider and can't be altered. Falls back to the static
+   *  `{value}` substitution on any failure. Default (omitted) = static. */
+  integrationWeave?: boolean;
   /**
    * Explicit host allow-list. When set, narrows the default (all hosts) to
    * this set. Use the canonical host names: claude-code, opencode, chrome,
@@ -925,6 +934,7 @@ export interface SingleCueFrontmatter extends CuesMdFrontmatter {
   blankSuffix?: string;
   blankShapes?: BlankShape[];
   integration?: string;
+  integrationWeave?: boolean;
   stepValues?: string[];
   blankSatellite?: boolean;
   blankSatelliteSeparator?: string;
@@ -1036,6 +1046,7 @@ function parseExtendedFrontmatter(content: string): { frontmatter: SingleCueFron
       case 'blankSuffix': fm.blankSuffix = value; break;
       case 'blankShapes': try { fm.blankShapes = JSON.parse(value); } catch { /* ignore malformed shapes */ } break;
       case 'integration': fm.integration = value; break;
+      case 'integration-weave': fm.integrationWeave = value === 'true'; break;
       case 'stepValues': try { fm.stepValues = JSON.parse(value); } catch { /* ignore */ } break;
       case 'blankSatellite': fm.blankSatellite = value === 'true'; break;
       case 'blankSatelliteSeparator': fm.blankSatelliteSeparator = value.replace(/^['"]|['"]$/g, ''); break;
@@ -1187,6 +1198,7 @@ export function parseSingleCueMd(content: string, folderPath: string, nameOverri
         if (synthesized.length > 0) blank.blankShapes = synthesized;
       }
       if (frontmatter.integration !== undefined) blank.integration = frontmatter.integration;
+      if (frontmatter.integrationWeave !== undefined) blank.integrationWeave = frontmatter.integrationWeave;
       if (frontmatter.stepValues !== undefined) blank.stepValues = frontmatter.stepValues;
       if (frontmatter.blankSatellite !== undefined) blank.blankSatellite = frontmatter.blankSatellite;
       if (frontmatter.blankSatelliteSeparator !== undefined) blank.blankSatelliteSeparator = frontmatter.blankSatelliteSeparator;

--- a/packages/opencues-core/src/feature-registry.ts
+++ b/packages/opencues-core/src/feature-registry.ts
@@ -322,6 +322,16 @@ export const FEATURES: readonly FeatureSpec[] = [
     ],
   },
   {
+    scalar: 'integration-weave-mode',
+    camelCase: 'integrationWeaveMode',
+    description: 'LLM contextual weaving of a blank\'s `integration:` exemplar (the value is swapped in AFTER the call — never sent to the provider)',
+    menuTip: 'Let a blank with `integration-weave: true` weave its output into surrounding prose via one LLM call. The real value is substituted for a sentinel token after the response, so it never reaches the provider; falls back to the static `{value}` template on any failure.',
+    values: [
+      { id: 'off', description: 'Disabled (default) — `integration:` is a static `{value}` template, zero LLM' },
+      { id: 'on',  description: 'Enabled — blanks declaring `integration-weave: true` weave their exemplar into context; the real value is spliced in deterministically post-response' },
+    ],
+  },
+  {
     scalar: 'sentence-cues-mode',
     camelCase: 'sentenceCuesMode',
     description: 'Sentence-scope cues — whole-sentence alternatives via `scope: sentence` cue declarations',

--- a/packages/opencues-core/vitest.config.ts
+++ b/packages/opencues-core/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 // @opencues/core has TWO test runners. Most test files in this
 // package were written for Node's built-in `node:test` runner
@@ -27,6 +27,9 @@ export default defineConfig({
       'src/conformance.test.ts',
       'src/sources/fluid-blank-error-substitute.test.ts',
     ],
+    // Never discover into git worktrees (`.claude/worktrees/`) — stale repo
+    // copies with unbuilt dist; their test copies pollute the run.
+    exclude: [...configDefaults.exclude, '**/.claude/**', '**/worktrees/**'],
     // `isolate: false` — don't reset modules between test files.
     // Mirrors the runtime config. Small absolute win here (the vitest-
     // loadable subset is fast already), but kept consistent so the

--- a/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
+++ b/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
@@ -34,6 +34,7 @@ import { SelectorSatelliteState } from '../../../src/state/selector-satellite';
 import { AgentTaskState } from '../../../src/state/agent-task';
 import { applyDirectives } from '../../../src/render-directives';
 import { buildAgentLLMResolver, buildBlankContextProvider, checkRuntimeDrift, NATIVE_HOST_MISSING_KEY_MESSAGE, nativeHostFormatLLMError } from '../../../src/boot-common';
+import { buildBlankWeaver } from '../../../src/modules/blank-weave';
 import { startEventBridge } from '../../../src/event-bridge';
 import type {
   BlankInvokeSpec,
@@ -599,7 +600,10 @@ export function boot(host: HostInfo): BootResult {
 
   // Routing is deterministic (blankShapes) — the old LLM BlankIntent gate
   // was retired.
-  const blankFill = new BlankFill(adapter, configLoader, spanFillState, dismissedBlanks, selectorSatelliteState, dynDefs, blankLoading);
+  // integration-weave LLM (blanks bucket, native NodeHttpAdapter fallback).
+  // No-ops to static unless `integration-weave-mode: on` + a blank opts in.
+  const blankWeaver = buildBlankWeaver(configLoader, () => apiKeys, undefined, (lvl, msg) => log(lvl, msg));
+  const blankFill = new BlankFill(adapter, configLoader, spanFillState, dismissedBlanks, selectorSatelliteState, dynDefs, blankLoading, blankWeaver);
   configLoader.load().then(() => blankFill.subscribe()).catch(() => { /* logged */ });
   void blankFill; // silence unused — referenced by future phases
 

--- a/packages/opencues-runtime/adapters/chrome/v1/boot.ts
+++ b/packages/opencues-runtime/adapters/chrome/v1/boot.ts
@@ -303,6 +303,10 @@ export function boot(host: HostInfo): BootResult {
     configSearchPaths: ['/chrome-storage/.cues'],
     settingsFile: '/chrome-storage/.cues/OPENCUES.md',
     getApiKeys: () => apiKeys,
+    // Chrome's fetch-based adapter for the integration-weave LLM call —
+    // NodeHttpAdapter (node:https) is stubbed in the browser bundle, so the
+    // weaver needs the host's adapter explicitly (mirrors the Resolver below).
+    httpAdapter: host.httpAdapter as import('@opencues/core').HttpAdapterShape | undefined,
   });
   configLoaderRef = shared.configLoader;
 

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/boot-common.ts
+++ b/packages/opencues-runtime/src/boot-common.ts
@@ -19,6 +19,8 @@
 
 import type { HostAdapter, LogLevel } from './adapter';
 import type { ResolvedAgentLLM } from './modules/agent-rewrite';
+import { buildBlankWeaver, type BlankWeaver } from './modules/blank-weave';
+import type { HttpAdapterShape } from '@opencues/core';
 
 /* ─── Direct-launch drift advisory ───────────────────────────────────────
  *
@@ -416,6 +418,11 @@ export interface BuildSharedRuntimeOptions {
    *  in which case CLI providers are conservatively dropped from the
    *  cycling menu. */
   readonly isCliProviderAvailable?: (providerId: string) => boolean;
+  /** Optional HTTP adapter for the `integration-weave` LLM call. Chrome
+   *  passes its fetch-based `host.httpAdapter`; native hosts omit it and the
+   *  weaver lazily falls back to NodeHttpAdapter. When the feature is off
+   *  (default) this is never consulted. */
+  readonly httpAdapter?: HttpAdapterShape;
 }
 
 /**
@@ -689,8 +696,15 @@ export function buildSharedRuntime(
   // initial scan sees the populated blanksByWord map. Same pattern
   // both hosts had inline. Routing is deterministic (blankShapes) — the
   // old LLM BlankIntent gate was retired.
+  // Optional integration-weave LLM (blanks bucket). Built only when the host
+  // exposed an API-key bag; the weaver itself no-ops to static when the
+  // feature is off, no key resolves, or the http adapter is unavailable.
+  const blankWeaver: BlankWeaver | null = getApiKeys
+    ? buildBlankWeaver(configLoader, getApiKeys, opts.httpAdapter, (lvl, msg) => log(lvl, msg))
+    : null;
   const blankFill = new BlankFill(
     adapter, configLoader, spanFillState, dismissedBlanks, selectorSatelliteState, dynDefs, blankLoading,
+    blankWeaver,
   );
   configLoader.load()
     .then(() => blankFill.subscribe())

--- a/packages/opencues-runtime/src/event-bridge.ts
+++ b/packages/opencues-runtime/src/event-bridge.ts
@@ -126,6 +126,7 @@ export type BridgeEventBody =
   | { type: 'resolver.completed'; text: string; textLen: number; cleanWords: number; resultCount: number; latencyMs: number; generation: number; routing: ReadonlyArray<{ wordIndex: number; word: string; sourceId: string }>; skipped: ReadonlyArray<{ wordIndex: number; word: string }> }
   | { type: 'blank.invoked'; blankName: string; keyword: string; contextWords: readonly string[] }
   | { type: 'blank.substituted'; blankName: string; keyword: string; input: string; output: string; altCount: number; dismissible: boolean }
+  | { type: 'blank.woven'; blankName: string; output: string }
   | { type: 'agent-rewrite.round-started'; taskId: string | null; prompt: string; textLen: number; cursor: number }
   | { type: 'agent-rewrite.round-completed'; taskId: string | null; applied: number; dropped: number; userHunks: number; latencyMs: number }
   | { type: 'transform-blank.started'; textLen: number; blankIdx: number }

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -983,12 +983,15 @@ export class BlankFill {
     // The script-get phase stopped the loader before applyAsyncFill ran; restart
     // it (same slot/owner, same tick → no flicker) so the wait stays animated.
     this._loadingAnimator().start(slot.index, 'blank-fill');
+    // Timeout is configurable via `integration-weave-timeout-ms` (default 6s),
+    // so a hung provider can't leave the `_` spinning — and tests can shorten it.
+    const weaveTimeoutMs = parseInt(this.configLoader.opencuesState.settings.get('integration-weave-timeout-ms') ?? '', 10) || BlankFill.WEAVE_TIMEOUT_MS;
     void (async () => {
       let woven: string | null = null;
       try {
         woven = await Promise.race([
           weaver({ exemplar: weaveExemplar, priorContext }),
-          new Promise<null>(resolve => setTimeout(() => resolve(null), BlankFill.WEAVE_TIMEOUT_MS)),
+          new Promise<null>(resolve => setTimeout(() => resolve(null), weaveTimeoutMs)),
         ]);
       } catch (e) {
         this.adapter.log('info', `BlankFill: weave error (static fallback) — ${(e as Error)?.message ?? e}`);

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -16,7 +16,6 @@ import type { SelectorSatelliteState } from '../state/selector-satellite';
 import type { DynDefs } from '../state/dyn-defs';
 import { BlankLoadingAnimator, parseCustomFrames, parseRgbColors, parseAnsiColors, parseFrameIntervalMs, DEFAULT_RGB_PALETTE, DEFAULT_ANSI_PALETTE, type BlankLoadingMode } from './blank-loading';
 import { buildSafeScriptEnv } from '../security/safe-env';
-import { threeWayMerge } from './word-diff';
 import { WEAVE_VALUE_TOKEN, type BlankWeaver } from './blank-weave';
 
 export interface BlankSlot {
@@ -91,6 +90,9 @@ export class BlankFill {
   private _resultCache = new Map<string, { output: string; fetchedAt: number; ttlMs: number }>();
   private static readonly RESULT_CACHE_MAX_ENTRIES = 32;
   private static readonly DEFAULT_CACHE_TTL_MS = 2000;
+  // Bound on the integration-weave LLM call. On timeout the fill lands as the
+  // static template, so a hung/slow provider can't leave the `_` spinning.
+  private static readonly WEAVE_TIMEOUT_MS = 6000;
   /**
    * Loading-animation owner for in-flight blank slots. Lazily created
    * on first dispatch; mode read from OPENCUES.md's
@@ -911,132 +913,116 @@ export class BlankFill {
       : { newText: cleaned.slice(0, target.start) + primaryFill + cleaned.slice(target.end),
           newCursor: target.start + primaryFill.length };
 
-    // Populate span for non-consume-all fills when there's
-    // anything cycleable to do: multi-word fill, multiple lines from
-    // the script, or blankDismissible. Index = post-fill word index of
-    // primaryFill's first word (re-derive from the new text since
-    // clear/expansion may have shifted positions).
     const fillStart = newCursor - primaryFill.length;
-    const newWords = splitWords(newText);
-    const startWord = newWords.find(w => w.start === fillStart);
-    // Char range of the substituted region in newText. Anchored at the
-    // keyword's first char (so deleting any character of the keyword
-    // counts as a touch, even though the answer text starts at fillStart).
-    // For blankClearKeywords:true the keyword is gone in newText, so
-    // both kwStartChar and the answer collapse to fillStart.
-    const kwStartChar = newWords[slot.keywordStart]?.start ?? fillStart;
-    const wantsClearOnEdit = blank?.blankClearOnEdit === true;
-    if (this.spanFillState) {
-      const fillWordCount = primaryFill.split(/\s+/).filter(Boolean).length;
-      const altsForSpan = isDismissible ? [...lines, '_'] : lines;
-      // wantsSpan widens to ALSO track single-alt fills when
-      // blankClearOnEdit is set — otherwise the clearOnEdit machinery
-      // has nothing in spanFillState to react to on the next text
-      // change.
-      const wantsSpan = fillWordCount > 1 || altsForSpan.length > 1 || wantsClearOnEdit;
-      if (startWord && wantsSpan) {
-        this.spanFillState.set({
-          index: startWord.index,
-          alternatives: altsForSpan,
-          currentAltIndex: 0,
-          spanLength: Math.max(1, fillWordCount),
-          tip: blank?.tip,
-          clearOnEdit: wantsClearOnEdit,
-          pairCharStart: wantsClearOnEdit ? kwStartChar : undefined,
-          pairCharEnd: wantsClearOnEdit ? newCursor : undefined,
-        }, newText);
-      } else {
-        this.spanFillState.clear();
+
+    // Commit the STATIC fill — splice + cycling/clearOnEdit registration.
+    // Factored into a closure so the weave path can run it ONLY on weave
+    // failure (so the buffer changes exactly once, never value-then-reflow).
+    const commitStatic = (): void => {
+      // Populate span for fills with anything cycleable to do: multi-word
+      // fill, multiple lines, blankDismissible, or clearOnEdit.
+      const newWords = splitWords(newText);
+      const startWord = newWords.find(w => w.start === fillStart);
+      const kwStartChar = newWords[slot.keywordStart]?.start ?? fillStart;
+      const wantsClearOnEdit = blank?.blankClearOnEdit === true;
+      if (this.spanFillState) {
+        const fillWordCount = primaryFill.split(/\s+/).filter(Boolean).length;
+        const altsForSpan = isDismissible ? [...lines, '_'] : lines;
+        const wantsSpan = fillWordCount > 1 || altsForSpan.length > 1 || wantsClearOnEdit;
+        if (startWord && wantsSpan) {
+          this.spanFillState.set({
+            index: startWord.index,
+            alternatives: altsForSpan,
+            currentAltIndex: 0,
+            spanLength: Math.max(1, fillWordCount),
+            tip: blank?.tip,
+            clearOnEdit: wantsClearOnEdit,
+            pairCharStart: wantsClearOnEdit ? kwStartChar : undefined,
+            pairCharEnd: wantsClearOnEdit ? newCursor : undefined,
+          }, newText);
+        } else {
+          this.spanFillState.clear();
+        }
       }
-    }
-
-    // When blankSuffix produced a numeric+unit fill (volume,
-    // brightness), attribute the resulting word to its source blank
-    // via a DynDef so cycling routes to the originating blank.
-    if (this.dynDefs && startWord && blank?.blankSuffix && primaryFill.endsWith(blank.blankSuffix)) {
-      this.dynDefs.set(startWord.index, {
-        originalWord: primaryFill,
-        alternatives: [primaryFill],
-        currentIndex: 0,
-        spanStart: startWord.start,
-        spanEnd: startWord.end,
-        blankName: slot.blankName,
-      });
-    }
-
-    if (this.adapter.pushText) {
-      this.adapter.pushText(newText, newCursor);
-    } else {
-      this.adapter.setText(newText);
-      this.adapter.setCursorOffset(newCursor);
-      this.adapter.forceRender();
-    }
+      // blankSuffix numeric+unit fill (volume, brightness) → attribute the word
+      // to its source blank via a DynDef so cycling routes correctly.
+      if (this.dynDefs && startWord && blank?.blankSuffix && primaryFill.endsWith(blank.blankSuffix)) {
+        this.dynDefs.set(startWord.index, {
+          originalWord: primaryFill,
+          alternatives: [primaryFill],
+          currentIndex: 0,
+          spanStart: startWord.start,
+          spanEnd: startWord.end,
+          blankName: slot.blankName,
+        });
+      }
+      this.commitText(newText, newCursor);
+    };
 
     // ── LLM contextual weave (optional, opt-in, off by default) ──────────
-    // The static fill above has ALREADY committed (instant, never-empty). When
-    // `integration-weave-mode: on` AND this blank declares `integration-weave:
-    // true`, fire one background LLM call that weaves the value's exemplar into
-    // the surrounding prose, then three-way-merge the result so a slow or failed
-    // weave can never block the fill or clobber edits made during the call.
-    if (hasIntegration) {
-      this.maybeWeaveIntegration(blank as Record<string, unknown>, newText, fillStart, newCursor, integrationValue);
+    // When `integration-weave-mode: on` AND this blank declares
+    // `integration-weave: true`, we DON'T commit the static fill. Instead we
+    // keep the loading animation running, WAIT for one blanks-bucket LLM call
+    // that weaves the exemplar into the prior prose, and commit ONCE: the woven
+    // text on success, the static fill on failure/timeout. One buffer change,
+    // never value-then-reflow. Privacy/integrity: the real value never reaches
+    // the LLM — the weaver gets the exemplar's sentinel token and we splice the
+    // value in here (see blank-weave.ts).
+    const weaveExemplar = typeof blank?.integration === 'string' ? blank.integration : '';
+    const willWeave = hasIntegration && !!this.weave && blank?.integrationWeave === true
+      && this.configLoader.opencuesState.settings.get('integration-weave-mode') === 'on'
+      && weaveExemplar.includes('{value}');
+
+    if (!willWeave) {
+      commitStatic();
+      return;
     }
+
+    const weaver = this.weave!;
+    const priorContext = newText.slice(0, fillStart);
+    // The script-get phase stopped the loader before applyAsyncFill ran; restart
+    // it (same slot/owner, same tick → no flicker) so the wait stays animated.
+    this._loadingAnimator().start(slot.index, 'blank-fill');
+    void (async () => {
+      let woven: string | null = null;
+      try {
+        woven = await Promise.race([
+          weaver({ exemplar: weaveExemplar, priorContext }),
+          new Promise<null>(resolve => setTimeout(() => resolve(null), BlankFill.WEAVE_TIMEOUT_MS)),
+        ]);
+      } catch (e) {
+        this.adapter.log('info', `BlankFill: weave error (static fallback) — ${(e as Error)?.message ?? e}`);
+      }
+      this._loadingAnimator().stop(slot.index, 'blank-fill');
+      // Staleness: if the user edited during the wait, the slot they were
+      // filling is gone — drop, don't clobber (matches the async-fill contract).
+      const liveNow = this.adapter.getText().replace(/[​‌]/g, '');
+      if (liveNow !== cleaned) {
+        this.adapter.log('debug', 'BlankFill: weave fill dropped — buffer changed during the call');
+        return;
+      }
+      if (woven) {
+        // Splice the REAL value in for the token (deterministic, local).
+        const swapped = woven.split(WEAVE_VALUE_TOKEN).join(integrationValue);
+        const finalText = newText.slice(0, fillStart) + swapped + newText.slice(newCursor);
+        const finalCursor = Math.min(finalText.length, fillStart + swapped.length);
+        // Woven output is contextual prose — NOT a cycleable/clearOnEdit pair,
+        // so don't register a span watcher (which would wipe it on the next edit).
+        this.spanFillState?.clear();
+        this.adapter.log('info', `BlankFill: woven integration → "${preview(swapped, 60)}"`);
+        this.commitText(finalText, finalCursor);
+        this.adapter.emitEvent?.('blank.woven', { blankName: String(blank?.name ?? ''), output: swapped });
+      } else {
+        // Weave failed / ceded / timed out — land the static fill (one change).
+        commitStatic();
+      }
+    })();
   }
 
-  /**
-   * Background upgrade of a just-committed static integration fill into an
-   * LLM-woven version. Privacy/integrity: the real value (`integrationValue`)
-   * is spliced in HERE, locally, after the response — the weaver only ever sees
-   * the exemplar's sentinel token (see `blank-weave.ts`). Safe by construction:
-   * any failure (gate off, no weaver, LLM error, mangled token, user moved on)
-   * leaves the static fill exactly as it landed.
-   */
-  private maybeWeaveIntegration(
-    blank: Record<string, unknown>,
-    snapshot: string,
-    fillStart: number,
-    fillEnd: number,
-    integrationValue: string,
-  ): void {
-    const weaver = this.weave;
-    if (!weaver) return;
-    if (blank.integrationWeave !== true) return;
-    if (this.configLoader.opencuesState.settings.get('integration-weave-mode') !== 'on') return;
-    const exemplar = blank.integration;
-    if (typeof exemplar !== 'string' || !exemplar.includes('{value}')) return;
-
-    // Context = the prose leading up to where the value landed.
-    const priorContext = snapshot.slice(0, fillStart);
-    void weaver({ exemplar, priorContext })
-      .then((wovenWithToken) => {
-        if (!wovenWithToken) return; // static fallback — already committed
-        // Splice the REAL value in for the token (deterministic, local).
-        const woven = wovenWithToken.split(WEAVE_VALUE_TOKEN).join(integrationValue);
-        // Rewrite = snapshot with the static-fill region replaced by the woven
-        // phrase; three-way-merge against the LIVE buffer so user edits win.
-        const rewrite = snapshot.slice(0, fillStart) + woven + snapshot.slice(fillEnd);
-        const live = this.adapter.getText().replace(/[​‌]/g, '');
-        const { newText: merged } = threeWayMerge(snapshot, rewrite, live);
-        if (merged === live) return; // weave fully dropped by the merge
-        const newCursor = Math.min(merged.length, fillStart + woven.length);
-        // The static fill registered cycling/clearOnEdit state (span + dynDef)
-        // for the RAW value. The woven output is contextual prose, not a
-        // cycleable/clearOnEdit pair — and leaving the stale watchers in place
-        // makes the upcoming setText look like a foreign edit to the blank
-        // span, which a clearOnEdit blank would WIPE. Retire those watchers
-        // BEFORE committing so the woven text lands as plain locked prose.
-        this.spanFillState?.clear();
-        if (this.dynDefs) {
-          for (const w of splitWords(snapshot)) {
-            if (w.start >= fillStart && w.start < fillEnd) this.dynDefs.delete(w.index);
-          }
-        }
-        this.adapter.log('info', `BlankFill: woven integration → "${preview(woven, 60)}"`);
-        if (this.adapter.pushText) this.adapter.pushText(merged, newCursor);
-        else { this.adapter.setText(merged); this.adapter.setCursorOffset(newCursor); this.adapter.forceRender(); }
-        this.adapter.emitEvent?.('blank.woven', { blankName: String(blank.name ?? ''), output: woven });
-      })
-      .catch((e) => { this.adapter.log('info', `BlankFill: weave error (static fill kept) — ${(e as Error)?.message ?? e}`); });
+  /** Commit text via the host's preferred path (pushText when available). */
+  private commitText(text: string, cursor: number): void {
+    if (this.adapter.pushText) this.adapter.pushText(text, cursor);
+    else { this.adapter.setText(text); this.adapter.setCursorOffset(cursor); this.adapter.forceRender(); }
   }
 
   /**

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -1019,6 +1019,18 @@ export class BlankFill {
         const { newText: merged } = threeWayMerge(snapshot, rewrite, live);
         if (merged === live) return; // weave fully dropped by the merge
         const newCursor = Math.min(merged.length, fillStart + woven.length);
+        // The static fill registered cycling/clearOnEdit state (span + dynDef)
+        // for the RAW value. The woven output is contextual prose, not a
+        // cycleable/clearOnEdit pair — and leaving the stale watchers in place
+        // makes the upcoming setText look like a foreign edit to the blank
+        // span, which a clearOnEdit blank would WIPE. Retire those watchers
+        // BEFORE committing so the woven text lands as plain locked prose.
+        this.spanFillState?.clear();
+        if (this.dynDefs) {
+          for (const w of splitWords(snapshot)) {
+            if (w.start >= fillStart && w.start < fillEnd) this.dynDefs.delete(w.index);
+          }
+        }
         this.adapter.log('info', `BlankFill: woven integration → "${preview(woven, 60)}"`);
         if (this.adapter.pushText) this.adapter.pushText(merged, newCursor);
         else { this.adapter.setText(merged); this.adapter.setCursorOffset(newCursor); this.adapter.forceRender(); }

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -1034,6 +1034,7 @@ export class BlankFill {
         this.adapter.log('info', `BlankFill: woven integration → "${preview(woven, 60)}"`);
         if (this.adapter.pushText) this.adapter.pushText(merged, newCursor);
         else { this.adapter.setText(merged); this.adapter.setCursorOffset(newCursor); this.adapter.forceRender(); }
+        this.adapter.emitEvent?.('blank.woven', { blankName: String(blank.name ?? ''), output: woven });
       })
       .catch((e) => { this.adapter.log('info', `BlankFill: weave error (static fill kept) — ${(e as Error)?.message ?? e}`); });
   }

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -16,6 +16,8 @@ import type { SelectorSatelliteState } from '../state/selector-satellite';
 import type { DynDefs } from '../state/dyn-defs';
 import { BlankLoadingAnimator, parseCustomFrames, parseRgbColors, parseAnsiColors, parseFrameIntervalMs, DEFAULT_RGB_PALETTE, DEFAULT_ANSI_PALETTE, type BlankLoadingMode } from './blank-loading';
 import { buildSafeScriptEnv } from '../security/safe-env';
+import { threeWayMerge } from './word-diff';
+import { WEAVE_VALUE_TOKEN, type BlankWeaver } from './blank-weave';
 
 export interface BlankSlot {
   /** Word index of the `_`. */
@@ -110,6 +112,11 @@ export class BlankFill {
      *  for backward compat with external callers that haven't wired the
      *  shared owner). */
     blankLoading?: BlankLoadingAnimator,
+    /** Optional LLM weaver (blanks bucket) for `integration-weave`. Built by
+     *  the boot layer from `buildBlankWeaver`; null on hosts/configs with no
+     *  blanks-bucket key. When absent, `integration:` stays a static template.
+     *  The real value is never passed to it — see `blank-weave.ts`. */
+    private weave?: BlankWeaver | null,
   ) {
     if (blankLoading) this._loading = blankLoading;
   }
@@ -842,6 +849,10 @@ export class BlankFill {
     // or the blank's replace flags (get path), so no command prefix survives.
     const hasIntegration = typeof blank?.integration === 'string'
       && (blank.integration as string).includes('{value}');
+    // The exact string that fills `{value}` (post-suffix). Captured BEFORE the
+    // static render so the LLM weave can splice it into the sentinel token
+    // afterwards — the value itself never reaches the weaver.
+    const integrationValue = primaryFill;
     if (hasIntegration) {
       primaryFill = this.renderIntegration(blank as Record<string, unknown>, primaryFill);
     } else if (typedAction) {
@@ -960,6 +971,59 @@ export class BlankFill {
       this.adapter.setCursorOffset(newCursor);
       this.adapter.forceRender();
     }
+
+    // ── LLM contextual weave (optional, opt-in, off by default) ──────────
+    // The static fill above has ALREADY committed (instant, never-empty). When
+    // `integration-weave-mode: on` AND this blank declares `integration-weave:
+    // true`, fire one background LLM call that weaves the value's exemplar into
+    // the surrounding prose, then three-way-merge the result so a slow or failed
+    // weave can never block the fill or clobber edits made during the call.
+    if (hasIntegration) {
+      this.maybeWeaveIntegration(blank as Record<string, unknown>, newText, fillStart, newCursor, integrationValue);
+    }
+  }
+
+  /**
+   * Background upgrade of a just-committed static integration fill into an
+   * LLM-woven version. Privacy/integrity: the real value (`integrationValue`)
+   * is spliced in HERE, locally, after the response — the weaver only ever sees
+   * the exemplar's sentinel token (see `blank-weave.ts`). Safe by construction:
+   * any failure (gate off, no weaver, LLM error, mangled token, user moved on)
+   * leaves the static fill exactly as it landed.
+   */
+  private maybeWeaveIntegration(
+    blank: Record<string, unknown>,
+    snapshot: string,
+    fillStart: number,
+    fillEnd: number,
+    integrationValue: string,
+  ): void {
+    const weaver = this.weave;
+    if (!weaver) return;
+    if (blank.integrationWeave !== true) return;
+    if (this.configLoader.opencuesState.settings.get('integration-weave-mode') !== 'on') return;
+    const exemplar = blank.integration;
+    if (typeof exemplar !== 'string' || !exemplar.includes('{value}')) return;
+
+    // Context = the prose leading up to where the value landed.
+    const priorContext = snapshot.slice(0, fillStart);
+    void weaver({ exemplar, priorContext })
+      .then((wovenWithToken) => {
+        if (!wovenWithToken) return; // static fallback — already committed
+        // Splice the REAL value in for the token (deterministic, local).
+        const woven = wovenWithToken.split(WEAVE_VALUE_TOKEN).join(integrationValue);
+        // Rewrite = snapshot with the static-fill region replaced by the woven
+        // phrase; three-way-merge against the LIVE buffer so user edits win.
+        const rewrite = snapshot.slice(0, fillStart) + woven + snapshot.slice(fillEnd);
+        const live = this.adapter.getText().replace(/[​‌]/g, '');
+        const { newText: merged } = threeWayMerge(snapshot, rewrite, live);
+        if (merged === live) return; // weave fully dropped by the merge
+        const newCursor = Math.min(merged.length, fillStart + woven.length);
+        this.adapter.log('info', `BlankFill: woven integration → "${preview(woven, 60)}"`);
+        if (this.adapter.pushText) this.adapter.pushText(merged, newCursor);
+        else { this.adapter.setText(merged); this.adapter.setCursorOffset(newCursor); this.adapter.forceRender(); }
+      })
+      .catch((e) => { this.adapter.log('info', `BlankFill: weave error (static fill kept) — ${(e as Error)?.message ?? e}`); });
   }
 
   /**

--- a/packages/opencues-runtime/src/modules/blank-weave-fill.scenarios.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-weave-fill.scenarios.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BlankFill } from './blank-fill';
+import { ConfigLoader } from './config-loader';
+import { MockAdapter, wrapTipsAsCuesMd } from '../../testing/mock-adapter';
+import { SpanFillState } from '../state/span-fill';
+import { DynDefs } from '../state/dyn-defs';
+import { WEAVE_VALUE_TOKEN, type BlankWeaver } from './blank-weave';
+
+// SCENARIO test for the integration-weave data-loss bug the LIVE agentic run
+// caught: a `clearOnEdit` blank wove its output, then the whole line got wiped.
+// Root cause: the static fill's span/clearOnEdit watcher reacted to the weave's
+// setText as a foreign edit and wiped the pair. Pinned here deterministically
+// with a mock weaver (no live LLM). Fill commits via `pushText`, so the buffer
+// is read with `getText()`.
+
+const TIPS = wrapTipsAsCuesMd({ concepts: [] });
+
+// A clearOnEdit script-blank with an integration exemplar + weave opt-in —
+// the exact shape that reproduced the wipe.
+const DIM_CUE = `---
+type: blank
+name: dim
+blankKeywords: dim
+blankScript: ./dim.sh
+blankSuffix: %
+integration: set to {value}
+integration-weave: true
+blankClearOnEdit: true
+---
+`;
+
+const flush = async () => { for (let i = 0; i < 8; i++) await new Promise(r => setTimeout(r, 0)); };
+
+async function setupWeave(weaver: BlankWeaver, weaveMode = 'on') {
+  const adapter = new MockAdapter({
+    cwd: '/proj',
+    files: {
+      '/mock/CUES.md': TIPS,
+      '/proj/blanks/dim/BLANK.md': DIM_CUE,
+      '/proj/.cues/OPENCUES.md': `---\nintegration-weave-mode: ${weaveMode}\n---\n`,
+    },
+  });
+  adapter.stubBlankInvoke('dim:get', '30\n');
+  const loader = new ConfigLoader(adapter, { settingsFile: '/proj/.cues/OPENCUES.md' });
+  await loader.load();
+  const spanFillState = new SpanFillState();
+  const dynDefs = new DynDefs();
+  const bf = new BlankFill(adapter, loader, spanFillState, undefined, undefined, dynDefs, undefined, weaver);
+  bf.subscribe();
+  return { adapter, loader, bf, spanFillState, dynDefs };
+}
+
+describe('integration-weave — clearOnEdit wipe regression', () => {
+  it('weave on a clearOnEdit blank preserves prior content + splices value (NO wipe)', async () => {
+    const weaver = vi.fn(async () => `we set it to ${WEAVE_VALUE_TOKEN} now`);
+    const { adapter, spanFillState } = await setupWeave(weaver);
+
+    adapter.pushText('lights ready.\ndim _');
+    await flush();
+
+    const finalText = adapter.getText();
+    // THE BUG: this used to become just 'lights ready.\n' (whole line wiped).
+    expect(finalText).toBe('lights ready.\nwe set it to 30% now');
+    expect(finalText).not.toBe('lights ready.\n');
+    expect(finalText).toContain('lights ready.'); // prior content preserved
+    expect(finalText).toContain('30%');           // value spliced deterministically
+
+    // The clearOnEdit/span watcher was retired so it can't wipe the woven prose.
+    expect(spanFillState.current).toBeNull();
+    expect(weaver).toHaveBeenCalledOnce();
+  });
+
+  it('the weaver NEVER receives the real value — only the exemplar + prior context', async () => {
+    const weaver = vi.fn(async () => `it is ${WEAVE_VALUE_TOKEN}`);
+    const { adapter } = await setupWeave(weaver);
+    adapter.pushText('mood lighting.\ndim _');
+    await flush();
+    expect(weaver).toHaveBeenCalledOnce();
+    const req = weaver.mock.calls[0]![0] as Record<string, unknown>;
+    expect(req).not.toHaveProperty('value');     // structural privacy guarantee
+    expect(req.exemplar).toBe('set to {value}'); // exemplar carries {value}, not the value
+    expect(typeof req.priorContext).toBe('string');
+  });
+
+  it('weave failure (returns null) keeps the static fill — never blocks or corrupts', async () => {
+    const weaver = vi.fn(async () => null);
+    const { adapter } = await setupWeave(weaver);
+    adapter.pushText('lights ready.\ndim _');
+    await flush();
+    const out = adapter.getText();
+    expect(out).toContain('lights ready.'); // prior content intact
+    expect(out).toContain('set to 30%');    // static template stays
+    expect(out).not.toContain('_');         // the _ was filled, not stranded
+  });
+
+  it('mode off → no weave call at all (pure static template)', async () => {
+    const weaver = vi.fn(async () => `woven ${WEAVE_VALUE_TOKEN}`);
+    const { adapter } = await setupWeave(weaver, 'off');
+    adapter.pushText('lights ready.\ndim _');
+    await flush();
+    expect(weaver).not.toHaveBeenCalled();
+    expect(adapter.getText()).toContain('set to 30%');
+  });
+});

--- a/packages/opencues-runtime/src/modules/blank-weave-fill.scenarios.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-weave-fill.scenarios.test.ts
@@ -31,13 +31,13 @@ blankClearOnEdit: true
 
 const flush = async () => { for (let i = 0; i < 8; i++) await new Promise(r => setTimeout(r, 0)); };
 
-async function setupWeave(weaver: BlankWeaver, weaveMode = 'on') {
+async function setupWeave(weaver: BlankWeaver, weaveMode = 'on', extraSettings = '') {
   const adapter = new MockAdapter({
     cwd: '/proj',
     files: {
       '/mock/CUES.md': TIPS,
       '/proj/blanks/dim/BLANK.md': DIM_CUE,
-      '/proj/.cues/OPENCUES.md': `---\nintegration-weave-mode: ${weaveMode}\n---\n`,
+      '/proj/.cues/OPENCUES.md': `---\nintegration-weave-mode: ${weaveMode}\n${extraSettings}\n---\n`,
     },
   });
   adapter.stubBlankInvoke('dim:get', '30\n');
@@ -100,5 +100,68 @@ describe('integration-weave — clearOnEdit wipe regression', () => {
     await flush();
     expect(weaver).not.toHaveBeenCalled();
     expect(adapter.getText()).toContain('set to 30%');
+  });
+});
+
+describe('integration-weave — wait-first, single-change contract', () => {
+  // A weaver whose promise we resolve by hand, to inspect the buffer WHILE the
+  // weave is in flight.
+  function deferredWeaver() {
+    let resolve!: (v: string | null) => void;
+    const promise = () => new Promise<string | null>(r => { resolve = r; });
+    const fn = vi.fn(promise);
+    return { fn, resolve: (v: string | null) => resolve(v) };
+  }
+
+  it('does NOT commit the static fill before the weave — buffer changes ONCE', async () => {
+    const d = deferredWeaver();
+    const { adapter } = await setupWeave(d.fn);
+
+    adapter.pushText('lights ready.\ndim _');
+    await flush(); // dispatch + get done; weave is now in flight (unresolved)
+
+    // The whole point of wait-first: the static template must NOT have landed.
+    expect(d.fn).toHaveBeenCalledOnce();
+    expect(adapter.getText()).not.toContain('set to 30%');
+
+    d.resolve(`we set it to ${WEAVE_VALUE_TOKEN} now`);
+    await flush();
+
+    // Exactly one content change: straight to the woven text, no static stop.
+    expect(adapter.getText()).toBe('lights ready.\nwe set it to 30% now');
+  });
+
+  it('drops the fill if the user edits during the weave wait (no clobber)', async () => {
+    const d = deferredWeaver();
+    const { adapter } = await setupWeave(d.fn);
+
+    adapter.pushText('lights ready.\ndim _');
+    await flush(); // weave in flight
+
+    // User keeps typing while the LLM call is outstanding.
+    adapter.pushText('changed my mind entirely');
+    await flush();
+
+    d.resolve(`we set it to ${WEAVE_VALUE_TOKEN} now`);
+    await flush();
+
+    // The late weave must not splice into the user's new buffer.
+    expect(adapter.getText()).not.toContain('30%');
+    expect(adapter.getText()).not.toContain('we set it to');
+  });
+
+  it('falls back to the static template when the weave exceeds the timeout', async () => {
+    // Weaver resolves at ~250ms; timeout pinned to 30ms via the setting.
+    const slow = vi.fn(() => new Promise<string | null>(r => setTimeout(() => r(`woven ${WEAVE_VALUE_TOKEN}`), 250)));
+    const { adapter } = await setupWeave(slow, 'on', 'integration-weave-timeout-ms: 30');
+
+    adapter.pushText('lights ready.\ndim _');
+    // Wait past the 30ms timeout (but before the 250ms weave would resolve).
+    await new Promise(r => setTimeout(r, 90));
+    await flush();
+
+    // Timeout fired → static template landed (one change), the `_` is filled.
+    expect(adapter.getText()).toContain('set to 30%');
+    expect(adapter.getText()).not.toContain('_');
   });
 });

--- a/packages/opencues-runtime/src/modules/blank-weave.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-weave.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { buildBlankWeaver, WEAVE_VALUE_TOKEN } from './blank-weave';
+import type { ConfigLoader } from './config-loader';
+
+// Minimal ConfigLoader stub — the weaver only reads opencuesState.settings.get
+// + opencuesState.blanksLlmProvider.
+function fakeConfigLoader(overrides: Record<string, string> = {}): ConfigLoader {
+  const settings = new Map<string, string>([['llm-provider', 'groq'], ...Object.entries(overrides)]);
+  return {
+    opencuesState: {
+      settings: { get: (k: string) => settings.get(k), has: (k: string) => settings.has(k) },
+      blanksLlmProvider: 'inherit',
+    },
+  } as unknown as ConfigLoader;
+}
+
+// Fake http adapter returning a canned OpenAI-compat chat response.
+function fakeHttp(content: string) {
+  return {
+    post: async () => JSON.stringify({ choices: [{ message: { content } }] }),
+  } as unknown as import('@opencues/core').HttpAdapterShape;
+}
+
+const KEYS = () => ({ GROQ_API_KEY: 'test-key' });
+
+describe('blank-weave — runtime contract (value never reaches the LLM)', () => {
+  it('returns the woven phrase with the token still present — the value swap is the CALLER\'s job', async () => {
+    const weave = buildBlankWeaver(fakeConfigLoader(), KEYS, fakeHttp(`right now it's ${WEAVE_VALUE_TOKEN} out there`));
+    const out = await weave({ exemplar: "it's currently {value}", priorContext: 'Planning a trip to Oslo.' });
+    expect(out).toBe(`right now it's ${WEAVE_VALUE_TOKEN} out there`);
+    // Critical: the woven text still carries the TOKEN, not a value. BlankFill
+    // splices the real value in afterward — so the value never went on the wire.
+    expect(out).toContain(WEAVE_VALUE_TOKEN);
+  });
+
+  it('falls back to static (null) when the model DROPPED the token', async () => {
+    const weave = buildBlankWeaver(fakeConfigLoader(), KEYS, fakeHttp("right now it's 22C out there"));
+    expect(await weave({ exemplar: "it's currently {value}", priorContext: '' })).toBeNull();
+  });
+
+  it('falls back to static (null) when the model DUPLICATED the token', async () => {
+    const weave = buildBlankWeaver(fakeConfigLoader(), KEYS, fakeHttp(`${WEAVE_VALUE_TOKEN} and again ${WEAVE_VALUE_TOKEN}`));
+    expect(await weave({ exemplar: '{value}', priorContext: '' })).toBeNull();
+  });
+
+  it('returns null when the exemplar has no {value} slot — nothing to anchor the swap', async () => {
+    const weave = buildBlankWeaver(fakeConfigLoader(), KEYS, fakeHttp(`x ${WEAVE_VALUE_TOKEN}`));
+    expect(await weave({ exemplar: 'no slot here', priorContext: '' })).toBeNull();
+  });
+
+  it('returns null (static) when no API key resolves — value never at risk', async () => {
+    const weave = buildBlankWeaver(fakeConfigLoader(), () => ({}), fakeHttp(`x ${WEAVE_VALUE_TOKEN}`));
+    expect(await weave({ exemplar: '{value}', priorContext: '' })).toBeNull();
+  });
+
+  it('returns null (static) when the model added no connective text (bare token)', async () => {
+    const weave = buildBlankWeaver(fakeConfigLoader(), KEYS, fakeHttp(WEAVE_VALUE_TOKEN));
+    expect(await weave({ exemplar: '{value}', priorContext: '' })).toBeNull();
+  });
+
+  it('strips a wrapping quote the model may add around the phrase', async () => {
+    const weave = buildBlankWeaver(fakeConfigLoader(), KEYS, fakeHttp(`"it's ${WEAVE_VALUE_TOKEN} now"`));
+    expect(await weave({ exemplar: '{value}', priorContext: '' })).toBe(`it's ${WEAVE_VALUE_TOKEN} now`);
+  });
+
+  it('falls back to static (null) when the http adapter throws — never blocks/corrupts', async () => {
+    const throwingHttp = { post: async () => { throw new Error('network down'); } } as unknown as import('@opencues/core').HttpAdapterShape;
+    const weave = buildBlankWeaver(fakeConfigLoader(), KEYS, throwingHttp);
+    expect(await weave({ exemplar: '{value}', priorContext: '' })).toBeNull();
+  });
+});

--- a/packages/opencues-runtime/src/modules/blank-weave.ts
+++ b/packages/opencues-runtime/src/modules/blank-weave.ts
@@ -1,0 +1,162 @@
+// blank-weave.ts — LLM contextual weaving for a blank's `integration:` exemplar.
+//
+// THE INVARIANT: the LLM never sees the blank's real value. It receives the
+// exemplar with `{value}` replaced by a sentinel TOKEN and weaves connective
+// "fluff" around that token to fit the surrounding prose. The runtime swaps the
+// real value in for the token AFTER the response (the swap happens in the
+// CALLER, `BlankFill`, so the value never even reaches this module). This buys
+// two properties the static `{value}` template can't:
+//   1. Privacy — the value (stock price, weather, anything personal) never
+//      reaches the provider's logs.
+//   2. Integrity — the LLM can't hallucinate, reformat, or drop the value; the
+//      runtime splices it deterministically.
+//
+// Gated by `integration-weave-mode: on` (off by default) + per-blank
+// `integration-weave: true`. On ANY failure (no key, dispatch error, the token
+// got mangled, an empty answer) the weaver returns null and the caller falls
+// back to the static `{value}` substitution — a weave can never destroy or
+// corrupt the buffer (the "no logical landmines" rule).
+
+import { resolveLLM, dispatchChat } from '@opencues/core';
+import type { ResolvedLLM, HttpAdapterShape, ChatRequest } from '@opencues/core';
+import type { ConfigLoader } from './config-loader';
+
+/** The placeholder the LLM weaves around. Distinctive (paired guillemets +
+ *  uppercase) so it survives tokenization and is trivial to locate + swap.
+ *  Exported so the caller swaps the real value in for it post-response. */
+export const WEAVE_VALUE_TOKEN = '⟦VALUE⟧';
+
+/** Stable session-level system prompt — kept constant so cerebras prefix-caches
+ *  it (per CLAUDE.md § Cerebras). Per-call binding (context + placeholder) rides
+ *  the USER message. */
+export const FUSED_WEAVE_SYSTEM = `You weave a value placeholder into surrounding prose.
+
+You receive PRIOR TEXT (the user's buffer up to an insertion point) and a PLACEHOLDER PHRASE containing the literal token ${WEAVE_VALUE_TOKEN}. Rewrite ONLY the placeholder phrase so it reads as a natural continuation of the prior text — add connective words, fix tense/articles/spacing, match the register and tone.
+
+HARD RULES:
+- Keep the token ${WEAVE_VALUE_TOKEN} EXACTLY as written, exactly once. Never translate it, reformat it, wrap it in quotes, or guess what it stands for — you do not know its value and must not invent one.
+- Output ONLY the rewritten phrase. No prior text, no surrounding quotes, no explanation, no trailing punctuation you weren't given.
+- Stay additive — you are slotting a value into the flow, not answering a question and not editing the prior text.
+- If the prior text is empty or unrelated, lightly polish the placeholder phrase on its own.`;
+
+export interface WeaveRequest {
+  /** The blank's `integration:` exemplar, e.g. `"it's currently {value}"`. MUST
+   *  contain `{value}` (the swap slot) — without it there's nothing to anchor
+   *  the value, and the weaver returns null. */
+  readonly exemplar: string;
+  /** Buffer text BEFORE the command region the value lands in. With anchored
+   *  shapes the command leads its line, so the natural context is the prior
+   *  buffer (earlier lines/sentences), not same-line text. */
+  readonly priorContext: string;
+  readonly signal?: AbortSignal;
+}
+
+/** Returns the woven phrase STILL CONTAINING {@link WEAVE_VALUE_TOKEN} (the
+ *  caller swaps the real value in), or null to signal "fall back to static". */
+export type BlankWeaver = (req: WeaveRequest) => Promise<string | null>;
+
+/**
+ * Build a weaver bound to the blanks LLM bucket. Re-resolves the
+ * provider/model AND re-reads the API keys on every call so OPENCUES.md
+ * hot-reload + chrome's async post-boot key delivery both propagate without a
+ * restart (mirrors `buildAgentLLMResolver`). `httpAdapter` is injected by the
+ * boot layer (chrome passes its fetch-based adapter); when omitted, native
+ * hosts lazily fall back to NodeHttpAdapter — the same pattern the Resolver
+ * uses, kept browser-safe by the guarded require.
+ */
+export function buildBlankWeaver(
+  configLoader: ConfigLoader,
+  getApiKeys: () => Readonly<Record<string, string | undefined>>,
+  httpAdapter: HttpAdapterShape | undefined,
+  log?: (level: 'info' | 'debug', msg: string) => void,
+): BlankWeaver {
+  let http: HttpAdapterShape | null = httpAdapter ?? null;
+  const resolveHttp = (): HttpAdapterShape | null => {
+    if (http) return http;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('@opencues/core/node-http-adapter'); // BROWSER-SAFE-ALLOW: native-host fallback only — chrome always injects host.httpAdapter
+      http = new mod.NodeHttpAdapter({ maxSockets: 2, timeout: 30000 }) as HttpAdapterShape;
+      return http;
+    } catch {
+      return null;
+    }
+  };
+
+  return async (req: WeaveRequest): Promise<string | null> => {
+    if (!req.exemplar.includes('{value}')) {
+      log?.('debug', 'blank-weave: exemplar has no {value} slot — static fallback');
+      return null;
+    }
+    const httpAdapterResolved = resolveHttp();
+    if (!httpAdapterResolved) {
+      log?.('info', 'blank-weave: no http adapter available — static fallback');
+      return null;
+    }
+    const apiKeys = getApiKeys();
+    // {value} → sentinel token. The real value is NOT involved here.
+    const placeholder = req.exemplar.replace(/\{value\}/g, WEAVE_VALUE_TOKEN);
+
+    // Resolve the blanks-bucket LLM (per-feature blank-provider override wins,
+    // then the blanks bucket, then global). Mirrors build-sources' precedence.
+    const s = configLoader.opencuesState.settings;
+    const bucket = configLoader.opencuesState.blanksLlmProvider;
+    const bucketProvider = bucket === 'inherit' ? undefined : bucket;
+    const bucketModel = bucketProvider ? s.get('blanks-llm-model') : undefined;
+    let resolved: ResolvedLLM | null = null;
+    try {
+      resolved = resolveLLM({
+        featureProvider: s.get('blank-provider') ?? null,
+        featureModel: s.get('blank-model') ?? null,
+        endpointOverride: s.get('blank-endpoint') ?? s.get('blanks-llm-endpoint') ?? s.get('llm-endpoint') ?? null,
+        globalProvider: bucketProvider ?? s.get('llm-provider') ?? null,
+        globalModel: (bucketProvider ? (bucketModel ?? undefined) : s.get('llm-model')) ?? null,
+        apiKeys,
+      });
+    } catch (e) {
+      log?.('info', `blank-weave: resolveLLM threw — ${(e as Error)?.message ?? e}; static fallback`);
+      return null;
+    }
+    if (!resolved) {
+      log?.('info', 'blank-weave: no LLM resolved (missing API key for the blanks bucket?) — static fallback');
+      return null;
+    }
+
+    const chatReq: ChatRequest = {
+      model: resolved.model,
+      messages: [
+        { role: 'system', content: FUSED_WEAVE_SYSTEM },
+        { role: 'user', content: `PRIOR TEXT:\n${req.priorContext.trim() || '(none)'}\n\nPLACEHOLDER PHRASE:\n${placeholder}` },
+      ],
+      temperature: 0,
+    };
+
+    let out: string;
+    try {
+      out = await dispatchChat(resolved.provider, httpAdapterResolved, chatReq, {
+        apiKey: resolved.apiKey,
+        endpoint: resolved.endpoint,
+        signal: req.signal,
+        maxThinking: s.get('max-thinking') !== 'off',
+      });
+    } catch (e) {
+      log?.('info', `blank-weave: dispatch failed — ${(e as Error)?.message ?? e}; static fallback`);
+      return null;
+    }
+
+    // The token MUST survive exactly once. If the model dropped, duplicated, or
+    // mangled it, we can't safely splice the value — fall back to static.
+    const woven = out.trim().replace(/^["'`]|["'`]$/g, '');
+    const tokenCount = woven.split(WEAVE_VALUE_TOKEN).length - 1;
+    if (tokenCount !== 1) {
+      log?.('info', `blank-weave: token survived ${tokenCount}× (need exactly 1) — static fallback`);
+      return null;
+    }
+    if (!woven || woven === WEAVE_VALUE_TOKEN) {
+      // No connective fluff added (bare token) → nothing gained over static.
+      log?.('debug', 'blank-weave: response added no connective text — static fallback');
+      return null;
+    }
+    return woven;
+  };
+}

--- a/packages/opencues-runtime/src/modules/feature-registry-alignment.test.ts
+++ b/packages/opencues-runtime/src/modules/feature-registry-alignment.test.ts
@@ -35,6 +35,8 @@ const SETTINGS_MAP_ONLY: ReadonlySet<string> = new Set([
   'transformBlankMode', // consumed by transform-blank pipeline gate
   'fluidConfigMode',    // consumed in resolver.ts:enableConfigIntent
   'sentenceCuesMode',   // consumed in resolver.ts:enableSentenceCues
+  'integrationWeaveMode', // consumed in blank-fill.ts applyAsyncFill weave gate
+                          // (read from settings map; no resolver/typed field)
   'maxThinking',        // consumed in resolver.ts (buildSources maxThinking)
                         // + boot-common buildAgentLLMResolver; a plain
                         // on/off toggle, no narrow-typed consumer needs it.

--- a/packages/opencues-runtime/vitest.config.ts
+++ b/packages/opencues-runtime/vitest.config.ts
@@ -1,9 +1,14 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     globals: false,
     include: ['src/**/*.test.ts', 'testing/**/*.test.ts', 'adapters/**/*.test.ts'],
+    // Never discover into git worktrees (`.claude/worktrees/<name>/` — created
+    // by Claude Code's worktree isolation). They hold full repo copies at old
+    // commits with stale/unbuilt dist; globbing their `*.test.ts` copies makes
+    // dist-loading + CLI-spawning tests fail there and pollute the run.
+    exclude: [...configDefaults.exclude, '**/.claude/**', '**/worktrees/**'],
     // `--no-isolate` equivalent: don't reset modules between test files.
     // ~30% faster locally (14s → 10s on the 1671-test suite), ~25s off
     // CI's test step. Trade-off: tests that rely on a hot module's

--- a/tests/benchmarks/integration-weave/README.md
+++ b/tests/benchmarks/integration-weave/README.md
@@ -1,0 +1,41 @@
+# integration-weave bench
+
+Weaving-quality bench for the `integration-weave` feature (LLM contextual
+weaving of a blank's `integration:` exemplar — see
+`docs/architecture/blank-integration.md`).
+
+## What it measures
+
+The **load-bearing contract is token survival**: the LLM must return the
+sentinel token (`WEAVE_VALUE_TOKEN`) exactly once and never reformat,
+translate, quote, or drop it — because the runtime swaps the real value in for
+the token *after* the response (the value never reaches the provider). If the
+token is mangled, the runtime falls back to the static template, so a low
+survival rate degrades the feature to "static only," it never corrupts output.
+
+The bench drives the **real** prompt (`FUSED_WEAVE_SYSTEM` imported from
+`@opencues/runtime` — no bench-local copy to drift, same principle as
+`blank-intent/prod.ts`). It prints each woven phrase (token rendered as
+`«value»`) so register/fluff quality can be eyeballed alongside the survival
+rate.
+
+## Run
+
+```bash
+CEREBRAS_API_KEY=xxx npx tsx tests/benchmarks/integration-weave/prod.ts --provider cerebras [--parallel 4]
+GROQ_API_KEY=xxx     npx tsx tests/benchmarks/integration-weave/prod.ts --provider groq
+GEMINI_API_KEY=xxx   npx tsx tests/benchmarks/integration-weave/prod.ts --provider gemini
+```
+
+Exit 0 iff every case preserved the token exactly once.
+
+## Baseline (June 2026)
+
+| Provider | Model | Token-survival |
+|---|---|---|
+| cerebras | gpt-oss-120b | 12/12 (100%) |
+| groq | openai/gpt-oss-120b | 12/12 (100%) |
+
+Register read naturally on both (e.g. a mid-thought prior "I cranked the
+speakers earlier but now" → "the volume is now «value»"). Re-run before editing
+`FUSED_WEAVE_SYSTEM` in `packages/opencues-runtime/src/modules/blank-weave.ts`.

--- a/tests/benchmarks/integration-weave/prod.ts
+++ b/tests/benchmarks/integration-weave/prod.ts
@@ -1,0 +1,107 @@
+/**
+ * integration-weave/prod.ts — weaving-quality bench for the `integration-weave`
+ * feature. Drives the REAL prompt (`FUSED_WEAVE_SYSTEM` + `WEAVE_VALUE_TOKEN`
+ * imported from the runtime — no bench-local copy to drift) across a provider.
+ *
+ * The load-bearing contract is TOKEN SURVIVAL: the LLM must return the sentinel
+ * token exactly once, never reformat/translate/drop it (the runtime swaps the
+ * real value in afterward — see blank-weave.ts). This bench measures that rate
+ * and prints the woven phrases so register/fluff quality can be eyeballed.
+ *
+ * Usage:
+ *   CEREBRAS_API_KEY=xxx npx tsx tests/benchmarks/integration-weave/prod.ts [--provider cerebras|groq|gemini] [--parallel N]
+ */
+import * as https from 'https';
+import { getProvider, dispatchChat, type HttpAdapterShape } from '../../../packages/opencues-core/src/llm-provider';
+import { FUSED_WEAVE_SYSTEM, WEAVE_VALUE_TOKEN } from '../../../packages/opencues-runtime/src/modules/blank-weave';
+
+interface Case { id: string; exemplar: string; priorContext: string; }
+
+// Varied exemplars (registers) × prior contexts (empty, mid-thought, sentence
+// lead, multi-line). The value the token stands for is deliberately NOT here —
+// the model never sees it, which is the whole point.
+const CASES: Case[] = [
+  { id: 'weather-trip',   exemplar: "it's currently {value}",     priorContext: 'Planning a trip to Oslo next week.' },
+  { id: 'weather-bare',   exemplar: "it's currently {value}",     priorContext: '' },
+  { id: 'volume-setup',   exemplar: 'volume is now {value}',      priorContext: 'Getting the room ready for movie night.' },
+  { id: 'volume-midline', exemplar: 'volume is now {value}',      priorContext: 'I cranked the speakers earlier but now' },
+  { id: 'stock-note',     exemplar: 'trading at {value}',         priorContext: 'Thinking about whether to buy more NVDA —' },
+  { id: 'stock-bare',     exemplar: 'trading at {value}',         priorContext: '' },
+  { id: 'price-list',     exemplar: 'the price is {value}',       priorContext: 'Shopping list:\n- milk\n- eggs\n- the thing I wanted,' },
+  { id: 'define-prose',   exemplar: 'it means {value}',           priorContext: "I keep seeing the word 'ephemeral' and" },
+  { id: 'brightness',     exemplar: 'brightness at {value}',      priorContext: 'My eyes are tired, so the screen' },
+  { id: 'time-greet',     exemplar: "it's {value}",               priorContext: 'Good morning! Just checking —' },
+  { id: 'count-report',   exemplar: '{value} open issues',        priorContext: 'Status update for the team:' },
+  { id: 'temp-formal',    exemplar: 'the temperature reads {value}', priorContext: 'Per the morning weather briefing,' },
+];
+
+const agent = new https.Agent({ keepAlive: true, maxSockets: 16 });
+const httpAdapter: HttpAdapterShape = {
+  post: (url: string, body: string, headers: Record<string, string>) => new Promise<string>((resolve, reject) => {
+    const u = new URL(url);
+    const req = https.request({ hostname: u.hostname, path: u.pathname + (u.search ?? ''), method: 'POST',
+      headers: { ...headers, 'content-length': Buffer.byteLength(body) }, agent, timeout: 30000 },
+      res => { let b = ''; res.on('data', c => b += c); res.on('end', () => resolve(b)); });
+    req.on('error', reject); req.on('timeout', () => req.destroy(new Error('timeout')));
+    req.write(body); req.end();
+  }),
+};
+
+const PROVIDERS: Record<string, { endpoint: string; key: string | undefined; model: string }> = {
+  cerebras: { endpoint: 'https://api.cerebras.ai/v1/chat/completions', key: process.env.CEREBRAS_API_KEY, model: process.env.OPENCUES_CEREBRAS_MODEL ?? 'gpt-oss-120b' },
+  groq:     { endpoint: 'https://api.groq.com/openai/v1/chat/completions', key: process.env.GROQ_API_KEY, model: process.env.OPENCUES_GROQ_MODEL ?? 'openai/gpt-oss-120b' },
+  gemini:   { endpoint: 'https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent', key: process.env.GEMINI_API_KEY, model: process.env.OPENCUES_GEMINI_MODEL ?? 'gemini-3.1-flash-lite' },
+};
+
+async function runWithConcurrency<T, R>(items: T[], fn: (it: T) => Promise<R>, conc: number): Promise<R[]> {
+  const out: R[] = new Array(items.length); let i = 0;
+  await Promise.all(Array.from({ length: Math.min(conc, items.length) }, async () => {
+    while (i < items.length) { const idx = i++; out[idx] = await fn(items[idx]); }
+  }));
+  return out;
+}
+
+async function main() {
+  const argVal = (f: string) => { const i = process.argv.indexOf(f); return i >= 0 ? process.argv[i + 1] : undefined; };
+  const providerId = argVal('--provider') ?? 'cerebras';
+  const parallel = parseInt(argVal('--parallel') ?? '4', 10);
+  const p = PROVIDERS[providerId];
+  if (!p) { console.error(`Unknown provider "${providerId}". Known: ${Object.keys(PROVIDERS).join(', ')}`); process.exit(1); }
+  if (!p.key) { console.error(`Missing API key for ${providerId}.`); process.exit(1); }
+  const provider = getProvider(providerId);
+  if (!provider) { console.error(`getProvider("${providerId}") returned null`); process.exit(1); }
+
+  console.log(`\nintegration-weave bench — provider=${providerId} model=${p.model} cases=${CASES.length}\n`);
+
+  const results = await runWithConcurrency(CASES, async (c) => {
+    const placeholder = c.exemplar.replace(/\{value\}/g, WEAVE_VALUE_TOKEN);
+    const user = `PRIOR TEXT:\n${c.priorContext.trim() || '(none)'}\n\nPLACEHOLDER PHRASE:\n${placeholder}`;
+    try {
+      const raw = await dispatchChat(provider, httpAdapter, {
+        model: p.model,
+        messages: [{ role: 'system', content: FUSED_WEAVE_SYSTEM }, { role: 'user', content: user }],
+        temperature: 0,
+      }, { apiKey: p.key!, endpoint: p.endpoint });
+      const woven = raw.trim().replace(/^["'`]|["'`]$/g, '');
+      const tokens = woven.split(WEAVE_VALUE_TOKEN).length - 1;
+      const survived = tokens === 1 && woven !== WEAVE_VALUE_TOKEN;
+      return { c, woven, tokens, survived };
+    } catch (e) {
+      return { c, woven: `<error: ${(e as Error).message}>`, tokens: -1, survived: false };
+    }
+  }, parallel);
+
+  let ok = 0;
+  for (const r of results) {
+    const mark = r.survived ? '✓' : '✗';
+    if (r.survived) ok++;
+    // Show the woven phrase with the token rendered as «value» so register reads naturally.
+    const display = r.woven.split(WEAVE_VALUE_TOKEN).join('«value»');
+    console.log(`${mark} ${r.c.id.padEnd(14)} ${r.tokens === 1 ? '' : `[tokens=${r.tokens}] `}${display}`);
+  }
+  console.log(`\nToken-survival: ${ok}/${results.length} (${Math.round((ok / results.length) * 100)}%)`);
+  console.log('(Token survival is the hard contract. Register/fluff quality is the eyeball pass above.)\n');
+  process.exit(ok === results.length ? 0 : 1);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## What

A blank declaring `integration-weave: true` weaves its `integration:` exemplar into the surrounding prose with one LLM call, instead of the static `{value}` template:

```
getting ready for the show.
volume 30 _        →  "Getting ready for the show, the volume is now 30%."
```

**OFF by default** (`integration-weave-mode: off`), per-blank opt-in.

## The key property — the value is never sent to the provider

The LLM only ever sees the exemplar with `{value}` replaced by a sentinel token (`⟦VALUE⟧`); the runtime swaps the **real** value back in *after* the response. So `volume`'s `17%`, a stock price, a weather reading — none of it reaches the provider's logs. Bench (`tests/benchmarks/integration-weave`, token-survival) confirms the sentinel survives the round-trip 100% on cerebras + groq.

## Wait-first, commit-once

The fill **waits** for the weave, then commits **once** — woven on success, static `{value}` on any failure/timeout (`integration-weave-timeout-ms`, default 6s). A staleness check drops the woven result if the buffer changed during the call, so a slow weave can never clobber later typing or block the fill. Falling back to the static template (which *is* the spec'd behavior) means a weave can never corrupt the buffer.

## Wiring

- New `blank.woven` event; `integration-weave-mode` in the FEATURES registry; per-blank `integration-weave` frontmatter key (parsed in `cues-md.ts`).
- Weaver built by the boot layer (`buildBlankWeaver`) and threaded into BlankFill — CC + chrome boot inline, OC via `buildSharedRuntime`.
- **No `SPEC_VERSION` bump** — reference-impl only. A second implementation that ignores the keys renders the spec'd static `{value}` template (graceful degrade).

## Validation

- core 945 node-test + vitest, runtime **1691** (incl. 15 weave tests: `blank-weave.test.ts` + `blank-weave-fill.scenarios.test.ts` — wait-first commit, value-never-sent, staleness drop, clearOnEdit non-trip, timeout fallback) — all green
- Agentic regression on OpenCode: 52–53/54 (the 2 failures are pre-existing LLM-latency transform-blank flakes, differ run-to-run, outside the weave path); blank-fill / integration-pass scenarios pass
- **Live-verified on OpenCode** — `BlankFill: woven integration → "The volume is now 22%"`, `"Getting ready for the show, the volume is now 30%."` — value spliced post-response, no `weave error` / `weave fill dropped`
- chrome rebuilt 0.2.43 → 0.2.44 (boot.ts wires the weaver); CC fork bundle-integrity verified

## Versions

`@opencues/core` 0.8.0 → 0.9.0, `@opencues/runtime` 0.6.0 → 0.7.0, chrome 0.2.43 → 0.2.44 (manifest + package lockstep).

## Stacked on

Rebased onto master after #218 (sentence-routing) merged — that's what makes the inline `<prose>. volume _` weave fire (a command after a sentence terminator on the same line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)