### PR TITLE
fix(cli): opencues identity honours $OPENCUES_HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `opencues identity` now honours `$OPENCUES_HOME` (`opencues` CLI 0.2.32 → 0.2.33)
+
+`opencues identity` hardcoded its target to `os.homedir()/.cues/IDENTITY.md`, silently ignoring `$OPENCUES_HOME` — so `OPENCUES_HOME=… opencues identity set …` wrote the real `~/.cues/IDENTITY.md` instead of the override. Now resolved per-call via `$OPENCUES_HOME || ~/.cues`, matching the search-path convention every other CLI command uses. Regression tests pin both the write target and `identity path`; the HOME-based E2E helper strips ambient `$OPENCUES_HOME` for hermeticity.
+
 ### Fixed — guard unguarded `process.env` in the rate-limit retry reader (`@opencues/core` 0.13.2 → 0.13.3)
 
 `RATE_LIMIT_MAX_RETRIES` in `llm-provider.ts` read `process.env.OPENCUES_RATE_LIMIT_RETRIES` without a `typeof process` guard, which would throw in chrome content scripts (no `process`). Wrapped the access; `?? 4` semantics preserved so `OPENCUES_RATE_LIMIT_RETRIES=0` still means zero retries. Caught by the `runtime-browser-safe` lint (pre-existing on master).

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/identity.cjs
+++ b/packages/opencues-cli/src/commands/identity.cjs
@@ -25,7 +25,15 @@ const { execSync } = require('node:child_process');
 const { tag, bold, dim, green, fileLink, banner, cliVersion } = require('../lib/style.cjs');
 const prompt = require('../lib/prompt.cjs');
 
-const IDENTITY_MD_PATH = path.join(os.homedir(), '.cues', 'IDENTITY.md');
+// Resolve per-call (not at module load) so $OPENCUES_HOME + a test's
+// HOME override are honoured — mirrors the search-path convention every
+// other CLI command uses (ai-callable.cjs / config.cjs / set-key.cjs).
+// Was hardcoded to os.homedir(), which silently ignored $OPENCUES_HOME
+// and always wrote the real ~/.cues/IDENTITY.md.
+function identityMdPath() {
+  const home = process.env.OPENCUES_HOME || path.join(os.homedir(), '.cues');
+  return path.join(home, 'IDENTITY.md');
+}
 
 // Lazy-load the validator from built core. Resolves a few candidate
 // paths so the CLI works from a clone (REPO_ROOT/packages/...) as well
@@ -103,7 +111,7 @@ function cmdList(argv) {
   }
   if (fields.length === 0) {
     console.log(`${tag('info')} no identity defined yet — run ${bold('opencues identity')} to add some`);
-    console.log(dim(`file: ${IDENTITY_MD_PATH}`));
+    console.log(dim(`file: ${identityMdPath()}`));
     return 0;
   }
   // Aligned three-column table: field · token · value, with a dim header row.
@@ -118,7 +126,7 @@ function cmdList(argv) {
     console.log(`  ${bold(r.key.padEnd(keyW))}   ${green(r.token.padEnd(tokW))}   ${r.value}`);
   }
   console.log('');
-  console.log(`${dim(`${fields.length} field${fields.length === 1 ? '' : 's'} ·`)} ${fileLink(IDENTITY_MD_PATH, IDENTITY_MD_PATH)}`);
+  console.log(`${dim(`${fields.length} field${fields.length === 1 ? '' : 's'} ·`)} ${fileLink(identityMdPath(), identityMdPath())}`);
   console.log(dim('activate token substitution with  ') + bold('identity-context-mode: safe'));
   return 0;
 }
@@ -142,7 +150,7 @@ function cmdSet(argv) {
       console.error('The runtime keeps the first definition; this set would be silently dropped.');
       console.error(`Either rename ${bold(key)} to avoid collision, or run ${bold(`opencues identity remove ${r.context.conflictingKey}`)} first.`);
     } else if (r.error === 'capacity-exceeded') {
-      console.error(dim(`IDENTITY.md path: ${IDENTITY_MD_PATH}`));
+      console.error(dim(`IDENTITY.md path: ${identityMdPath()}`));
     }
     // Exit codes: shape errors (invalid-key, value-*, capacity) → 2,
     // state errors (collision) → 1. Matches the unix convention.
