### PR TITLE
feat(core): make gemma selectable by name (parity with haiku)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `gemma` selectable by name in the fluid-config classifier (parity with `haiku`) (`@opencues/core` 0.13.3 → 0.13.4)
+
+`gemma-4-31b` was already in cerebras `knownModels` (so it resolves via the config menu and bucket-scoped phrasings like `use gemma for blanks _`), but `gemma` was missing from the fluid-config pre-filter's curated model-alias list — so bare-name phrasings (`use gemma _`, `switch to gemma _`) were silently skipped while `use haiku _` fired. Added `gemma` to the alias set for full parity. Verified live: `use gemma for blanks _` → cerebras/gemma-4-31b (0.92). **Not** the cerebras default (gpt-oss-120b stays default) — gemma is private preview. Regression test pins the gemma↔haiku parity; docs note in `docs/architecture/llm-routing.md`.
+
 ### Fixed — `opencues identity` now honours `$OPENCUES_HOME` (`opencues` CLI 0.2.32 → 0.2.33)
 
 `opencues identity` hardcoded its target to `os.homedir()/.cues/IDENTITY.md`, silently ignoring `$OPENCUES_HOME` — so `OPENCUES_HOME=… opencues identity set …` wrote the real `~/.cues/IDENTITY.md` instead of the override. Now resolved per-call via `$OPENCUES_HOME || ~/.cues`, matching the search-path convention every other CLI command uses. Regression tests pin both the write target and `identity path`; the HOME-based E2E helper strips ambient `$OPENCUES_HOME` for hermeticity.

--- a/docs/architecture/llm-routing.md
+++ b/docs/architecture/llm-routing.md
@@ -105,7 +105,18 @@ use claude opus for auditors _        → auditors-llm-provider: anthropic
 route everything to gemini _          → blanks-llm-provider: gemini (blanks = default scope)
 switch to anthropic _                 → blanks-llm-provider: anthropic
 use cerebras _                        → blanks-llm-provider: cerebras
