### PR TITLE
fix(core): combined-mode CUE.md drops LLM half; bracketed keywords: breaks first/last entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — combined-mode CUE.md silently dropped its LLM half; bracketed `keywords:` lists lost their first/last entry (`@opencues/core` 0.13.5 → 0.13.6)
+
+Found while auditing `spec/cue-spec.md` for accuracy against the reference implementation — both were real parsing bugs, not just doc drift.
+
+- **Combined mode** (a single `CUE.md` pairing a static JSON tips block with `match:`/`keywords:` + prompt-body LLM text, per `spec/cue-spec.md`'s worked "legal" example) never actually built the LLM half. `parseSingleCueMd` `break`ed unconditionally as soon as the JSON block parsed, so `result.promptConfig` was never populated — only the static-block words (e.g. `herein`) ever got alternatives; everything meant to fall through to the model (`contract`, `agreement`, …) silently matched nothing. Now the parser only stops at the static block when frontmatter declares neither `match:` nor `keywords:` (a pure-static cue); when either is present it falls through and builds `promptConfig` too. `spec/conformance/valid/cue/combined.md` — already a fixture — now asserts both halves are present (previously the suite's `hasTips || hasPrompt` OR-assertion silently accepted the missing half).
+- **`keywords: [a, b, c]`** (YAML bracket-list syntax, documented as valid in `spec/cue-spec.md`) stored the literal bracketed string rather than stripping brackets like `on-host:`/`on-site:` already do — so `RoutedWordSourceGroup`'s downstream `.split(',')` left the first keyword prefixed with `[` and the last suffixed with `]`, and neither could ever match. Comma-separated plain strings were unaffected. Added `normalizeKeywordsValue()` (reuses `parseHostList`'s bracket/JSON-array handling) applied at all three `keywords:` assignment sites (frontmatter, `### <name>` subsection YAML, legacy single-grammar body).
+
+Regression tests added to `cues-md.test.ts` for both. `docs/architecture` and `spec/` docs updated in the same pass to describe the now-correct behavior.
+
 ### Fixed — `switch model to gemma` resolved to the wrong model in the config-intent classifier (`@opencues/core` 0.13.4 → 0.13.5)
 
 `switch model to gemma _` was silently resolving to `cerebras:gpt-oss-120b` instead of `gemma-4-31b`. The classifier's few-shot examples had no anchor mapping the informal "gemma" alias to the private-preview model id, so it emitted `MODEL:` empty per the "unrecognised model" rule — the apply path then fell back to the provider's `defaultModel` (gpt-oss-120b for cerebras). The equivalent `haiku` phrasing only appeared to work because Anthropic's `defaultModel` happens to literally be the haiku model id, masking the same gap. Added a `SYSTEM_PROMPT` few-shot example anchoring `switch model to gemma` → `cerebras / gemma-4-31b`. Verified live via the agentic harness: resolves to gemma-4-31b (conf 0.92) and correctly writes `blanks-llm-model` to `OPENCUES.md`.

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/conformance.test.ts
+++ b/packages/opencues-core/src/conformance.test.ts
@@ -64,6 +64,13 @@ describe('valid/cue/*.md', () => {
       const hasTips = config.tips && config.tips.length > 0;
       const hasPrompt = config.promptConfig && Object.keys(config.promptConfig.sources).length > 0;
       expect(hasTips || hasPrompt).toBe(true);
+      // combined.md specifically declares match:/keywords: alongside a
+      // static JSON block — it MUST produce BOTH halves (static override +
+      // LLM fallback), not just whichever one satisfies the OR above.
+      if (file === 'combined.md') {
+        expect(hasTips).toBe(true);
+        expect(hasPrompt).toBe(true);
+      }
     });
   }
 });