@@ -152,7 +160,7 @@ function cmdSet(argv) {
   const token = deriveToken(key);
   const verb = r.action === 'added' ? 'added' : r.action === 'updated' ? 'updated' : 'unchanged';
   console.log(`${tag('ok')} ${verb} ${bold(key)} → ${dim(token)} = ${value}`);
-  console.log(dim(`file: ${IDENTITY_MD_PATH}`));
+  console.log(dim(`file: ${identityMdPath()}`));
   return 0;
 }
 
@@ -180,7 +188,7 @@ function cmdRemove(argv) {
 function cmdPath() {
   // Pure scriptable: just print the absolute path, no banner, no
   // styling. `opencues identity path | xargs $EDITOR` etc.
-  process.stdout.write(IDENTITY_MD_PATH + '\n');
+  process.stdout.write(identityMdPath() + '\n');
   return 0;
 }
 
@@ -195,7 +203,7 @@ async function cmdInterview(ctx) {
   console.log(dim('Each answer becomes an identity field token the LLM can emit; the runtime'));
   console.log(dim('substitutes your real value before it reaches the buffer. Press Enter to'));
   console.log(dim('accept the pre-filled value, or clear it to skip a field.'));
-  console.log(dim(`File: ${IDENTITY_MD_PATH}`));
+  console.log(dim(`File: ${identityMdPath()}`));
   console.log('');
 
   // Preload existing values so re-running the interview is a no-op for
@@ -225,7 +233,7 @@ async function cmdInterview(ctx) {
     if (!interviewKeys.has(key)) result.push({ key, value });
   }
   writeUserMd(result);
-  console.log(`${tag('ok')} wrote ${result.length} identity field${result.length === 1 ? '' : 's'} → ${fileLink(IDENTITY_MD_PATH, IDENTITY_MD_PATH)}`);
+  console.log(`${tag('ok')} wrote ${result.length} identity field${result.length === 1 ? '' : 's'} → ${fileLink(identityMdPath(), identityMdPath())}`);
   console.log('');
   console.log(dim('Activate identity field substitution in OPENCUES.md:'));
   console.log(`  ${bold('identity-context-mode: safe')}`);
@@ -245,8 +253,8 @@ async function cmdInterview(ctx) {
 // core's own test cases.
 
 function readUserMd() {
-  if (!fs.existsSync(IDENTITY_MD_PATH)) return '';
-  return fs.readFileSync(IDENTITY_MD_PATH, 'utf8');
+  if (!fs.existsSync(identityMdPath())) return '';
+  return fs.readFileSync(identityMdPath(), 'utf8');
 }
 
 function parseSentinelsMd(content) {
@@ -288,7 +296,7 @@ function stripInlineComment(rest) {
 }
 
 function writeUserMd(fields) {
-  fs.mkdirSync(path.dirname(IDENTITY_MD_PATH), { recursive: true });
+  fs.mkdirSync(path.dirname(identityMdPath()), { recursive: true });
   // Preserve the original body (anything after the closing `---`) so
   // the user's docstring + spec-reference notes survive. New file
   // ships with the same boilerplate as `opencues seed-configs`.
@@ -303,7 +311,7 @@ function writeUserMd(fields) {
     return `${f.key}:${' '.repeat(longestKey - f.key.length + 4)}${v}`;
   });
   const out = `---\n${lines.join('\n')}\n---\n${body.startsWith('\n') ? body : '\n' + body}`;
-  fs.writeFileSync(IDENTITY_MD_PATH, out, 'utf8');
+  fs.writeFileSync(identityMdPath(), out, 'utf8');
 }
 
 function needsQuoting(value) {
@@ -397,5 +405,5 @@ function printHelp() {
 
 // Exported for tests.
 module.exports.__test__ = {
-  parseSentinelsMd, deriveToken, needsQuoting, stripInlineComment, IDENTITY_MD_PATH,
+  parseSentinelsMd, deriveToken, needsQuoting, stripInlineComment, identityMdPath,
 };

--- a/packages/opencues-cli/src/commands/identity.test.cjs
+++ b/packages/opencues-cli/src/commands/identity.test.cjs
@@ -130,6 +130,11 @@ describe('needsQuoting', () => {
 function runCli(args, opts = {}) {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-sent-'));
   const env = { ...process.env, HOME: tmp, FORCE_COLOR: '0', NO_COLOR: '1' };
+  // These tests exercise HOME-based resolution; strip any ambient
+  // $OPENCUES_HOME so a dev with it set in their shell doesn't redirect
+  // the write out of the sandbox HOME. (The dedicated OPENCUES_HOME tests
+  // below set it explicitly.)
+  delete env.OPENCUES_HOME;
   if (opts.userMd) {
     fs.mkdirSync(path.join(tmp, '.cues'), { recursive: true });
     fs.writeFileSync(path.join(tmp, '.cues', 'IDENTITY.md'), opts.userMd, 'utf8');
@@ -311,6 +316,37 @@ describe('opencues identity — E2E', () => {
     const r = runCli(['set', 'k', `foo\x1bbar`]);
     assert.notStrictEqual(r.status, 0);
     assert.match(r.stderr, /forbidden control characters/);
+  });
+
+  it('honours $OPENCUES_HOME over ~/.cues for the write target', () => {
+    // Regression: identity used to hardcode os.homedir()/.cues, silently
+    // ignoring $OPENCUES_HOME and always writing the real ~/.cues/IDENTITY.md
+    // even when the caller pointed OPENCUES_HOME elsewhere.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-sent-'));
+    const ocHome = path.join(tmp, 'custom', '.cues');
+    fs.mkdirSync(ocHome, { recursive: true });
+    const env = { ...process.env, HOME: tmp, OPENCUES_HOME: ocHome, FORCE_COLOR: '0', NO_COLOR: '1' };
+    const r = spawnSync('node', [CLI, 'identity', 'set', 'jobTitle', 'Founder'], { env, encoding: 'utf8' });
+    assert.strictEqual(r.status, 0, r.stderr);
+    // Write landed under $OPENCUES_HOME …
+    const ocFile = path.join(ocHome, 'IDENTITY.md');
+    assert.ok(fs.existsSync(ocFile), 'IDENTITY.md should be written under $OPENCUES_HOME');
+    assert.deepStrictEqual(parseSentinelsMd(fs.readFileSync(ocFile, 'utf8')), [
+      { key: 'jobTitle', value: 'Founder' },
+    ]);
+    // … and NOT under $HOME/.cues.
+    assert.ok(!fs.existsSync(path.join(tmp, '.cues', 'IDENTITY.md')),
+      '$HOME/.cues/IDENTITY.md must NOT be created when $OPENCUES_HOME is set');
+  });
+
+  it('path: reflects $OPENCUES_HOME when set', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-sent-'));
+    const ocHome = path.join(tmp, 'custom', '.cues');
+    fs.mkdirSync(ocHome, { recursive: true });
+    const env = { ...process.env, HOME: tmp, OPENCUES_HOME: ocHome, FORCE_COLOR: '0', NO_COLOR: '1' };
+    const r = spawnSync('node', [CLI, 'identity', 'path'], { env, encoding: 'utf8' });
+    assert.strictEqual(r.status, 0, r.stderr);
+    assert.strictEqual(r.stdout.trim(), path.join(ocHome, 'IDENTITY.md'));
   });
 
   it('preserves the file body (docstring) across writes', () => {


### PR DESCRIPTION
## The bug

`opencues identity` resolved its target file as `os.homedir()/.cues/IDENTITY.md` at module load, **never reading `$OPENCUES_HOME`**. So:

```bash
OPENCUES_HOME=/tmp/sandbox/.cues opencues identity set company "Acme"
# → wrote the REAL ~/.cues/IDENTITY.md, not the sandbox
```

Every other CLI command (`config`, `ai-callable`, `set-key`, `show`, `doctor`, …) honours the `$OPENCUES_HOME || ~/.cues` search-path convention; identity was the lone exception. This surfaced during agentic-suite testing — an isolated test home couldn't be pointed at, and two writes landed in the developer's real identity file.

## The fix

Resolve the path **per-call** through `$OPENCUES_HOME || ~/.cues` (per-call, not module-load, so a test's env override applies — mirrors `set-key.cjs`). One helper replaces the constant across all 13 call sites.

## Tests

- New E2E: write target lands under `$OPENCUES_HOME` (and **not** `$HOME/.cues`) when it's set.
- New E2E: `identity path` reflects `$OPENCUES_HOME`.
- Hermeticity: the HOME-based `runCli` helper now strips ambient `$OPENCUES_HOME`, so a dev who has it set in their shell can't redirect the sandbox writes.

CLI suite: **194 pass** (was 192). `legacy-names` lint clean. `opencues` CLI `0.2.32 → 0.2.33` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