+use gemma for blanks _                → blanks-llm-provider: cerebras
+                                        blanks-llm-model: gemma-4-31b
 ```
+
+> **Gemma on Cerebras (private preview).** `gemma-4-31b` is in cerebras's
+> `knownModels`, so it's selectable by name — via the `opencues config`
+> menu (`blanks-llm-model`) or natural language (`use gemma for blanks _`,
+> `use gemma for cues _`) — exactly like `haiku` on anthropic. It is
+> **NOT** the cerebras default (`gpt-oss-120b` stays the default) while it
+> is in preview. It benches faster than gpt-oss-120b with comparable
+> accuracy on lookups/rewrites, but trails on multilingual transforms
+> (`tests/results/gemma-benchmark-2026-07-01/FINDINGS.md`).
 
 ### What the classifier may emit
 

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/config-intent-source.test.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.test.ts
@@ -13,6 +13,7 @@ import {
   summonPhraseStart,
   resolveSummonStart,
   parseSummonOutput,
+  hasLikelyIntent,
 } from './config-intent-source';
 import type { CueContext, HttpAdapter } from '../types';
 import { getProvider } from '../llm-provider';
@@ -786,5 +787,38 @@ describe('resolveSummonStart — model span with regex floor + data-loss guard',
     const t = 'voice mode off _';
     assert.strictEqual(resolveSummonStart(t, t), 0);
     assert.strictEqual(resolveSummonStart(t, null), 0);
+  });
+});
+
+// ============================================================================
+// hasLikelyIntent — the cheap pre-filter gate. `gemma` was added as a curated
+// model alias so it trips the gate on bare-name phrasings, at parity with
+// `haiku` (both models sit in their provider's knownModels; the classifier
+// resolves gemma → cerebras/gemma-4-31b, haiku → anthropic/claude-haiku).
+// ============================================================================
+
+describe('hasLikelyIntent — model-alias parity (gemma ↔ haiku)', () => {
+  it('trips on bucket-scoped model phrasings', () => {
+    assert.strictEqual(hasLikelyIntent('use gemma for blanks _'), true);
+    assert.strictEqual(hasLikelyIntent('use gemma for cues _'), true);
+    assert.strictEqual(hasLikelyIntent('use haiku for blanks _'), true);
+  });
+
+  it('trips on BARE model-name phrasings (no bucket word) — gemma at parity with haiku', () => {
+    // These have no bucket/provider word — only the curated model alias trips
+    // the gate. Before `gemma` was added, "use gemma _" was silently skipped
+    // while "use haiku _" fired. This pins the parity.
+    assert.strictEqual(hasLikelyIntent('use gemma _'), true);
+    assert.strictEqual(hasLikelyIntent('use haiku _'), true);
+    assert.strictEqual(hasLikelyIntent('switch to gemma _'), true);
+  });
+
+  it('does NOT trip on ordinary lookup/transform buffers with no model/setting token', () => {
+    // The gate is intentionally loose (a false-positive only costs a NONE
+    // classification downstream), so these are picked to contain zero
+    // provider/model/bucket/setting tokens.
+    assert.strictEqual(hasLikelyIntent('the capital of france _'), false);
+    assert.strictEqual(hasLikelyIntent('translate to spanish _ hola'), false);
+    assert.strictEqual(hasLikelyIntent('fix typos _ teh cat'), false);
   });
 });

--- a/packages/opencues-core/src/sources/config-intent-source.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.ts
@@ -203,7 +203,7 @@ const LIKELY_INTENT_KEYWORDS: ReadonlySet<string> = (() => {
     'opus', 'haiku', 'sonnet', 'fable', 'claude',
     'cerebras', 'groq', 'openai', 'anthropic', 'gemini',
     'openrouter', 'nano', 'mini', 'flash', 'llama',
-    'gpt-oss', 'gpt-5',
+    'gpt-oss', 'gpt-5', 'gemma',
   ];
   for (const k of curated) addToken(k);
 
@@ -219,7 +219,7 @@ const LIKELY_INTENT_KEYWORDS: ReadonlySet<string> = (() => {
  *  match "blanket". O(K) string scans where K = keyword count.
  *  Measured at < 0.5ms on a 32-char buffer with the full keyword set.
  */
-function hasLikelyIntent(text: string): boolean {
+export function hasLikelyIntent(text: string): boolean {
   const lower = text.toLowerCase();
   for (const kw of LIKELY_INTENT_KEYWORDS) {
     if (kw.includes(' ') || kw.includes('-')) {


### PR DESCRIPTION
## What

Makes `gemma-4-31b` on Cerebras selectable **by name**, at full parity with how `haiku` works — without changing the cerebras default (gpt-oss-120b stays default; gemma is private preview).

## The honest scope

gemma-4-31b was *already* in cerebras `knownModels`, so it was already selectable via:
- the `opencues config` menu (`blanks-llm-model` lists it), and
- bucket-scoped natural language — `use gemma for blanks _`, `use gemma for cues _` (the bucket words `cues`/`blanks` already trip the fluid-config pre-filter).

The **one gap** vs `haiku`: `gemma` was missing from the pre-filter's curated model-alias list, so bare-name phrasings with no bucket word — `use gemma _`, `switch to gemma _` — were silently skipped, while `use haiku _` fired (haiku is a curated alias). This adds `gemma` to that list → full parity.

## Verification (live, cerebras)

| Input | Classifier verdict |
|---|---|
| `use gemma for blanks _` | provider · blanks · **cerebras/gemma-4-31b** · 0.92 |
| `use gemma for cues _` | provider · cues · cerebras/gemma-4-31b · 0.92 |
| `use haiku for cues _` | provider · cues · anthropic/claude-haiku-4-5 · 0.95 |
| `turn on voice mode _` | setting · voice-mode · active (unaffected) |

## Not the default

`gpt-oss-120b` stays the cerebras default. gemma is opt-in only while in private preview. Docs note added to `docs/architecture/llm-routing.md` (with the multilingual-weakness caveat from the bench).

## Tests

Exports the pure `hasLikelyIntent` pre-filter and pins the gemma↔haiku parity (bucket-scoped + bare-name phrasings trip; neutral buffers don't). Full core suite green (198 + node:test). `@opencues/core` 0.13.3 → 0.13.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
