### PR TITLE
fix(core): anchor gemma model resolution in config-intent classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `switch model to gemma` resolved to the wrong model in the config-intent classifier (`@opencues/core` 0.13.4 → 0.13.5)
+
+`switch model to gemma _` was silently resolving to `cerebras:gpt-oss-120b` instead of `gemma-4-31b`. The classifier's few-shot examples had no anchor mapping the informal "gemma" alias to the private-preview model id, so it emitted `MODEL:` empty per the "unrecognised model" rule — the apply path then fell back to the provider's `defaultModel` (gpt-oss-120b for cerebras). The equivalent `haiku` phrasing only appeared to work because Anthropic's `defaultModel` happens to literally be the haiku model id, masking the same gap. Added a `SYSTEM_PROMPT` few-shot example anchoring `switch model to gemma` → `cerebras / gemma-4-31b`. Verified live via the agentic harness: resolves to gemma-4-31b (conf 0.92) and correctly writes `blanks-llm-model` to `OPENCUES.md`.
+
 ### Added — `gemma` selectable by name in the fluid-config classifier (parity with `haiku`) (`@opencues/core` 0.13.3 → 0.13.4)
 
 `gemma-4-31b` was already in cerebras `knownModels` (so it resolves via the config menu and bucket-scoped phrasings like `use gemma for blanks _`), but `gemma` was missing from the fluid-config pre-filter's curated model-alias list — so bare-name phrasings (`use gemma _`, `switch to gemma _`) were silently skipped while `use haiku _` fired. Added `gemma` to the alias set for full parity. Verified live: `use gemma for blanks _` → cerebras/gemma-4-31b (0.92). **Not** the cerebras default (gpt-oss-120b stays default) — gemma is private preview. Regression test pins the gemma↔haiku parity; docs note in `docs/architecture/llm-routing.md`.

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/config-intent-source.ts
+++ b/packages/opencues-core/src/sources/config-intent-source.ts
@@ -416,6 +416,15 @@ PROVIDER: gemini
 MODEL:
 CONFIDENCE: 0.8
 
+INPUT: switch model to gemma _
+INTENT: PROVIDER
+SETTING:
+VALUE:
+SCOPE: blanks
+PROVIDER: cerebras
+MODEL: gemma-4-31b
+CONFIDENCE: 0.85
+
 INPUT: switch to anthropic _
 INTENT: PROVIDER
 SETTING:


### PR DESCRIPTION
## Summary
- "switch model to gemma _" was resolving to `cerebras:gpt-oss-120b` instead of `gemma-4-31b` — the config-intent classifier's few-shot examples had no anchor teaching it to map the informal "gemma" alias to the private-preview model id `gemma-4-31b`, so it emitted `MODEL:` empty per the "unrecognised model → emit MODEL empty" rule. The apply path then fell back to the provider's `defaultModel` (gpt-oss-120b for cerebras).
- The equivalent `haiku` case only appeared to work by coincidence — Anthropic's `defaultModel` happens to literally be the haiku model id, so the same blank-MODEL fallback landed on the right model anyway.
- Adds one `SYSTEM_PROMPT` few-shot example anchoring `switch model to gemma` → `PROVIDER: cerebras / MODEL: gemma-4-31b` in `packages/opencues-core/src/sources/config-intent-source.ts`.

## Test plan
- [x] `npm run build && npm test` in `packages/opencues-core` — 992 + 198 tests pass, 0 failures
- [x] Verified live via the agentic harness on a rebuilt OpenCode fork:
  - `switch model to gemma _` → resolves to `cerebras:gemma-4-31b` (conf 0.92), and `~/.cues/OPENCUES.md` gets `blanks-llm-provider: cerebras` / `blanks-llm-model: gemma-4-31b` written correctly
  - `use claude opus for auditors _` → still `anthropic:claude-opus-4-7` (unaffected)
  - `switch to cerebras _` (no model named) → still correctly falls back to `cerebras:gpt-oss-120b` (intended bare-switch default)

## Known follow-up (not in this PR)
The shorter unanchored phrasing `switch to gemma` (no "model") is flakier — it misfired to gpt-oss-120b at conf 0.73 on one live attempt, then correctly resolved at conf 0.93 on a retry with identical input. Left as a follow-up; may need a second few-shot example for the bare `switch to <alias>` phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)