--- a/packages/opencues-core/src/cues-md.test.ts
+++ b/packages/opencues-core/src/cues-md.test.ts
@@ -812,3 +812,92 @@ describe('Phase 4 — typed-sentinel blank fields (signature/returns/ai-callable
     assert.match(warned, /IGNORED/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Combined mode — a CUE.md with both a static JSON tips block AND
+// match:/keywords: in frontmatter should populate BOTH result.tips (the
+// static overrides) and result.promptConfig (the LLM fallback for
+// everything else). Previously the parser `break`d unconditionally after
+// a JSON block parsed, so the LLM half was silently never built.
+// ---------------------------------------------------------------------------
+
+describe('parseCuesMd: combined mode (static tips + LLM fallback)', () => {
+  const legalCue = [
+    '---',
+    'name: legal',
+    'description: Legal terminology',
+    'match: contract|agreement|clause|herein|whereas',
+    '---',
+    '',
+    '```json',
+    '[{',
+    '  "id": "legal-overrides",',
+    '  "words": {',
+    '    "herein": { "tip": "Avoid; replace with explicit reference", "alts": ["in this agreement", "above", "hereunder"] }',
+    '  }',
+    '}]',
+    '```',
+    '',
+    'For other matched terms, suggest 3 alternatives that preserve legal meaning.',
+    'Format: INDEX:alt1,alt2,alt3',
+  ].join('\n');
+
+  it('builds both result.tips and result.promptConfig when frontmatter declares match:/keywords:', () => {
+    const cfg = parseSingleCueMd(legalCue, '/cues/legal');
+    assert.ok(cfg.tips && cfg.tips.length > 0, 'static tips should still be populated');
+    const src = cfg.promptConfig?.sources?.['legal'];
+    assert.ok(src, 'combined mode must also build an LLM source, not just the static block');
+    assert.strictEqual(src?.match, 'contract|agreement|clause|herein|whereas');
+    assert.match(src?.promptText ?? '', /suggest 3 alternatives/);
+  });
+
+  it('stays static-only (no promptConfig) when frontmatter declares neither match: nor keywords:', () => {
+    const content = [
+      '---',
+      'name: grammar',
+      '---',
+      '```json',
+      '[{ "id": "grammar", "words": { "teh": { "tip": "typo", "alts": ["the"] } } }]',
+      '```',
+    ].join('\n');
+    const cfg = parseSingleCueMd(content, '/cues/grammar');
+    assert.ok(cfg.tips && cfg.tips.length > 0);
+    assert.strictEqual(cfg.promptConfig, undefined, 'pure-static cue must not acquire an unroutable LLM source');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `keywords:` bracket-list syntax — a YAML array (`[a, b, c]`) must parse
+// identically to a comma-separated string. Previously only on-host/on-site
+// went through bracket-stripping; keywords stored the literal bracketed
+// text, so the first/last entries kept a stray `[`/`]` and could never
+// match after RoutedWordSourceGroup's `.split(',')`.
+// ---------------------------------------------------------------------------
+
+describe('parseCuesMd: keywords: bracket-list syntax', () => {
+  it('parseSingleCueMd normalizes a bracketed keywords: list to comma-separated', () => {
+    const content = '---\nname: thinking\nkeywords: [ultrathink, Tab, deep thinking, think harder]\n---\nPrompt body.';
+    const cfg = parseSingleCueMd(content, '/cues/thinking');
+    const src = cfg.promptConfig?.sources?.['thinking'];
+    assert.strictEqual(src?.keywords, 'ultrathink, Tab, deep thinking, think harder');
+  });
+
+  it('parseSingleCueMd still accepts plain comma-separated keywords:', () => {
+    const content = '---\nname: thinking\nkeywords: ultrathink, Tab, deep thinking\n---\nPrompt body.';
+    const cfg = parseSingleCueMd(content, '/cues/thinking');
+    assert.strictEqual(cfg.promptConfig?.sources?.['thinking'].keywords, 'ultrathink, Tab, deep thinking');
+  });
+
+  it('parseCuesMd normalizes bracketed keywords: in a ### subsection', () => {
+    const md = [
+      '## Prompt',
+      '### thinking',
+      '```yaml',
+      'keywords: [ultrathink, deep thinking]',
+      '```',
+      'prompt body',
+    ].join('\n');
+    const cfg = parseCuesMd(md);
+    assert.strictEqual(cfg.promptConfig?.sources?.['thinking'].keywords, 'ultrathink, deep thinking');
+  });
+});

--- a/packages/opencues-core/src/cues-md.ts
+++ b/packages/opencues-core/src/cues-md.ts
@@ -534,6 +534,21 @@ function parseHostList(value: string): string[] {
   return v.split(',').map(s => s.trim()).filter(s => s.length > 0);
 }
 
+/**
+ * Normalize a `keywords:` value written as a YAML bracket list
+ * (`[a, b, c]`) into a plain comma-separated string — the shape every
+ * downstream consumer (RoutedWordSourceGroup's `.split(',')`) expects.
+ * Plain comma-separated input is returned unchanged (preserves existing
+ * whitespace exactly; only the bracket form needed fixing). Without
+ * this, `keywords: [a, b, c]` stored the literal bracketed string, and
+ * the first/last keyword kept its stray `[`/`]` and could never match.
+ */
+function normalizeKeywordsValue(value: string): string {
+  const v = value.trim();
+  if (!(v.startsWith('[') && v.endsWith(']'))) return value;
+  return parseHostList(v).join(', ');
+}
+
 function parseFrontmatter(content: string): { frontmatter: CuesMdFrontmatter; body: string } {
   const match = content.match(FRONTMATTER_RE);
   if (!match) {
@@ -749,7 +764,7 @@ function parsePromptSection(content: string): PromptConfig {
         continue;
       }
       if (kv.match) source.match = kv.match;
-      if (kv.keywords) source.keywords = kv.keywords;
+      if (kv.keywords) source.keywords = normalizeKeywordsValue(kv.keywords);
       if (kv.classify) source.classify = kv.classify;
       if (kv.priority) source.priority = parseInt(kv.priority, 10) || undefined;
       if (kv.enabled !== undefined) source.enabled = kv.enabled !== 'false';
@@ -798,7 +813,7 @@ function parsePromptSection(content: string): PromptConfig {
           const text = extractTextOutsideCodeBlocks(content);
           const source: SourceConfig = { name: 'grammar' };
           if (kv.match) source.match = kv.match;
-          if (kv.keywords) source.keywords = kv.keywords;
+          if (kv.keywords) source.keywords = normalizeKeywordsValue(kv.keywords);
           if (kv.classify) source.classify = kv.classify;
           if (kv.priority) source.priority = parseInt(kv.priority, 10) || undefined;
           if (kv.model) source.model = kv.model;
@@ -1050,7 +1065,7 @@ function parseExtendedFrontmatter(content: string): { frontmatter: SingleCueFron
       case 'parser': fm.parser = value as BlankParser; break;
       case 'priority': fm.priority = parseInt(value, 10) || undefined; break;
       case 'match': fm.match = value; break;
-      case 'keywords': fm.keywords = value; break;
+      case 'keywords': fm.keywords = normalizeKeywordsValue(value); break;
       case 'classify': fm.classify = value; break;
       case 'model': fm.model = value; break;
       case 'provider': fm.provider = value; break;
@@ -1308,6 +1323,12 @@ export function parseSingleCueMd(content: string, folderPath: string, nameOverri
       //     words map, populates result.tips)
       //   - otherwise ⇒ LLM cue source (prompt in body, match/keywords
       //     in frontmatter, populates result.promptConfig)
+      //   - both, when frontmatter declares match:/keywords: ⇒ combined
+      //     mode: the static block still populates result.tips, but we
+      //     fall through to also build result.promptConfig so the LLM
+      //     handles the long tail. Without the match/keywords check, a
+      //     pure-static cue (no routing signal) would fall through too
+      //     and construct an unroutable ConfigSource with neither.
       const jsonBlock = extractCodeBlock(body, 'json');
       if (jsonBlock) {
         try {
@@ -1320,7 +1341,7 @@ export function parseSingleCueMd(content: string, folderPath: string, nameOverri
               ? [{ id: name, ...data }]
               : [{ id: name, words: data as Record<string, unknown> }];
           }
-          break; // static cue — done
+          if (!frontmatter.match && !frontmatter.keywords) break; // static-only cue — done
         } catch { /* malformed JSON — fall through to prompt parsing */ }
       }
 


### PR DESCRIPTION
## Summary
Found while code-verifying `spec/cue-spec.md`'s claims against the reference parser during a docs-accuracy audit — both are real parsing bugs, not just documentation drift.

- **Combined mode** (a `CUE.md` pairing a static JSON tips block with `match:`/`keywords:` + prompt-body LLM text, exactly the worked "legal" example in `spec/cue-spec.md`) never built the LLM half. `parseSingleCueMd` `break`ed unconditionally as soon as the JSON block parsed, so `result.promptConfig` was never populated — only the static-block words got alternatives; everything meant to fall through to the model matched nothing. Now the parser only stops at the static block when frontmatter declares neither `match:` nor `keywords:` (a pure-static cue); otherwise it falls through and builds `promptConfig` too.
- **`keywords: [a, b, c]`** (YAML bracket-list syntax, documented as valid) stored the literal bracketed string instead of stripping brackets like `on-host:`/`on-site:` already do, so the downstream `.split(',')` left the first keyword prefixed with `[` and the last suffixed with `]` — neither could ever match. Added `normalizeKeywordsValue()` (reuses `parseHostList`'s bracket/JSON-array handling) at all three `keywords:` assignment sites.

`spec/conformance/valid/cue/combined.md` now asserts both halves are present (previously the suite's `hasTips || hasPrompt` OR-assertion silently accepted the missing half).

`@opencues/core` 0.13.5 → 0.13.6 per the version-bump-gate convention.

## Test plan
- [x] Regression tests added to `cues-md.test.ts` for both bugs
- [x] Full package test suite green (997 node:test + 198 vitest, zero regressions)
- [x] `spec/conformance` suite green with tightened combined-mode assertion
- [x] `bash scripts/pre-pr.sh` gates pass (version-bump-gate, legacy-names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CrGD7J1LHUxx9vjZuSv6p