### PR TITLE
docs(features): fix code-verified drift across docs/features/ (biggest sweep yet)

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -85,12 +85,14 @@ The state machine that keeps multi-word substitutions, cycle progress, and per-e
 
 ## LLM context inputs
 
-Optional information the FluidBlank LLM call receives in addition to the user's prompt. Both OFF by default and gated on a scalar in `OPENCUES.md`. Read [`docs/architecture/ambient-context.md`](../architecture/ambient-context.md) and [`docs/architecture/sentinels.md`](../architecture/sentinels.md) before wiring fluid-blank output into any side-effect channel.
+Optional information the FluidBlank LLM call receives in addition to the user's prompt. Both OFF by default and gated on a scalar in `OPENCUES.md`. Read [`docs/architecture/ambient-context.md`](../architecture/ambient-context.md) and [`docs/architecture/identity-context.md`](../architecture/identity-context.md) before wiring fluid-blank output into any side-effect channel.
 
 | # | Feature | Description |
 |---|---------|-------------|
 | 32 | [Ambient Context](ambient-context.md) | FluidBlank optionally receives the focused field's label / placeholder / page-title so `_` lookups disambiguate per context (e.g. "destination" on flights.google.com vs airbnb.com). OFF by default. Chrome only — needs DOM. Host-agnostic at the `HostAdapter` contract level. |
 | 33 | [Identity Context](identity-context.md) | FluidBlank optionally injects the user's own personal data (`~/.cues/IDENTITY.md` frontmatter) as identity-context tokens so `_` lookups personalise without re-typing. `safe` mode keeps PII off the LLM provider's logs; `raw` opts in to inlining. OFF by default. Phase 1 wires fluid-blank only. |
+| 39 | [Blank as Context](blank-as-context.md) | Local blanks (weather, stocks, calendar, …) surfaced as ambient catalog context for fluid-blank/transform-blank — same security model as identity-context, for parameterised dynamic data instead of static personal fields. |
+| 40 | [Max Thinking](max-thinking.md) | `max-thinking` scalar trades reasoning depth for speed on reasoning-capable models (Groq / Cerebras / OpenAI gpt-oss + gpt-5 families). |
 
 ## Surfacing
 
@@ -111,6 +113,8 @@ Where `.cues/` lives, when changes reload, how `defaults/` seeds a fresh install
 | 16 | [Hot-Reload Config](hot-reload-config.md) | Config file changes take effect without restart |
 | 24 | [Shipped Defaults](shipped-defaults.md) | `<repo>/defaults/` as the seed + bake source for `opencues seed-configs` and the Chrome extension's bundled fallback |
 | 28 | [Config Search Paths](config-search-paths.md) | Three-layer precedence (`$OPENCUES_HOME → <cwd>/.cues → ~/.cues`), the `OPENCUES.md` system-settings user-level-only special case, and how `seed-configs` populates `~/.cues/` |
+| 41 | [claude-cli Provider](claude-cli-provider.md) | Route opencues' agent surfaces through a Claude Pro/Max subscription (via the local `claude` CLI) instead of a pay-per-token `ANTHROPIC_API_KEY`. |
+| 42 | [Cues Skill + Plugin](cues-skill-and-plugin.md) *(experimental, WIP)* | A Claude skill / plugin that side-effect-writes `.cues/CUES.md` from within a chat conversation with the user's AI assistant. |
 
 ## Chrome specifics
 

--- a/docs/features/agent-task.md
+++ b/docs/features/agent-task.md
@@ -205,9 +205,14 @@ AgentRewrite):
 | professionalism | ~50% | model has its own style opinions; over-edits clean prose |
 | mixed-task | ~80% | composed prompts ("X AND Y") harder for the model |
 
-**Aggregate**: 120/128 (93.8%) on the full suite, ~379ms per case.
 Stylistic-task failures are model judgement, not pipeline bugs —
 don't prompt-tune to suppress them; that hurts the mechanical tasks.
+(The specific aggregate pass-rate and case count cited in older
+revisions of this doc referenced `tests/benchmarks/agent-task/`, which
+was deleted in the May 2026 AgentLoop→AgentRewrite retirement — see
+`tests/benchmarks/agent-rewrite/CONTINUE.md`. The replacement suite's
+case/category count changes as it grows; re-run it for a current
+number rather than trusting a cited figure here.)
 
 ---
 
@@ -217,7 +222,6 @@ Per debounce cycle (gpt-oss-120b @ Groq, EDITS format):
 - Build candidates: <1ms
 - LLM edit pass: ~300–500ms (most docs); 1.7s for a 200-word doc
 - Apply DynDefs + setText: ~10–50ms
-- **Total: ~379ms avg across the 128-case suite**
 
 Same 500ms debounce as the resolver. The agent runs ON TOP of
 resolver's results — no second clock. Cache hits skip the LLM
@@ -268,15 +272,17 @@ Quick locator:
   (search for `handleTaskCommand`)
 - **Statusline**: `packages/opencues-runtime/src/modules/statusline.ts`
   (agentTask field in the payload)
-- **Benchmarks** (all under `tests/benchmarks/agent-task/`):
-  - `run.ts` — main suite, 128 cases across 16 categories
-    (`--parallel 8`, `--category <name>`, `--case <id>`,
-    `--format DECISIONS|EDITS`)
-  - `convergence.ts` — pins the cache contract: re-running on
-    unchanged text fires zero LLM calls (6/6 scenarios)
-  - `scale.ts` — 25/50/100/200-word docs, measures latency + recall
-  - `robustness.ts` — 16 stubbed-transport scenarios for failure-mode
-    coverage (empty body, malformed JSON, rate limits, throws, etc.)
+- **Benchmarks** (`tests/benchmarks/agent-rewrite/` — replaced the
+  deleted `tests/benchmarks/agent-task/` in the May 2026
+  AgentLoop→AgentRewrite retirement; see that directory's
+  `CONTINUE.md` for the migration history):
+  - `cases.ts` — categorized cases (spelling, capitalisation,
+    translation, grammar, paragraph-structure, idempotent, style,
+    long-doc, …) — check the file directly for the current count,
+    it's grown since the retirement
+  - `run.ts` — main runner (`--parallel`, `--category`, `--case`, `--verbose`)
+  - `live-typing.ts` — stress test simulating user typing during the
+    LLM call, asserting user content always survives the merge
 - **Implementation reference**: `docs/architecture/agent-task.md` — pipeline shape, prompt design rationale, response format choice, and the empirical lessons that justify each.
 - **Cache reference**: `docs/architecture/agent-rewrite-cache.md` — two-tier skip-on-stable + LRU cache, key composition, determinism assumption, and extension points (size, persistence, approximate keys, negative caching, telemetry).
 

--- a/docs/features/auto-submit.md
+++ b/docs/features/auto-submit.md
@@ -1,57 +1,29 @@
 ---
-last_updated: 2026-04-06
+last_updated: 2026-07-04
 ---
 
 # Auto-Submit Trigger
 
-Analysis fires automatically as the user types, without requiring an explicit submit action. A three-tier trigger system detects when words are ready for analysis and invokes the resolver after a debounce period and stability check.
+Analysis fires automatically as the user types, without requiring an explicit submit action. The `Resolver` module (`packages/opencues-runtime/src/modules/resolver.ts`) debounces normal typing but bypasses the debounce entirely for an explicit `_` trigger.
 
 ---
 
 ## How It Works
 
-1. **On every text change**, the auto-submit code (`writeAutoSubmitDebounced`) runs inside the render loop
-2. **Hot-reload check** — if no LLM request is in flight and `Date.now() - _configLoadedAt > 2000`, `_reloadCuesConfig()` fires before any analysis logic
-3. **Eager tips lookup** — before debouncing, all current words are checked against `_localCueMap` via `cuesCore.lookupMultiple()`. Matching words get their `WordDef` entries immediately (~0ms), dimming them in the input before the LLM round-trip
-4. **If all words resolved from tips** (no missing indices and no blanks), the 50ms debounce timer still fires, but `_dynTriggerAnalysis` returns early because `_dynLastAnalyzed` is already up to date. No LLM call is made
-5. **Otherwise**, a 50ms debounce timer fires, followed by a stability check, then `_dynTriggerAnalysis()` runs the full LLM pipeline
+1. **On every text change** (user-sourced only — the resolver ignores its own `setText` echoes), `Resolver.onTextChange` runs.
+2. **Config hot-reload check** — if `OPENCUES.md` scalars changed since the sources were last built, the resolver rebuilds before dispatching, so a flag flip (`fluid-blank-mode: off → on`, etc.) takes effect without a host restart.
+3. **Same-text dedupe** — if the incoming text is identical to the last user-sourced text seen, the change is a no-op echo (some hosts re-emit change events for unchanged content) and is dropped immediately.
+4. **Blank-trigger fast path**: if the buffer's trailing edge just gained a `_` (per `blank-trigger-mode` — `immediate`: the instant `_` becomes the last non-whitespace char; `spaced`: only once a confirming space follows), the debounce is bypassed entirely and the resolver dispatches right away. This is what cuts perceived `_` latency roughly in half versus waiting out the debounce.
+5. **Otherwise**, a single debounce timer (`debounceMs`, default **500ms**) is (re)armed. When it fires, the resolver dispatches the current text.
+6. **In-flight cancellation**: every dispatch bumps a monotonic `_generation` counter. If a newer keystroke supersedes an in-flight LLM call, the stale response is discarded on arrival by generation mismatch rather than being applied over newer text.
+
+There is no separate "space typed" / "typing pause" / "mid-sentence edit" tier system with different debounce values — it's one debounce for anything that isn't a `_`-trigger, plus the immediate `_`-trigger fast path.
 
 ---
 
-## Three-Tier Trigger
+## Word Stability / Staleness
 
-| Tier | Condition | Debounce | Purpose |
-|------|-----------|----------|---------|
-| 1 — Space typed | `_curWords.length > _prevWords.length` | 50ms + stability check | The previous word is complete; analyze it |
-| 2 — Typing pause | Last word differs from last analyzed word | 300ms + stability check | Catches the final word when the user stops typing without a trailing space |
-| 3 — Mid-sentence edit | `_curWords.length === _prevWords.length` but a word changed | 50ms + stability check | Re-analyze the changed word |
-
-**Tier 1** fires on the main debounce path. The code detects `_curWords.length > _prevWords.length` and sets `_needsAnalysis = true`.
-
-**Tier 2** uses a separate timer (`_dynFinalPauseTimer`). After any text change, if the last word differs from the last analyzed word, a 300ms `setTimeout` is set. When it fires, it re-checks that the last word still differs (stability check) and calls `_dynTriggerAnalysis()`.
-
-**Tier 3** fires when word count is unchanged but the joined text differs from `_dynLastAnalyzed`. The same 50ms debounce path as Tier 1 handles it.
-
-All three tiers clear `_dynFinalPauseTimer` on text change to prevent stale pause triggers from firing.
-
----
-
-## Word Stability Check
-
-After the debounce timer fires, the system verifies the text has not changed since the timer was set:
-
-```
-var _nowText = hlText.split(/\s+/).filter(w => w).join(" ");
-var _thenText = _curWords.join(" ");
-if (_nowText !== _thenText) return;  // skip — next keystroke re-triggers
-```
-
-This prevents false triggers from rapid typing. If the user types "hel" then quickly "lo", the 50ms timer from "hel" fires but sees "hello" and aborts. The timer from "hello" then fires cleanly.
-
-**Additional guards:**
-- `_dynPending` flag prevents overlapping LLM requests. If a request is in flight, the trigger is skipped. When the response returns, a post-check detects if the text changed during the call and re-triggers if needed
-- `_resolverGeneration` counter — incremented on config reload. In-flight responses from an old generation are discarded
-- `_dynUnderscoreQueued` — when a blank's context changes, a re-analysis is queued for the next available slot
+Because dispatches are generation-tagged, a response that arrives after the buffer has moved on doesn't need a separate "did the text change since the timer was set" check the way a naive setTimeout would — the generation mismatch alone is enough to drop it. Local, non-LLM matches (a word that's already in a loaded `CUE.md`'s `## Tips`, or already covered by an existing `DynDef`) resolve without a network round-trip at all, so they're not subject to the debounce or generation dance in the first place.
 
 ---
 
@@ -60,15 +32,13 @@ This prevents false triggers from rapid typing. If the user types "hel" then qui
 ### Standard (opencues-core)
 
 - The resolver is stateless — it accepts text and word indices, returns results, and has no opinion on when it is called
-- No built-in debounce, timer, or text-change detection
+- No built-in debounce, timer, or text-change detection in opencues-core itself; debounce/generation/dedupe are all runtime-layer (`@opencues/runtime`) concerns
 - Supports targeted indices so the caller can request analysis for specific words only
 - Returns results keyed by word index, allowing incremental merging with previous results
 
 ### Integration responsibilities
 
-- Implement a debounce strategy for each trigger tier (space-typed, typing pause, word-edited)
-- Detect text changes and determine which words changed (new, edited, deleted)
-- Track pending/in-flight request state to prevent duplicate LLM calls
-- Perform the stability check (verify text hasn't changed between debounce fire and actual submission)
+- Supply a `HostAdapter` with `onTextChange` — the shared runtime's `Resolver` handles debounce, the `_`-trigger fast path, hot-reload detection, and generation-based cancellation for you
+- If implementing outside the shared runtime: debounce normal typing, bypass the debounce for an explicit `_` trigger, and tag in-flight requests so a stale response can't clobber newer text
 - Merge incremental results into the existing alternatives map
-- Decide when to skip remote cues (all words already have alternatives)
+- Decide when to skip remote cues (all words already have alternatives from local tips or existing `DynDef`s)

--- a/docs/features/blank-as-context.md
+++ b/docs/features/blank-as-context.md
@@ -8,12 +8,15 @@ trackers, …).
 **Off by default.** Opt in per-blank via the `as-context:` frontmatter
 key + the global `blank-context-mode:` scalar in `OPENCUES.md`.
 
-**Status:** design + bench validated (May 2026). Not yet wired to the
-production runtime — `tests/benchmarks/blank-sentinels-matrix/` proves
-the representation reliably resolves at scale across the four scoring
-axes (correctToken / verbatim / hallucination / leak). See its
-`FINDINGS.md` for the matrix and `docs/architecture/blank-as-context.md`
-when it lands for the production wiring plan.
+**Status:** shipped and wired into the production runtime. `blank-context.ts`
+(catalog derivation/rendering), `blank-context-cache.ts` (snapshot cache
++ pre-warm timer), the `blank-context-mode` registry scalar, the
+`as-context:`/`context-ttl:`/`context-slots:`/`context-bind:` frontmatter
+fields, and the resolver/adapter wiring are all live — see
+`docs/architecture/blank-as-context.md` for the production wiring detail.
+`tests/benchmarks/blank-sentinels-matrix/` is the bench that validated
+the representation at scale across the four scoring axes (correctToken /
+verbatim / hallucination / leak); see its `FINDINGS.md` for the matrix.
 
 ## What it is
 
@@ -252,5 +255,5 @@ could see (by name in `safe`, by value in `raw`).
   member of the context-shaping family.
 - `tests/benchmarks/blank-sentinels-matrix/FINDINGS.md` — bench
   evidence that shaped the representation choice.
-- `docs/architecture/blank-as-context.md` *(to land)* — production
-  wiring plan, snapshot adapter contract, eviction policy.
+- `docs/architecture/blank-as-context.md` — production
+  wiring, snapshot adapter contract, eviction policy.

--- a/docs/features/blank-as-context.md
+++ b/docs/features/blank-as-context.md
@@ -246,7 +246,7 @@ could see (by name in `safe`, by value in `raw`).
 
 ## See also
 
-- `docs/features/sentinels.md` — the sister feature; same threat model,
+- `docs/features/identity-context.md` — the sister feature; same threat model,
   static data only.
 - `docs/features/ambient-context.md` — page-level metadata; the third
   member of the context-shaping family.

--- a/docs/features/chrome-hot-reload.md
+++ b/docs/features/chrome-hot-reload.md
@@ -1,281 +1,60 @@
 ---
-last_updated: 2026-04-22
+last_updated: 2026-07-04
 ---
 
 # Chrome Hot-Reload
 
-Config edits propagate into already-open Chrome tabs within ~2.5
-seconds without an extension reload, page refresh, or user action.
-The mechanism is different from the native hosts (CC, OC) —
-those poll the filesystem on every keystroke (see `hot-reload-config.md`).
-Chrome content scripts have no filesystem access, so the extension
-polls a content-addressable hash file (`dist/configs/.version`)
-instead.
+> ⚠️ **Superseded.** Everything below the "Current mechanism" section
+> describes the pre-May-2026 poll-based design, which has been
+> **fully removed** from the codebase. It's kept here as a historical
+> record since older references (including this doc's own earlier
+> revisions) describe it as current. [`docs/features/chrome-sync.md`](chrome-sync.md)
+> is the canonical, current doc for how config changes reach Chrome —
+> read that first.
 
-This doc covers the end-to-end loop. For the source-discovery rules
-that decide *what* gets bundled in the first place, see
-`docs/features/chrome-sync.md`.
+Config edits propagate into already-open Chrome tabs without an extension reload, page refresh, or user action. The mechanism is different from the native hosts (CC, OC) — those poll the filesystem on every keystroke (see [Hot-Reload Config](hot-reload-config.md)). Chrome content scripts have no filesystem access, so the browser side needs an out-of-band channel.
 
 ---
 
-## Why it's different from native hosts
+## Current mechanism (as of May 2026 — see `chrome-sync.md` for full detail)
 
-Native hosts read `~/.cues/` and `<cwd>/.cues/` directly. They
-can poll mtimes, watch dirents, or just re-stat files cheaply.
-
-Chrome content scripts run inside the page's renderer process under a
-strict sandbox. They can't read `~/.cues/`. Everything they see
-must be inside the extension's bundle (`dist/configs/`), which gets
-populated by `opencues sync chrome`.
-
-So the hot-reload story for chrome is two cooperating loops:
+A local **native-messaging host** process (installed via `opencues install chrome-host`) watches `~/.cues/` (or `$OPENCUES_HOME`) directly on the filesystem side, and **pushes** the rebuilt bundle into `chrome.storage.local['opencues_bundle']` whenever something changes. Chrome's `chrome.storage.onChanged` event then fires in every open tab:
 
 ```
-WSL/macOS side                      Chrome content script side
-───────────────                      ───────────────────────────
-~/.cues/CUES.md edited           tick every 2.5s:
-        ↓                                fetch dist/configs/.version
-fs.watch fires (250ms debounce)          if hash changed:
-        ↓                                    invalidate bundle index
-syncChrome() re-runs                         await reloadConfig()
-        ↓                                        ↓
-dist/configs/* rewritten             ConfigLoader re-reads every source
-.version = sha256(all files)         New tips/alts immediately live
-        ↓
-mirrored to Windows install path
+~/.cues/ edited                     Every open tab's content script
+        ↓                                  ↓
+native-messaging host detects        chrome.storage.onChanged fires
+        ↓                                  ↓
+rebuilds bundle,                     invalidates its in-memory
+chrome.storage.local.set(...)        bundle-index cache, calls
+                                      reloadConfig(), re-walks
+                                      every source against the
+                                      new bundle
 ```
 
-The `--watch` flag is what makes the first column happen
-automatically. Without it, you'd run `sync chrome` manually after
-edits and the second column still wakes up within 2.5s.
+Typical propagation: **~300ms**, no polling interval involved — it's a genuine push, not a timer tick. There's also a separate **bake-time bundle** (`opencues sync chrome` + esbuild-inlined constants) used as a static fallback when the native-messaging host isn't installed; that one only refreshes when you rebuild/redeploy the extension.
+
+For the full protocol, install steps, source-resolution rules, and the storage read-priority chain (`chrome.storage.local` → bake-time bundle → esbuild-inlined defaults → null), see [`docs/features/chrome-sync.md`](chrome-sync.md).
 
 ---
 
-## The `.version` file
+## Why the old poll-based design was replaced
 
-`dist/configs/.version` holds a 16-char hex hash plus a trailing
-newline. It's computed by `computeVersion()` in
-`packages/opencues-cli/src/commands/sync.cjs`:
-
-```js
-// Hash of every relPath + content. Stable across machines so a no-op
-// sync (re-run with same inputs) doesn't bump the version and trigger
-// pointless reloads in the extension.
-const h = crypto.createHash('sha256');
-// ... walk distConfigs, sort files by relpath, skip .version itself ...
-for (const f of files) {
-  h.update(path.relative(rootDir, f));
-  h.update('\0');
-  h.update(fs.readFileSync(f));
-}
-return h.digest('hex').slice(0, 16) + '\n';
-```
-
-Two important properties:
-
-- **Content-addressable.** Two syncs with identical inputs produce the
-  same hash. A no-op `sync chrome` doesn't trigger a reload.
-- **Round-trippable.** Edit a file, sync (hash flips), revert the
-  edit, sync again — the hash returns to its original value. The
-  in-page poller treats that as a normal change and re-loads.
-
-The hash deliberately excludes `.version` itself so the file isn't
-self-referential.
+The retired design (below) worked, but had two real costs the current push model doesn't: up to ~2.5s latency between a save and the reload firing, and a requirement to keep a `sync chrome --watch` terminal process running. The native-messaging host removes both — it's a genuine push, and it's a background-installed service rather than something you have to remember to run.
 
 ---
 
-## The poll loop (in-page)
+## Retired: the `.version`-poll design (pre-May-2026, removed)
 
-Lives in `integrations/chrome/src/opencues-bootstrap.ts` ~line 510:
+This section is preserved for historical context only — **none of the code below exists anymore.**
 
-```ts
-const VERSION_POLL_MS = 2500;
-let _lastKnownVersion: string | null = null;
+Before May 2026, Chrome had no live-push channel, so the extension polled a content-addressable hash file instead:
 
-function startVersionPoll(bootResult: BootResult): void {
-  const tick = async () => {
-    try {
-      const url = chrome.runtime.getURL('dist/configs/.version');
-      const res = await fetch(url, { cache: 'no-store' });
-      if (!res.ok) return;
-      const version = (await res.text()).trim();
-      if (_lastKnownVersion === null) {
-        _lastKnownVersion = version;
-        return;
-      }
-      if (version !== _lastKnownVersion) {
-        _lastKnownVersion = version;
-        _bundleIndexPromise = null;        // force index.json re-fetch
-        await bootResult.reloadConfig();   // re-read every source
-      }
-    } catch { /* bundle absent / offline — next tick tries again */ }
-  };
-  void tick();                       // seed _lastKnownVersion
-  setInterval(tick, VERSION_POLL_MS);
-}
-```
+- `dist/configs/.version` held a sha256 hash of every bundled file's path+content, computed by `packages/opencues-cli/src/commands/sync.cjs`'s `computeVersion()`.
+- The in-page bootstrap (`integrations/chrome/src/opencues-bootstrap.ts`) ran `startVersionPoll()` — a `setInterval` fetching `dist/configs/.version` every `VERSION_POLL_MS` (2500ms) and calling `reloadConfig()` when the hash changed.
+- `opencues sync chrome --watch` ran an `fs.watch`-based CLI daemon that re-synced the bundle (and bumped `.version`) on any source-dir change, with a 250ms debounce.
 
-Key behaviours:
-
-- **First tick seeds** `_lastKnownVersion` and does NOT trigger a
-  reload — otherwise every page load would gratuitously re-read.
-- **`cache: 'no-store'`** bypasses the HTTP cache (the extension URL
-  scheme would otherwise serve a 200-OK from disk cache forever).
-- **Index-cache invalidation.** The runtime caches `index.json`
-  (the manifest of which files exist in the bundle); on version
-  change, the cache is dropped before `reloadConfig` runs so newly
-  added files are picked up.
-- **Catch-and-continue.** Network errors (extension reloading, file
-  briefly missing during atomic rewrite) just skip that tick.
-
----
-
-## The watcher (CLI side, `--watch`)
-
-`packages/opencues-cli/src/commands/sync.cjs` ~line 79:
-
-```js
-const DEBOUNCE_MS = 250;
-const w = fs.watch(s.dir, { recursive: true }, (event, filename) => {
-  if (!filename) return;
-  if (filename.includes('~') || filename.endsWith('.swp') || filename.endsWith('.tmp')) return;
-  trigger(filename);
-});
-```
-
-Watches each resolved source dir (user-level by default;
-`--include` adds more). On any non-noise change, debounces 250ms then
-re-runs the same `syncChrome` code as a one-shot run. Logs whether
-`.version` actually changed (`version <hash>` vs `no changes`).
-
-The `fs.watch({ recursive: true })` API is OS-dependent:
-
-- **macOS / Windows**: native FSEvents/ReadDirectoryChanges. Fires
-  reliably for any descendant change.
-- **Linux**: relies on inotify, which has a per-process watch limit.
-  For large source dirs, you may need to bump
-  `/proc/sys/fs/inotify/max_user_watches`.
-
----
-
-## End-to-end timing
-
-| Step | Latency |
-|---|---|
-| File save → `fs.watch` event | ~immediate |
-| Watch event → debounce expiry → re-sync starts | 250ms |
-| Re-sync runtime (read sources, write bundle, mirror) | ~50–200ms |
-| Re-sync finish → next in-page poll tick | up to 2500ms |
-| Poll tick → `reloadConfig` → new tip live | ~50–100ms |
-
-**Worst case: ~3 seconds.** Typically ~1.5s. The 2.5s poll cadence is
-the dominant term — if you need it tighter, drop `VERSION_POLL_MS`
-in the bootstrap (cost: more `chrome.runtime.getURL` fetches per
-tab per minute, all served locally so cheap).
-
----
-
-## What triggers reload
-
-- Editing any file inside a source dir (`~/.cues/`, an
-  `--include`'d path, or `<cwd>/.cues/` under `--project`)
-- Adding or removing a folder cue (`cues/<name>/CUE.md`) or blank (`blanks/<name>/BLANK.md`)
-- Running `opencues sync chrome` manually (the `.version` flips even
-  outside `--watch`)
-- Calling `opencues sync chrome --pack` or `--source` to swap source
-  sets entirely
-
-## What does NOT trigger reload
-
-- Editing files outside the resolved source dirs (the watcher isn't
-  watching them; there's no leak from arbitrary cwd)
-- Editing `dist/configs/*` directly — `sync` overwrites these on next
-  run, and `.version` won't update without a sync
-- Re-running `sync chrome` with identical inputs — hash is stable
-- Editing `CUES.md` frontmatter user-level scalars (voice-mode,
-  debug-mode, etc.) — those round-trip through `chrome.storage.local`,
-  NOT the bundle. The bootstrap's storage-change listener picks them
-  up separately. See `OpenCuesSettingsBlank` for the storage path.
-
----
-
-## Code locations
-
-| Concern | File | Symbol |
-|---|---|---|
-| In-page polling | `integrations/chrome/src/opencues-bootstrap.ts` | `startVersionPoll`, `VERSION_POLL_MS` |
-| Bundle index cache | same file | `_bundleIndexPromise` |
-| Re-read on change | runtime (`@opencues/runtime`) `bootResult` | `reloadConfig` |
-| `.version` write | `packages/opencues-cli/src/commands/sync.cjs` | `computeVersion`, `syncChrome` |
-| Watch loop | same file | `syncChromeWatch` |
-| Sync sources | same file | `resolveSources` (see `chrome-sync.md` for the rules) |
-
----
-
-## Trade-offs
-
-**Polling here isn't a trade-off we *chose* — it's the only option
-Chrome gives us.** Push would be cleaner if it existed, but it
-doesn't for bundle files.
-
-### What "push" would look like (and why it doesn't exist for us)
-
-Chrome has exactly one push channel for content scripts:
-`chrome.storage.onChanged`. It fires when something writes to
-`chrome.storage.{local,sync}`. Files inside the extension's own
-package (`dist/configs/...`) have no event API — Chrome treats the
-bundle as immutable from the content script's view, even though we
-know the CLI is mutating it from outside.
-
-We *could* fake push by having the CLI write the version to
-`chrome.storage.local` instead of a file. Two problems:
-
-1. **The CLI runs outside Chrome.** It has no `chrome.storage` API.
-   We'd need a bridge (native messaging host, or a popup the CLI
-   talks to). That's a real piece of infrastructure for a marginal
-   gain.
-2. **The bundle stops being self-describing.** Right now
-   `dist/configs/.version` lives next to the data it describes —
-   atomically synced together, no possibility of drift. If the
-   version moves to storage, you can have storage saying "v3" while
-   the bundle on disk is still v2.
-
-`chrome.runtime.requestUpdateCheck` is also not it — that API only
-checks for *extension updates from the Chrome Web Store*, not for
-changes to packaged files mid-session.
-
-### Costs of polling (as actually experienced)
-
-| Cost | Magnitude | Notes |
-|---|---|---|
-| **Latency** | up to 2500ms between sync finishing and reload firing | Dominant cost. Tunable via `VERSION_POLL_MS`. |
-| **Idle CPU/IO** | 1 fetch per tab per 2.5s, served from local disk | Negligible — `.version` is 17 bytes. 100 tabs ≈ 40 fetches/sec, all in-process. |
-| **Battery** | tiny | Same reason — local disk, no network, no parsing on unchanged hash. |
-| **No back-pressure** | can't dynamically slow under load | Doesn't matter at this volume. |
-| **Wasted reloads on round-trip** | edit → sync → revert → sync = bundle reloaded twice for net-zero change | Cheap (just re-parses configs). Acceptable. |
-
-### Counterfactual: if push were available
-
-| Pro / Con | Notes |
-|---|---|
-| 0ms latency | the genuine win |
-| No idle traffic | also genuine, but baseline is already negligible |
-| One more API surface to keep healthy | native messaging hosts can break silently across Chrome updates |
-| Bridges between CLI and extension | adds installer complexity, a new failure mode for users |
-| Bundle no longer self-describing | version-in-storage can drift from files-on-disk |
-
-**Verdict.** Even if push were available natively (it isn't), polling
-is the right call here. The only real cost is the 2.5s latency, fine
-for a dev-iteration workflow. If we ever hit a use case that needed
-sub-second propagation we'd have to do real work to get it.
-
-### Why 2.5s and not 500ms?
-
-Every open tab polls independently. With 20 tabs open: 500ms ≈ 40
-fetches/sec; 2.5s ≈ 8 fetches/sec. All served from local disk so
-the absolute cost is small either way, but the cadence was tuned for
-"feels live during dev" not "feels instantaneous in production." Drop
-the constant if you find yourself wishing edits propagated faster.
+Worst-case latency was cited at ~3 seconds, typically ~1.5s, dominated by the 2.5s poll cadence. `startVersionPoll`, `VERSION_POLL_MS`, and the `--watch` daemon are all gone from the current source — grepping for any of them in `integrations/chrome/src/` or `packages/opencues-cli/src/commands/sync.cjs` returns nothing.
 
 ---
 
@@ -283,25 +62,11 @@ the constant if you find yourself wishing edits propagated faster.
 
 ### Standard (opencues-core / opencues-runtime)
 
-- `BootResult.reloadConfig` is host-agnostic — every adapter exposes
-  the same handle for triggering a re-read of all sources.
-- The runtime doesn't know or care what triggered the reload.
+- `BootResult.reloadConfig` is host-agnostic — every adapter exposes the same handle for triggering a re-read of all sources.
+- The runtime doesn't know or care what triggered the reload — filesystem watch, storage push, or (for a hypothetical future host) something else entirely.
 
 ### Integration responsibilities
 
-- Decide *when* to call `reloadConfig` based on whatever observable
-  channel the host gives you (filesystem polling for native, content-
-  addressable hash polling for chrome, IPC events for hypothetical
-  future hosts).
-- Avoid hammering `reloadConfig` — debounce or rate-limit at the
-  trigger layer; the runtime treats every call as a full re-parse.
-- Invalidate any host-specific caches (e.g. chrome's `index.json`
-  promise) before calling `reloadConfig`.
-
----
-
-## Verification
-
-End-to-end: edit `~/.cues/CUES.md`, observe `.version` flip, observe
-Chrome pick up the change without page refresh, revert the edit,
-observe `.version` round-trip back to its original hash.
+- Decide *when* to call `reloadConfig` based on whatever observable channel the host gives you (filesystem polling for native hosts, `chrome.storage.onChanged` for chrome).
+- Avoid hammering `reloadConfig` — debounce or rate-limit at the trigger layer; the runtime treats every call as a full re-parse.
+- Invalidate any host-specific caches (e.g. chrome's bundle-index promise) before calling `reloadConfig`.

--- a/docs/features/claude-cli-provider.md
+++ b/docs/features/claude-cli-provider.md
@@ -42,13 +42,14 @@ agent-rewrite-model: haiku                          # latest Haiku (auto-tracks 
 agent-rewrite-model: claude-haiku-4-5-20251001      # pinned to one version
 agent-rewrite-model: claude-sonnet-4-6              # pinned Sonnet
 agent-rewrite-model: claude-opus-4-7                # pinned Opus
+agent-rewrite-model: claude-fable-5                 # pinned Fable
 ```
 
-Use an **alias** (`haiku` / `sonnet` / `opus`) when you want the latest
-release of a family automatically. Use a **full name** when you want
-reproducibility (your config keeps the same model even when Anthropic
-ships a new generation — useful if you're benchmarking or want to lock
-in a tested setup).
+Use an **alias** (`haiku` / `sonnet` / `opus` / `fable`) when you want
+the latest release of a family automatically. Use a **full name** when
+you want reproducibility (your config keeps the same model even when
+Anthropic ships a new generation — useful if you're benchmarking or
+want to lock in a tested setup).
 
 Either form picks the right latency-tuning automatically. The daemon
 maps both `haiku` and `claude-haiku-*-*` to the same flag set internally.
@@ -62,6 +63,7 @@ We measured the per-model wall-clock latency through `claude -p`:
 | haiku  | 840ms  | 874ms  | transform-blank, fluid-blank, agent-rewrite |
 | sonnet | 1338ms | 1445ms | fluid-blank (borderline), agent-rewrite |
 | opus   | 1982ms | 2900ms | agent-rewrite (when quality matters), transform-blank |
+| fable  | *(not yet benched)* | *(not yet benched)* | pre-bench tuning mirrors opus |
 
 **Word-cues are not supported** via `claude-cli` — they need sub-500ms
 response and even Haiku via the CLI is over budget. Leave word-cues on

--- a/docs/features/cue-blanks.md
+++ b/docs/features/cue-blanks.md
@@ -12,17 +12,19 @@ There are five flavours:
 - **List blanks** — BLANK.md has `stepValues: ["I am brave", "I am strong", …]`. No script; the runtime cycles through the list. Multi-word values are span-tracked.
 - **Dynamic list blanks** — `blankInvoke get` returns multiple lines, each becoming a cycling alternative (e.g., HN front-page titles).
 - **Read-only blanks** — a plain `blankScript:`/`impl:` blank with no `blankStep`/`stepValues`/`blankSatellite` fetches data once and is non-cycleable by default (e.g., stock prices via Finnhub). A multi-line `get` still rotates its results via the alternatives stash.
+- **Selector + satellite blanks** — `blankSatellite: true` auto-populates as TWO linked words (e.g. `opencues settings _` → `voice-mode active`); see [Selector + Satellite](selector-satellite.md) for the dedicated mechanics.
 
-Cue-blanks are checked **first** in the cycling function (`_cycleAlt`) before any alternative or linked-word cycling.
+Cue-blanks are checked at **priority 1-2** in `Cycling.step()`'s dispatch chain (see [Word Cycling](cycling.md)) — after selector/satellite and span-fill, but before plain static-alternative cycling.
 
 ---
 
 ## How It Works
 
 1. **Detection** — at analysis time, every `_` is matched against the registered cue-blanks. If a blank's shape (or synthesized keyword shape) matches the sentence containing `_` — the command leading its sentence, `_` at the trailing edge — the `_` is bound to that blank.
-2. **Auto-populate** — `blankInvoke({ blankName, action: 'get', args: [keyword, ...context] })` returns the current value; the `_` is replaced with that value, and `metadata.blankName` is set on the resulting WordDef.
-3. **On cycle (Up/Down)** — the cycling function checks the bound blank and calls `up` / `down` (or `set` for selector/satellite) via `blankInvoke`. The class implementation (or `blankScript`) updates external state and returns the new display value.
-4. **Debounced spawn** — for shell-script blanks, rapid key presses only trigger one subprocess per ~50ms; the timer fires with the final accumulated value.
+2. **Auto-populate** — `blankInvoke({ blankName, action: 'get', args: [keyword, ...context] })` returns the current value; the `_` is replaced with that value, and `metadata.blankName` is set on the resulting `DynDef`.
+3. **On cycle (Up/Down)** — `Cycling.step()` checks the bound blank and calls `up` / `down` (or `set` for selector/satellite) via `blankInvoke`. The class implementation (or `blankScript`) updates external state and returns the new display value.
+
+Each keypress spawns/invokes immediately — there's no debounce or coalescing of rapid up/down presses today (an unimplemented proposal for one exists in the CC adapter's REPAIR.md, but no current code path does it).
 
 ---
 
@@ -144,7 +146,7 @@ bash {blankScript} {action} {args...}
 
 **Spawn behavior:**
 - **`get` is synchronous** — the runtime awaits stdout to populate the blank
-- **`up` / `down` / `set` are detached fire-and-forget** for OS-state changes; debounced to one spawn per ~50ms
+- **`up` / `down` / `set` are detached fire-and-forget** for OS-state changes — each keypress spawns immediately, with no debounce/coalescing today
 - **Path resolution** — `~` is expanded to `$HOME`. Folder-based blanks use `./{name}-blank.sh` relative to the BLANK.md
 - **WSL** — scripts run in the Linux environment. To talk to Windows applications, use `powershell.exe` or compiled `.exe` helpers inside the script
 

--- a/docs/features/cursor-preservation.md
+++ b/docs/features/cursor-preservation.md
@@ -1,45 +1,49 @@
 ---
-last_updated: 2026-04-06
+last_updated: 2026-07-04
 ---
 
 # Cursor Position Preservation
 
-When a word changes length during cycling, the cursor position must adjust so the user's editing position does not jump. The system calculates a length delta and applies it conditionally based on where the replacement occurs relative to the cursor.
+When a word changes length during cycling, the cursor position must adjust so the user's editing position does not jump. Every cycling path (`Cycling` module, `packages/opencues-runtime/src/modules/cycling.ts`) computes the replacement's exact character range from the live buffer, then applies the same three-way cursor rule.
 
 ---
 
 ## How It Works
 
-1. **When cycling or incrementing**, the code locates the highlighted word's start position (`_wStart`) by walking the word array and calling `text.indexOf(word, wordPos)` for each word up to the target index
-2. **The old word is spliced out** and the new word is spliced in: `text.slice(0, _wStart) + newWord + text.slice(_wEnd)`
-3. **The cursor offset is adjusted** based on the replacement position relative to the current offset
-4. **A new `InputZone`** is created via `InputZone.fromText(newText, config, newOffset)`, which triggers React's re-render with both the updated text and the corrected cursor position
+1. **Compute the replacement range** from the live word positions (`splitWords(event.text)`), not from a cached span — spans on a `DynDef` can drift across multi-word cycles, so recomputing from the live buffer every time is the single source of truth.
+2. **Splice**: `before = text.slice(0, rangeStart)`, `after = text.slice(rangeEnd)`, `newText = before + nextWord + after`.
+3. **Adjust the cursor** per the three-way rule below.
+4. **Commit**: `adapter.setText(newText)` then `adapter.setCursorOffset(clampedCursor)` — the host applies both.
 
 ---
 
 ## Offset Calculation
 
-The offset logic is a single conditional:
+Every cycling path (list-blank, blank-step, static-alts) uses the same three-way conditional, not a two-way one:
 
-```
-var _lenDiff = _newWord.length - _word.length;
-var _newOffset = _wStart < inputZone.offset
-    ? inputZone.offset + _lenDiff
-    : inputZone.offset;
+```ts
+const lenDiff = nextWord.length - (rangeEnd - rangeStart);
+const newCursor = cursorOffset <= rangeStart
+  ? cursorOffset                        // cursor before the word: unchanged
+  : cursorOffset >= rangeEnd
+    ? cursorOffset + lenDiff             // cursor after the word: shifts by the delta
+    : rangeStart + nextWord.length;      // cursor INSIDE the word: snaps to its new end
+const clampedCursor = Math.max(0, Math.min(newCursor, newText.length));
 ```
 
 | Condition | Result |
 |-----------|--------|
-| Replacement is **before** the cursor (`_wStart < offset`) | Offset shifts by `_lenDiff` (positive if word grew, negative if it shrank) |
-| Replacement is **at or after** the cursor (`_wStart >= offset`) | Offset unchanged |
+| Cursor **before** the replaced range (`cursor <= rangeStart`) | Unchanged |
+| Cursor **after** the replaced range (`cursor >= rangeEnd`) | Shifts by `lenDiff` (positive if the word grew, negative if it shrank) |
+| Cursor **inside** the replaced range | Snaps to the end of the new word — there's no meaningful "same relative position" once the old word is gone |
 
-This handles all cases:
-- **Step increment** (e.g., "9" -> "10"): `_lenDiff = 1`, cursor moves right by 1 if it was after the word
-- **Alt cycling** (e.g., "dog" -> "puppy"): `_lenDiff = 2`, cursor moves right by 2 if it was after the word
-- **Shorter replacement** (e.g., "puppy" -> "cat"): `_lenDiff = -2`, cursor moves left by 2 if it was after the word
-- **Cursor at end of text**: The cursor is always after the replacement, so it tracks correctly as text grows or shrinks
+This covers:
+- **Step increment** (e.g., "9" → "10"): `lenDiff = 1`.
+- **Alt cycling** (e.g., "dog" → "puppy"): `lenDiff = 2`.
+- **Shorter replacement** (e.g., "puppy" → "cat"): `lenDiff = -2`.
+- **Cursor at end of text**: always past `rangeEnd`, so it tracks correctly as text grows or shrinks.
 
-The same logic applies in both the Up (increment/next-alt) and Down (decrement/prev-alt) key handlers, using identical `_lenDiff` / `_newOffset` / `fromText` patterns.
+Every downstream span-bound `DynDef` (e.g. a later sentence-cue in a multi-paragraph buffer) also gets its cached char offsets shifted by `lenDiff` when the splice happens (`DynDefs.shiftCharSpansAfter`) — without this, a def that starts after the replaced range would point at stale characters and mis-splice on its own next cycle.
 
 ---
 
@@ -53,7 +57,7 @@ The same logic applies in both the Up (increment/next-alt) and Down (decrement/p
 
 ### Integration responsibilities
 
-- When text changes (cycling, auto-populate, span replacement), calculate the new cursor offset based on the insertion/deletion position and the length delta
-- Handle the "cursor at end" special case so the cursor tracks the growing text
+- Supply `setText` + `setCursorOffset` on the `HostAdapter` — the shared runtime's `Cycling` module computes the offset and calls both
+- If implementing cycling outside the shared runtime, recompute the replacement range from the LIVE buffer on every cycle (not a cached span) and apply the three-way cursor rule above
 - Adjust for multi-word span replacements where a single word expands to multiple words or vice versa
 - Ensure cursor repositioning happens atomically with the text replacement to avoid visual flicker

--- a/docs/features/cycling.md
+++ b/docs/features/cycling.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-04-29
+last_updated: 2026-07-04
 ---
 
 # Word Cycling
@@ -10,28 +10,38 @@ Word cycling replaces the focused word with an alternative. It is the **vertical
 
 ## How It Works
 
-1. **Press** Ctrl+Alt+Up or Ctrl+Alt+Down while a word is highlighted
-2. **Priority check**: The `_cycleAlt` function evaluates the highlighted word against a three-level priority chain (see Cycling Priority below). The first level that matches handles the press; the rest are skipped.
-3. **Text replacement**: The matched handler computes a new word, splices it into `globalThis._hlText` at the correct character offset, and returns `{text, lenDiff, wStart, newLen}` so the input zone can reposition the cursor.
-4. **State update**: `globalThis._hlState.text` is updated to match the new text. For alternative cycling, the highlight export JSON is written to `/tmp/opencues-status-<pid>.json` for the status line.
+Implemented by the `Cycling` module (`packages/opencues-runtime/src/modules/cycling.ts`).
+
+1. **Press** Ctrl+Alt+Up or Ctrl+Alt+Down while a word is highlighted (`HighlightState.active`).
+2. **Priority check**: `Cycling.step()` evaluates the highlighted word against a **five-level priority chain** (see Cycling Priority below), highest first. The first level that applies handles the press; the rest are skipped.
+3. **Text replacement**: the matched handler computes the new text and calls the host's `setText`, which repositions the cursor per the length delta.
+4. **State update**: the relevant state object (`DynDefs`, `SpanFillState`, `SelectorSatelliteState`, or a plain `WordDef` in `DynDefs`) is updated to reflect the new position/value. `HighlightState`'s `onChange` subscribers (notably Statusline) react synchronously the same tick.
 
 ---
 
 ## Cycling Priority
 
-The levels are checked in order. The first match wins.
+Checked in this order — the first match wins:
 
-### 1. Cue-blanks (auto-populated `_`)
+### -1. Selector + satellite
 
-**Condition**: The word's `_dynDefs` entry has `metadata.blankName` set — a position auto-populated from a blank bound via `blankKeywords`.
+**Condition**: a `SelectorSatelliteState.current` entry exists and the highlighted word falls on either half of the pair.
 
-Modes:
+The "opencues settings" pattern: highlighting the selector half cycles setting names; highlighting the satellite half cycles that setting's value. Both write back through the blank's script/class via `blankInvoke`.
 
-- **Script-based** (default): `blankInvoke('<name>', { action: 'up'|'down' })` runs synchronously, then `blankInvoke('<name>', { action: 'get' })` returns the new live value. `blankStep` sets the step size; `blankSuffix` the display unit.
-- **List-based** (`stepValues`): The blank auto-populates with the first value and Up/Down cycles through the list. Multi-word values are span-tracked automatically. No script is needed.
-- **Dynamic list** (multi-line `get` output): Each line becomes a cycling alternative — same behaviour as `stepValues` but populated from live data (e.g., RSS feeds, API results).
+### 0. Span fill
 
-All list-based blanks (static `stepValues`, dynamic multi-line) support `blankDismissible: true` — appends `_` as the last cycling option so the user can dismiss the value. Dismissed positions are tracked to prevent auto-populate from re-firing.
+**Condition**: `SpanFillState.current` is set and the highlight falls within it.
+
+Takes precedence over list/static cycling when the highlight sits inside a consume-all span (e.g. an agent-improved prompt) or a multi-word `stepValues` span (e.g. affirmations spanning several words) — cycles through the stashed alts for that span.
+
+### 1. List blank (`stepValues`)
+
+**Condition**: the highlighted word resolves to a blank whose config declares `stepValues`.
+
+The blank auto-populates with the first value; Up/Down rotates through the list in place. Multi-word values are span-tracked automatically. No script is needed.
+
+All list-based blanks support `blankDismissible: true` — appends `_` as the last cycling option so the user can dismiss the value.
 
 Example list blank (`defaults/blanks/affirmations/BLANK.md`):
 ```yaml
@@ -46,38 +56,19 @@ blankDismissible: true
 ```
 Type `affirmation _` → blank auto-populates with "I am strong", Up/Down cycles through the list. Cycle past the last value → `_` to dismiss.
 
-### 2. Consume-all cycling
+### 2. Blank-fill DynDef (`blankStep`)
 
-**Condition**: `globalThis._consumeAllAlts` exists AND the current word (resolved via span) matches `_consumeAllAlts.index`.
+**Condition**: the highlighted word has a `DynDef` with `blankName` set (an auto-populated value from a keyword-bound blank), and that blank declares `blankStep`.
 
-Used by multi-line blanks (e.g. `hn _` returning many story titles) whose multi-word result is cycled as a span. Uses dedicated storage independent of `_dynDefs` because the standard WordDef array is overwritten by tips/grammar analysis. Span-aware: replaces the full span, updates `_dynSpans`, and prevents re-analysis by updating `_dynLastAnalyzed`/`_dynPrevWords`. Supports `blankDismissible` (cycling to `_` tracks dismissal).
+`blankInvoke('<name>', { action: 'up'|'down' })` runs (script, in-process class, or dynamic multi-line `get` output — same handling either way), and the resulting live value replaces the word. `blankStep` sets the step size; `blankSuffix` the display unit.
 
-### 3. Alternative cycling
+### 3. Static alternatives
 
-**Condition**: A `_dWord` entry exists in `globalThis._dynDefs.words` with `alts.length > 1`. If no entry exists but the word is in `globalThis._localCueMap` (tip-lookup fallback), a `_tipDef` is created on the fly and pushed into `_dynDefs.words`.
+**Condition**: none of the above matched, and the word has (or can be built into) a `DynDef` with more than one alternative — an LLM word-cue, or a fallback tip-only def built on the fly from cueMap.
 
-- `currentAltIndex` tracks position in the alts array. `alts[0]` is always the original word.
-- Next index: `(currentAltIndex + dir + alts.length) % alts.length` — wraps in both directions.
-- **Span-aware replacement**: If the word is part of a multi-word span (tracked in `globalThis._dynSpans`), the replacement splices across all span positions. After replacement, `_dynSpans` is updated: multi-word results register entries for each sub-word; single-word results clear the span entries.
-- **TTS**: If `_dWord.speak` is true, the alt's tip is spoken via `SpeakCtl.exe` or `speak.sh` after an 80 ms debounce.
-- **Underscore re-analysis**: If `_` appears in the updated text and the surrounding context changed, a fresh LLM analysis is queued.
-
----
-
-## Linked Word Cycling
-
-When a word definition has a `linked` array (indices of co-dependent words), cycling one word simultaneously updates all linked words to the same `currentAltIndex`.
-
-The linked-word update loop:
-
-1. Compute `_nextAlt` for the primary word
-2. For each index in `_dWord.linked`:
-   - Find the linked word's definition in `_dWords`
-   - If it has an alt at `_nextAlt`, set `_lDef.currentAltIndex = _nextAlt` and replace its text in the already-modified `_newText`
-   - Track replacements in `_updW` (a map of index to new word) so subsequent linked replacements use correct character offsets
-3. All replacements happen in a single pass before `_hlText` is finalized
-
-Linked groups are resolved and merged across sources by `CueResolver` in opencues-core. The integration only needs to apply the indices it receives.
+- `currentAltIndex` tracks position in the alternatives array (`alts[0]` is always the original word).
+- Cycling wraps in both directions: `(currentAltIndex + direction + alts.length) % alts.length`.
+- **Multi-word spans**: if the highlighted index is an inner position of an existing span, cycling redirects to the span's origin instead, so the whole span rotates as one unit.
 
 ---
 
@@ -86,15 +77,11 @@ Linked groups are resolved and merged across sources by `CueResolver` in opencue
 ### Standard (opencues-core)
 
 - `CueResult.alternatives` array provides the ordered list of replacements (`alts[0]` is always the original word)
-- `CueResult.linked` array contains indices of co-dependent words that must cycle together
-- Priority order is defined by the standard: cue-blanks > consume-all > alternative cycling
 - `CueResult.metadata.blankName` identifies blank-bound words
-- Linked-word groups are resolved and merged across sources by the resolver
+- opencues-core does not define the cycling priority order itself — that's a runtime-layer decision (`Cycling.step()`'s five-level chain above)
 
 ### Integration responsibilities
 
-- Perform the actual text replacement in the editor buffer when the user cycles
-- Maintain `currentAltIndex` per word and handle wrap-around (`alts.length`)
-- Implement `blankInvoke` for cue-blank cycling (registry lookup → spawnProcess fallback)
-- When cycling a linked word, update ALL linked words' `currentAltIndex` and replace their text simultaneously
-- Map Up/Down (or equivalent) input events to cycle direction
+- Supply a `HostAdapter` (`setText`, `onKey`, `blankInvoke`) — `Cycling` does the rest in the shared runtime
+- Render the updated text and reposition the cursor per the length delta the setText call implies
+- Map Up/Down (or equivalent) input events, with the configured `nav-keymap` modifier combo, to `Cycling.step(event, direction)`

--- a/docs/features/deterministic-relocate.md
+++ b/docs/features/deterministic-relocate.md
@@ -143,11 +143,11 @@ Three phases makes both impossible by construction.
 
 ## Code reference
 
-- `packages/opencues-runtime/src/state/dyn-defs.ts:120` —
+- `packages/opencues-runtime/src/state/dyn-defs.ts:222` —
   `pruneStale` (the three-phase algorithm)
-- `packages/opencues-runtime/src/state/dyn-defs.ts:173` —
+- `packages/opencues-runtime/src/state/dyn-defs.ts:275` —
   `_defMatchesAt` (the matching predicate)
-- `packages/opencues-runtime/src/state/dyn-defs.ts:191` —
+- `packages/opencues-runtime/src/state/dyn-defs.ts:292` —
   `_findUniqueMatch` (the disambiguator)
 - Scenario tests: `cycling.scenarios.test.ts` covers
   - relocate single-word, single-cycle through prefix edit

--- a/docs/features/host-compat.md
+++ b/docs/features/host-compat.md
@@ -156,27 +156,6 @@ The OpenStandard's design principle: **default to working, declare exceptions, v
 
 ---
 
-## Practitioner notes (from CLAUDE.md, May 2026)
-
-### Default-attempt model
-
-Every cue / blank has an implicit (or explicit) host-compat list: which of `{chrome, claude-code, gemini-cli, opencode}` it works on. Native hosts (CC, OC, gemini-cli) can spawn subprocesses + read the filesystem natively. Chrome can do both — config sync via the chrome-host's filesystem watch, subprocess via the chrome-host's `exec` protocol — but only when `opencues install chrome-host` has been run. Without the host, chrome is sandboxed and scripted blanks fail with exit 127.
-
-Default: every cue / blank advertises as compatible with every host. The runtime attempts the call; if the host can't fulfil it (e.g. chrome without chrome-host trying to spawn `.sh`), it fails at runtime (exit 127) rather than being hidden behind a misleading "incompatible host" marker.
-
-Historical note: `inferHostCompat` used to auto-exclude chrome for entries with `script: ./X.sh` / `.py` / etc., on the assumption chrome couldn't run subprocesses. With chrome-host (May 2026 native-messaging bridge) chrome CAN run POSIX scripts via the host process, so the heuristic became actively wrong. Removed in favour of explicit overrides.
-
-### Override frontmatter
-
-```yaml
-on-host: [claude-code, opencode, gemini-cli]   # allow-list (chrome would fail)
-not-on-host: [chrome]                          # equivalent deny-list
-```
-
-Resolution: `on-host` (if set) is the allow-list; `not-on-host` removes denials from whichever set was chosen. Surfaced by `opencues list` (per-entry marker, hidden when "all"), validated by `opencues validate` (typos + contradictions).
-
-API: `@opencues/core`'s `inferHostCompat()`, `formatHostList()`, `unknownHostNames()`, `HOSTS`, `NATIVE_HOSTS`.
-
 ## Site scoping (chrome) — `on-site` / `not-on-site`
 
 `on-site` is the strictly-broader sibling of `on-host`. Each entry can be:

--- a/docs/features/host-compat.md
+++ b/docs/features/host-compat.md
@@ -102,7 +102,7 @@ not-on-host: chrome, opencode
 ---
 ```
 
-Valid host names: **`chrome`**, **`claude-code`**, **`gemini-cli`**, **`opencode`**, **`terminal`**.
+Valid host names: **`chrome`**, **`claude-code`**, **`gemini-cli`**, **`opencode`**, **`shell`** (alias `terminal` kept for back-compat in `on-host:`/`not-on-host:` directives).
 
 Unknown names are silently dropped at runtime; `opencues validate` prints
 warnings about them so typos are caught.
@@ -117,30 +117,30 @@ warnings about them so typos are caught.
 import { inferHostCompat, formatHostList, HOSTS, NATIVE_HOSTS } from '@opencues/core';
 
 inferHostCompat({});
-// → { hosts: ['chrome', 'claude-code', 'gemini-cli', 'opencode'], all: true, source: 'auto' }
+// → { hosts: ['chrome', 'claude-code', 'gemini-cli', 'opencode', 'shell'], all: true, source: 'auto' }
 
 inferHostCompat({ 'on-host': ['chrome'] });
 // → { hosts: ['chrome'], all: false, source: 'on-host' }
 
 inferHostCompat({ 'not-on-host': ['chrome'] });
-// → { hosts: ['claude-code', 'gemini-cli', 'opencode'], all: false, source: 'not-on-host' }
+// → { hosts: ['claude-code', 'gemini-cli', 'opencode', 'shell'], all: false, source: 'not-on-host' }
 
-formatHostList(['claude-code', 'gemini-cli', 'opencode']);
-// → 'claude-code, gemini-cli, opencode'
-formatHostList(['chrome', 'claude-code', 'gemini-cli', 'opencode']);
+formatHostList(['claude-code', 'gemini-cli', 'opencode', 'shell']);
+// → 'claude-code, gemini-cli, opencode, shell'
+formatHostList(['chrome', 'claude-code', 'gemini-cli', 'opencode', 'shell']);
 // → 'all'
 ```
 
 | Constant | Value |
 |---|---|
-| `HOSTS` | `['chrome', 'claude-code', 'gemini-cli', 'opencode']` |
-| `NATIVE_HOSTS` | `['claude-code', 'gemini-cli', 'opencode']` — hosts that have subprocess + filesystem capability unconditionally (no auxiliary helper needed) |
+| `HOSTS` | `['chrome', 'claude-code', 'gemini-cli', 'opencode', 'shell']` |
+| `NATIVE_HOSTS` | `['claude-code', 'gemini-cli', 'opencode', 'shell']` — hosts that have subprocess + filesystem capability unconditionally (no auxiliary helper needed) |
 
 | Function | Returns |
 |---|---|
 | `inferHostCompat(input)` | `{ hosts, all, source }` — `source` is `'auto'` / `'on-host'` / `'not-on-host'` |
 | `unknownHostNames(value)` | `string[]` of host names that aren't in `HOSTS` (validator helper) |
-| `formatHostList(hosts)` | Human display: `"all"` or `"claude-code, gemini-cli, opencode"` |
+| `formatHostList(hosts)` | Human display: `"all"` or the comma-joined host list |
 
 ---
 

--- a/docs/features/identity-context.md
+++ b/docs/features/identity-context.md
@@ -4,8 +4,13 @@ Stop typing your name, email, work city, and other personal facts
 into every form. Tell OpenCues once via `~/.cues/IDENTITY.md`; from then
 on the `_` blank uses your real data when it's relevant.
 
-**Off by default.** Opt in via `identity-context-mode: safe` in
-`~/.cues/OPENCUES.md`. Phase 1 wires fluid-blank only.
+**`safe` by default** (`identity-context-mode: safe` in
+`~/.cues/OPENCUES.md`) — tokens-only catalog reaches the LLM, values
+substitute post-response, PII stays on the host. Set `off` to disable
+entirely (IDENTITY.md never read). `raw` mode (values inlined into the
+prompt) is implementation-complete but deliberately not exposed in the
+`opencues config` menu — a deliberate file edit only. Phase 1 wires
+fluid-blank only.
 
 > **Naming note (June 2026 rename).** Identity context was previously
 > called "sentinels"; the file used to be `SENTINELS.md` (and earlier

--- a/docs/features/identity-context.md
+++ b/docs/features/identity-context.md
@@ -116,4 +116,4 @@ place). Re-edit any time — changes hot-reload on the next keystroke.
 - [`docs/architecture/identity-context.md`](../architecture/identity-context.md) — design + threat model
 - [`docs/architecture/ambient-context.md`](../architecture/ambient-context.md) — the related feature
 - [`docs/features/blank-as-context.md`](blank-as-context.md) — the sibling feature for ambient blank tokens
-- [`tests/benchmarks/sentinels/FINDINGS.md`](../../tests/benchmarks/sentinels/FINDINGS.md) — bench evidence that shaped the design
+- [`tests/benchmarks/user-context/FINDINGS.md`](../../tests/benchmarks/user-context/FINDINGS.md) — bench evidence that shaped the design

--- a/docs/features/linked-words.md
+++ b/docs/features/linked-words.md
@@ -1,67 +1,39 @@
 ---
-last_updated: 2026-04-06
+last_updated: 2026-07-04
 ---
 
 # Linked Words
 
-Linked words are words that must change together when any one of them cycles. When the user cycles "boy" to "girl", the pronoun "his" simultaneously becomes "her". The LLM detects these semantic relationships and returns them as index arrays on each word definition.
+> ⚠️ **Not implemented in the current runtime.** This page describes a
+> feature that existed in the pre-refactor Claude Code patch (the
+> `globalThis`-based `_cycleAlt`/`_dynDefs` system) and has NOT been
+> carried over to `@opencues/runtime`'s modular `Cycling`/`DynDefs`
+> system. Read this as a design record / possible-future-work
+> reference, not as current behavior.
+
+Linked words are words that must change together when any one of them cycles. When the user cycles "boy" to "girl", the pronoun "his" would simultaneously become "her". The idea was for an LLM prompt to detect these semantic relationships and return them as index arrays on each word definition.
 
 ---
 
-## How It Works
+## Current status
 
-1. **LLM detection**: The linked words prompt analyses the input and returns `linked` index arrays on each `CueResult` — e.g., word 0 ("boy") gets `linked: [3]` and word 3 ("his") gets `linked: [0]`
-2. **Storage**: `linked` arrays are stored on the `WordDef` objects in `globalThis._dynDefs.words`
-3. **Cycling trigger**: When the user presses Up/Down on a highlighted word, `_cycleAlt` checks `_dWord.linked`
-4. **Propagation**: All linked words are updated to the same `currentAltIndex` and their text is replaced in a single pass
+- **`CueResult.linked?: number[]`** still exists on the type (`packages/opencues-core/src/types.ts:28`), and the resolver still merges `linked` arrays across sources when present (`resolver.ts:323-333`) — this plumbing was never removed.
+- **Nothing produces real `linked` data today.** A `prompts/linked.txt` reference file still sits in `packages/opencues-core/prompts/`, but no source class loads or dispatches it — grepping for `linked.txt`/`LINKED_PROMPT` across `opencues-core/src/` returns zero hits. `LocalCueSource` always sets `linked: null` on its own entries; it only merges the field through if some other source populates it, which none currently do.
+- **Nothing consumes `linked` in the runtime.** `packages/opencues-runtime/src/modules/cycling.ts` has zero references to `linked` — cycling a word today never propagates to any other word, co-dependent or not.
 
-Detected relationship types include:
-- **Gender agreement**: "The boy loves his dog" -- boy links to his
-- **Number agreement**: "The cats chase their toys" -- cats links to their and toys
-- **Verb agreement**: "She runs" -- she links to runs
-- **Possession**: "John loves his car" -- John links to his
+So the field is a vestige: real in the type system, inert everywhere else. If you're implementing a new integration, you can safely ignore `linked` — nothing sets it and nothing reads it.
 
 ---
 
-## CueResult Contract
+## If this gets reimplemented
 
-The `CueResult` interface in `types.ts` defines the linked field:
+The original design, for reference:
 
-```typescript
-linked?: number[];
-```
+1. An LLM prompt would analyze the input and return `linked` index arrays on each `CueResult` — e.g., word 0 ("boy") gets `linked: [3]` and word 3 ("his") gets `linked: [0]`. Relationship types envisioned: gender agreement, number agreement, verb agreement, possession.
+2. The relationship is symmetric — if word A lists B, word B lists A.
+3. When cycling a word with a non-empty `linked` array, every linked word's `currentAltIndex` would update to match, with all text replacements committed as a single atomic buffer update (never partially visible).
 
-On `WordDef` (the runtime representation), this becomes:
-
-```typescript
-linked?: number[] | null;
-```
-
-Each entry is a zero-based word index into the whitespace-split word array. The relationship is symmetric: if word A lists B in its `linked` array, word B lists A in its `linked` array. The resolver merges `linked` arrays from multiple sources.
-
-When building `WordDef` objects from `CueResult`, the integration stores `linked` directly:
-
-```javascript
-var _wdef = { index: _r.wordIndex, word: _r.word, alts: ..., linked: _r.linked || null, ... };
-```
-
----
-
-## Cycling Behaviour
-
-The linked-word cycling logic lives in `_cycleAlt` inside `@opencues/runtime`. After the primary word is cycled to `_nextAlt`:
-
-1. **Guard**: Check `_dWord.linked && _dWord.linked.length > 0`
-2. **Iterate**: For each linked index `_lIdx`:
-   - Skip if out of bounds (`_lIdx < 0 || _lIdx >= _allW.length`)
-   - Find the linked word's definition (`_lDef`) in `_dWords`
-   - Skip if the linked word has no alt at `_nextAlt` (`_lDef.alts.length <= _nextAlt`)
-3. **Update index**: Set `_lDef.currentAltIndex = _nextAlt` (same position as the primary word)
-4. **Get new text**: `_lNew = _lDef.alts[_nextAlt]`
-5. **Replace in text**: Locate `_lOld` (the current text at `_lIdx`) by scanning forward through word positions using `_updW` (a map of already-updated indices), then splice `_lNew` into `_newText`
-6. **Track**: Record `_updW[_lIdx] = _lNew` so subsequent linked replacements use correct positions
-
-All linked replacements happen in the same pass before the text is committed to `globalThis._hlText` and `globalThis._hlState.text`. The user sees a single atomic update.
+Any reimplementation would need to fit into the CURRENT architecture: DynDefs-keyed state, the `Cycling.step()` priority chain (see [Word Cycling](cycling.md)), and the shared `HostAdapter.setText` commit path — not the retired globalThis mechanism described in older revisions of this doc.
 
 ---
 
@@ -69,14 +41,10 @@ All linked replacements happen in the same pass before the text is committed to 
 
 ### Standard (opencues-core)
 
-- `CueResult.linked` array on each word contains indices of all co-dependent words
-- The resolver merges `linked` arrays from multiple sources (e.g., LLM-detected gender + number agreement)
-- Linked relationships are symmetric: if word A links to B, word B links to A
-- The linked words prompt is a standard opencues-core prompt that detects semantic relationships automatically
+- `CueResult.linked` is part of the standard's data shape and the resolver merge logic honors it if populated — but no shipped source populates it today
+- The standard does not mandate a specific detection prompt or mechanism; `linked` is meant to accept relationships from ANY source (LLM-detected or otherwise)
 
 ### Integration responsibilities
 
-- When cycling any word, check its `linked` array and update ALL linked words' `currentAltIndex` to match
-- Replace the text of every linked word simultaneously so the user sees a single coordinated change
-- Apply the highlighted visual state to all linked words when any one of them is focused
-- Ensure linked word updates are atomic: partial updates (some words changed, others not) must not be visible to the user
+- None today — no integration needs to implement linked-word propagation, since no source emits `linked` data to propagate
+- If you build a source that DOES populate `linked`, your integration is responsible for the propagation behavior described above (it isn't provided by the shared `@opencues/runtime` `Cycling` module)

--- a/docs/features/max-thinking.md
+++ b/docs/features/max-thinking.md
@@ -18,12 +18,20 @@ ever think) and a reduced **off** level:
 | Provider / model            | ceiling (`on`) | reduced (`off`) |
 |-----------------------------|----------------|-----------------|
 | Cerebras gpt-oss-120b       | medium         | low             |
-| Cerebras zai-glm-4.7        | medium         | low             |
-| Groq gpt-oss-120b / 20b     | low            | none            |
+| Cerebras zai-glm-4.7        | none           | none            |
+| Cerebras gemma-4-31b        | none           | none            |
+| Groq gpt-oss-120b / 20b     | low            | low             |
 | OpenAI gpt-5.4 / mini / nano| low            | none            |
-| OpenRouter gpt-oss          | low            | none            |
-| OpenCode Zen free pool      | low            | none            |
+| OpenRouter gpt-oss          | low            | low             |
+| OpenCode Zen free pool      | low            | low             |
 | Anthropic / Gemini          | (no reasoning — `max-thinking` has no effect) | |
+
+`zai-glm-4.7`'s reasoning knob is binary in practice (`none` cleanly
+disables it; any other value burns extra reasoning tokens regardless
+of level), so both tiers pin `none`. `gemma-4-31b` is non-reasoning
+entirely. Groq/OpenRouter/OpenCode Zen's gpt-oss models reject
+`reasoning_effort: 'none'` outright (HTTP 400) — their floor is `low`,
+not `none`.
 
 `on` is the default and reproduces the behaviour OpenCues has always
 had — each model already used its ceiling. `off` is the opt-in "go

--- a/docs/features/navigation.md
+++ b/docs/features/navigation.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-04-06
+last_updated: 2026-07-04
 ---
 
 # Word Navigation
@@ -10,24 +10,29 @@ Word navigation lets users move a highlight cursor between interactive words in 
 
 ## How It Works
 
-1. **Press** Ctrl+Alt+Left or Ctrl+Alt+Right to activate navigation and highlight a word
-2. **Filter**: The system splits the input on whitespace, then builds `_targetIdx` — an array of word indices that pass the navigation filter (see Navigation Targets below)
-3. **Index**: Words are indexed right-to-left — the rightmost navigable word is index 0. Left increments the index (moves toward the start), Right decrements it (moves toward the end)
-4. **Deactivate**: Pressing Right when already at the rightmost target, pressing Escape, or typing any character clears the highlight and resets `_hlState`
+Implemented by the `Navigation` module (`packages/opencues-runtime/src/modules/navigation.ts`), which owns a shared `HighlightState` object.
+
+1. **Press** Ctrl+Alt+Left or Ctrl+Alt+Right to activate navigation and highlight a word (modifier combo is configurable via `nav-keymap` — see [Cursor Navigate](cursor-navigate.md)).
+2. **Compute targets**: on every keystroke, `Navigation.computeTargets()` walks the whitespace-split word list and returns the indices that are navigable (see Navigation Targets below).
+3. **Walk from the right**: targets are stepped "from the right" — first activation lands on the rightmost target. Ctrl+Alt+Left moves further from the right (toward the start); Ctrl+Alt+Right moves closer to the right. Neither wraps.
+4. **Deactivate**: pressing Ctrl+Alt+Right when already at the rightmost target, or pressing Escape, clears the highlight. A plain text edit deactivates too, unless `cursor-navigate: active` is on (see below), in which case the highlight follows the cursor instead of clearing.
 
 ---
 
 ## Navigation Targets
 
-A word is navigable if it passes the navigation filter. After analysis, a word at index `i` is navigable if any of these are true:
+`computeTargets()` builds the candidate list, then layers span and selector/satellite handling on top:
 
-- **Local cue tip** (`_hasTipAlt`) — word exists in `globalThis._localCueMap` (case-insensitive lookup)
-- **Dynamic alternative** (`_hasDynAlt`) — `globalThis._dynDefs.words` has an entry at that index with either `alts.length > 1` (and the current word appears in the alts list) or `metadata.blankName` set (a cue-blank-bound auto-populated value)
-- **Span original** — the word is the original position of a multi-word span (e.g., "Jeff" in "Jeff Bezos"). Note: `_isInSpan` and `_isSpanOriginal` evaluate to the same thing in practice — both select only the original position of a span; non-original span positions like "Bezos" are skipped
+- **cueMap match** — the word (lowercased) is a key in the config loader's `navigableWords` set (built from every loaded `CUE.md`/`BLANK.md`).
+- **DynDef entry** — `DynDefs.get(wordIndex)` returns a def for that position (LLM alternatives, blank-fill substitution, selector/satellite, span fill — anything currently tracked as cycleable).
+- If **no word matches either** and cueMap is genuinely loaded (non-empty), the result is **silence** — an empty target list, not a fallback to "every word." No cue source has an opinion, so nothing is navigable.
+- If cueMap is missing/empty **and** there are no DynDefs (fresh install, or a test scaffold with no `ConfigLoader` wired), the whole word list becomes navigable so the system isn't dead out of the box.
 
-Plain words without alts and without a blank binding are NOT navigable. There is no word-cycling on plain text — all external state is `_`-gated.
+On top of that base set:
+- **Multi-word spans** — only the span's origin index is navigable; inner positions ("Bezos" in "Jeff Bezos") are dropped so a multi-word value counts as one nav stop.
+- **Selector + satellite** — both halves of an active selector/satellite pair are force-included (even if neither word is in cueMap), with their own inner positions (for multi-word settings/values) dropped the same way.
 
-The combined filter pushes index `i` into `_targetIdx` if any of the above conditions are true and the word is not a non-original span position.
+Plain words with no cue, no blank binding, and no active DynDef are NOT navigable — there is no word-cycling on plain text; all external state is `_`-gated or cue-gated.
 
 ---
 
@@ -35,30 +40,28 @@ The combined filter pushes index `i` into `_targetIdx` if any of the above condi
 
 | Key | Action |
 |-----|--------|
-| Ctrl+Alt+Left | Activate navigation (if inactive) or move highlight one target toward the start of the line |
-| Ctrl+Alt+Right | Move highlight one target toward the end of the line, or deactivate if already at the rightmost target |
+| Ctrl+Alt+Left | Activate navigation (if inactive, lands on the rightmost target) or move one target further from the right |
+| Ctrl+Alt+Right | Move one target closer to the right, or deactivate if already at the rightmost target |
 | Ctrl+Alt+Up | Cycle to next alternative (or invoke cue-blank `up` action if blank-bound) |
 | Ctrl+Alt+Down | Cycle to previous alternative (or invoke cue-blank `down` action if blank-bound) |
-| Escape | Clear highlight and reset `_hlState` |
-| Any text change | Clear highlight and reset `_hlState` (detected by comparing `_hlText !== _oldText`) |
+| Escape | Clear the highlight |
+| Any text change | Clears the highlight, UNLESS `cursor-navigate: active`, in which case the highlight follows the cursor to whichever navigable word it lands in (or clears if the cursor is in whitespace) |
 
-If `highlightWrap` is enabled in config, Left and Right wrap around using modulo arithmetic instead of deactivating at the edges.
-
-Both the Ink key-property path (`leftArrow`/`rightArrow` with `ctrl` + `meta`/`option`/`alt`) and raw escape sequences (`\x1B[1;7D` for Left, `\x1B[1;7C` for Right, modifier 7) are handled to cover different terminal emulators.
+The modifier combo (`ctrl+alt` by default) is resolved per-keystroke by `resolveNavKeymap()` and configurable via the `nav-keymap` scalar, so flipping it in `OPENCUES.md` hot-reloads without re-subscribing.
 
 ---
 
 ## Highlight State
 
-All navigation state lives in `globalThis._hlState`, an object with these fields:
+Navigation state lives in a shared `HighlightState` object (`packages/opencues-runtime/src/state/highlight-state.ts`), not a per-host global:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `active` | boolean | Whether a word is currently highlighted |
-| `index` | number \| null | Position within the `_targetIdx` array (0 = rightmost target) |
-| `wordIndex` | number \| null | Actual index into the whitespace-split word array — computed as `_targetIdx[_targetIdx.length - 1 - index]` |
-| `text` | string | Snapshot of the input text when navigation was activated |
-The state is reset to `{active:false, index:null, wordIndex:null, text:""}` on Escape, on Right past the last target, or when the input text changes.
+| `wordIndex` | number \| null | The actual word index (into the whitespace-split array) that's highlighted — not an offset into a separate target-index array |
+| `text` | string | Snapshot of the input text at the last activate/update |
+
+`HighlightState` exposes an `onChange` subscription so other modules (notably Statusline) can react synchronously the same tick a highlight activates or deactivates.
 
 ---
 
@@ -66,16 +69,13 @@ The state is reset to `{active:false, index:null, wordIndex:null, text:""}` on E
 
 ### Standard (opencues-core)
 
-- `WordDef` provides `index`, `word`, and `alts` for every word in the input
-- Navigation targets are words where `alts.length > 1` or words with `metadata.blankName` (cue-blank auto-populated values)
-- `CueResolver.analyze()` returns the full word list with classification already applied
-- No navigation state is tracked in opencues-core; it only identifies which words are navigable
+- `CueResult`/`WordDef`-equivalent data provides alternatives + metadata for every word in the input
+- Navigation targets are words with cue/DynDef coverage, per the rules above
+- The resolver returns the classified word list; navigability itself is a runtime-layer decision (`Navigation.computeTargets`), not something opencues-core computes directly
 
 ### Integration responsibilities
 
-- Map keyboard shortcuts (or mouse/touch events) to move between navigable words
-- Filter the `WordDef[]` array to determine the ordered set of navigation targets
-- Track which word is currently focused (`highlightIndex` or equivalent)
-- Move the editor cursor or viewport to the focused word's position
-- Distinguish navigation targets by type (alt word, cue-blank-bound) if the UI treats them differently
-- Communicate the focused word to the cycling and visual-cues subsystems
+- Supply a `HostAdapter` with key subscription (`onKey`), text-change (`onTextChange`), and cursor-change (`onCursorChange`) hooks — `Navigation` does the rest
+- Render the highlight at `HighlightState.wordIndex` when `active` is true
+- Move the editor cursor/viewport to the focused word's position if the host wants visual cursor-follow
+- Communicate the focused word to the cycling and visual-cues subsystems (in the shared runtime, this is automatic — `Cycling` and `DimRender` both read the same `HighlightState`)

--- a/docs/features/per-word-clearing.md
+++ b/docs/features/per-word-clearing.md
@@ -1,40 +1,28 @@
 ---
-last_updated: 2026-04-06
+last_updated: 2026-07-04
 ---
 
 # Per-Word Clearing
 
-When the user edits text, alternatives are preserved intelligently rather than discarding everything. Only the specific word positions that changed are invalidated, so unedited words keep their alternatives and remain navigable.
+When the user edits text, alternatives are preserved intelligently rather than discarding everything. Only the specific word positions affected by an edit lose their `DynDef`; unedited words keep their alternatives and remain navigable.
 
 ---
 
 ## How It Works
 
-1. **On every text change** (`_hlText !== _oldText`), the `writeDynamicClearOnChange` code runs before any highlight or analysis logic
-2. **Both old and new text** are split into word arrays (`_oldW`, `_newW`)
-3. **For each position** up to `Math.min(oldLength, newLength)`, the old and new words are compared
-4. **If a word changed and is in alts** — `_def.alts.indexOf(newWord) >= 0` — the `WordDef` is updated: `word` is set to the new word and `currentAltIndex` is set to the matching position. The word remains navigable (valid cycle)
-5. **If a word changed and is not in alts** — `alts` is set to `null` and `currentAltIndex` is reset to 0. Any span data for that position is also deleted. The word becomes non-navigable until re-analyzed
-6. **Removed words** — if `newLength < oldLength`, all `WordDef` entries at indices beyond the new length have their `alts` set to `null`
-7. **`_wordCount`** is updated to the new word count after every pass
+This is now the same mechanism [Deterministic Relocate](deterministic-relocate.md) describes — `DynDefs.pruneStale()` (`packages/opencues-runtime/src/state/dyn-defs.ts`), called from `Navigation.onTextChange` on every text change. Per-word clearing is really the "drop" outcome of that three-pass algorithm, not a separate mechanism:
+
+1. **Classify each existing `DynDef`** against the current word array: does the word (or, for multi-word alternatives, the word sequence) at its stored index still match? If yes → **keep**, untouched.
+2. **If not, look for a unique relocation** — does the def's current alternative appear at exactly one OTHER position in the buffer? If yes → **move** (this is what makes a cycled word survive a prefix insert elsewhere in the buffer; see deterministic-relocate.md for the collision rules).
+3. **Otherwise → drop.** The def is deleted. The word at that position becomes non-navigable until something re-establishes a def for it (a fresh LLM resolve, or an instant local-tip match if the word happens to match a loaded `CUE.md`'s `## Tips`).
+
+So editing "dog" to "do" drops dog's `DynDef` (no relocation match, "do" isn't one of dog's alternatives) — "do" is non-navigable until re-analyzed. Typing "dog" back doesn't instantly restore the OLD def (it was deleted, not cached) — it either waits for the next LLM resolve, or resolves immediately if "dog" is a local tip match (a `LocalCueSource` hit doesn't need history — it matches by word content, not by a preserved position).
 
 ---
 
-## Stale Detection
+## Stale LLM Result Handling
 
-Stale detection also applies when LLM results return after a delay. The merge logic in `_dynTriggerAnalysis` checks each incoming result against the current text:
-
-| Check | Action |
-|-------|--------|
-| `result.word !== _curTextWords[result.index]` | Skip — word changed during the LLM call |
-| `result.index >= _curTextWords.length` | Skip — word was deleted |
-| Old alt is a strict prefix of the current word | Skip old alt during merge (stale partial from mid-typing) |
-| `_resolverGeneration` mismatch | Discard entire response (config was reloaded mid-flight) |
-| Old entry has `source === "tips"` | Skip — tip-sourced entries are curated and not overwritten by LLM results |
-
-**Merge behavior** for non-stale results: new alts go first, then valid old alts are appended (deduplicated). `currentAltIndex` is set to the current word's position in the merged alts list.
-
-**Typing recovery:** "dog" -> "do" -> "dog" works because clearing sets `alts` to `null` but the auto-submit trigger re-analyzes the changed word. If the user types the word back before re-analysis completes, the eager tips lookup resolves it instantly from `_localCueMap`.
+A separate concern from pruning: what happens when an LLM response for an OLDER version of the text arrives after the user kept typing. The `Resolver` (see [Auto-Submit](auto-submit.md)) tags every dispatch with a monotonic generation counter; a response whose generation no longer matches the resolver's current generation is discarded outright rather than merged — this handles the "user kept typing during the LLM round-trip, then a config reload happened" case at the coarsest level. Tip-sourced entries (`source: 'tips'`) are also never overwritten by LLM results, regardless of generation.
 
 ---
 
@@ -48,9 +36,7 @@ Stale detection also applies when LLM results return after a delay. The merge lo
 
 ### Integration responsibilities
 
-- Maintain a `WordDef` array (or equivalent) that persists across text edits and maps word indices to their current text and alternatives
-- On each edit, diff the old and new word arrays to determine which words changed, were added, or were removed
-- Mark edited words as non-navigable when their current text does not match any known alternative
-- Restore navigability immediately when the user types the word back to a value that matches an existing alternative
-- Preserve the alternatives array for edited words so recovery is instant (no re-fetch needed)
-- Trigger re-analysis only for words that genuinely need fresh alternatives (changed text, no local match)
+- Supply `HostAdapter.onTextChange` — the shared runtime's `Navigation`/`DynDefs` handle keep/move/drop for you
+- If implementing outside the shared runtime: on each edit, classify each tracked def as keep (still matches its position), relocate (matches uniquely elsewhere), or drop (no match) — see [Deterministic Relocate](deterministic-relocate.md) for the exact three-pass algorithm and its collision-resolution rules
+- Don't try to "restore" a dropped def from a cache — the design intentionally re-resolves (or falls through to an instant local-tip match) rather than keeping stale alternatives around
+- Trigger re-analysis only for words that genuinely need fresh alternatives (dropped, no local match)

--- a/docs/features/resolver-skip-filter.md
+++ b/docs/features/resolver-skip-filter.md
@@ -30,10 +30,15 @@ at index `i`:
 
 | # | Condition | Action |
 |---|---|---|
-| 1 | The word IS `_` (blank) | **Always re-resolve.** Blank context can change between resolves; the answer depends on it. |
+| 1a | The word IS `_` AND it falls inside an existing `DynDef`'s span (`findSpanContaining(i)`) | **Skip.** The answer is already cached — typical case: the user cycled the def back to `currentIndex=0` to view the original query, then nudged the buffer elsewhere. Re-resolving would burn a redundant LLM round-trip for a cache hit. |
+| 1b | The word IS `_` AND this resolve pass wasn't declared to come from an explicit `_` keystroke (`allowBlanks` is false) | **Skip.** Mirrors the explicit-`_` gate in `onTextChange` — a `_` in the buffer only routes to blank sources when the caller confirms it came from an actual keystroke (not paste, programmatic `setText`, or cursor-relocation exposing a pre-existing `_`). Direct unit-test calls default `allowBlanks` to `true`. |
+| 1c | The word IS `_`, doesn't match 1a or 1b | **Always re-resolve.** Blank context can change between resolves; the answer depends on it. |
 | 2 | `i` falls inside an active `SpanFillState` range (a blank-fill spanning multiple words) | **Skip.** Cycling owns these positions; the LLM would compete with the user's selection. |
 | 3 | `findSpanContaining(i)` returns a multi-word static-alt span | **Skip.** Both the origin position and every inner position are owned by the cycled span. |
-| 4 | A `DynDef` already exists at `i` AND `existing.originalWord === text[i]` OR `existing.alternatives[currentIndex].split(/\s+/)[0] === text[i]` | **Skip.** Either the word is unchanged since resolution, or the user has cycled to one of the alternatives — in both cases cycling owns the position. |
+| 4 | A `DynDef` already exists at `i` with **more than one alternative** (`alternatives.length > 1` — a def with just one alternative has nothing to protect) AND `existing.originalWord === text[i]` OR `existing.alternatives[currentIndex].split(/\s+/)[0] === text[i]` | **Skip.** Either the word is unchanged since resolution, or the user has cycled to one of the alternatives — in both cases cycling owns the position. |
+
+(This is really five checks, not four — the blank-word case (1) splits
+into three sub-cases depending on caching and the explicit-`_` gate.)
 
 Words that pass all four checks are kept; everything else is replaced
 with `''` in the `cleanWords` array passed to
@@ -84,8 +89,8 @@ sufficient — the rest is governed by the multi-word span machinery
 
 ## Code reference
 
-- `packages/opencues-runtime/src/modules/resolver.ts:158` —
-  `resolveAndApply` builds `cleanWords` with the four conditions
+- `packages/opencues-runtime/src/modules/resolver.ts:1139` —
+  `resolveAndApply` builds `cleanWords` with the conditions above
 - Empty strings are filtered out by `RoutedWordSourceGroup.resolve`
   in `@opencues/core/src/sources/routed-word-source-group.ts` (every
   child `ConfigSource` ignores blank entries too)

--- a/docs/features/selector-satellite.md
+++ b/docs/features/selector-satellite.md
@@ -27,11 +27,28 @@ The sharp distinction from linked words: with linked words the alts lists are al
 
 ## The Two Roles
 
-**Selector (word N).** Identified by a `selectorWord` flag on its word definition. Carries a pointer to its satellite (`childIndex`) and a `currentSetting` field that is the authoritative logical state (distinct from the display text, though they usually match). Its alts list is the enumeration of all available setting names. Cycling it is read-only navigation across settings.
+Unlike the framing above might suggest, the pair isn't modeled as two independent `WordDef`s cross-linked by pointers. The reference implementation (`packages/opencues-runtime/src/state/selector-satellite.ts`) tracks BOTH halves as fields on one shared `SelectorSatelliteEntry` object:
 
-**Satellite (word N+1).** Identified by a `satelliteWord` flag. Carries a pointer back to its parent (`parentIndex`). Its alts list is **derived from whichever setting the selector currently points at** — it is rebuilt every time the selector moves. Cycling it triggers persistence.
+```ts
+interface SelectorSatelliteEntry {
+  selectorIndex: number;    // word index of the selector's first word
+  selectorLength: number;   // word count (1 for "voice-mode", 2+ for "display mode")
+  satelliteIndex: number;   // word index of the satellite's first word
+  satelliteLength: number;  // word count (1 for "active", 2+ for "plain text")
+  currentSetting: string;   // currently-displayed setting name
+  currentValue: string;     // currently-displayed value for that setting
+  separator: string;
+  clearOnEdit: boolean;
+  pairCharStart: number;    // char range of the whole pair, for clearOnEdit splicing
+  pairCharEnd: number;
+}
+```
 
-The parent↔child link lives entirely in metadata. Selector and satellite are **not a span of each other** — they are two fully independent, individually navigable units.
+**Selector.** `Cycling.cycleSelectorSatellite()` treats a highlight landing in `[selectorIndex, selectorIndex + selectorLength)` as selector-cycling. `currentSetting` is the authoritative logical state; its "alts list" (the enumeration of all available setting names) is derived on the fly from the registry, not stored as a persistent array. Cycling it is read-only navigation across settings.
+
+**Satellite.** A highlight in `[satelliteIndex, satelliteIndex + satelliteLength)` is satellite-cycling. Its valid values are looked up fresh from `currentSetting` on every cycle (via the registry) — there's no separately-maintained "satellite's alts list" that gets rebuilt; it's just re-derived each time from whatever `currentSetting` currently is. Cycling it triggers persistence.
+
+Selector and satellite are still two independently-navigable ranges — `Navigation.computeTargets()` force-includes both indices — but the shared-state-object design means there's no cross-pointer traversal at read time; both halves are fields on the one entry `Cycling`/`Navigation`/`DimRender` all read from `SelectorSatelliteState.current`.
 
 ---
 
@@ -102,10 +119,10 @@ No writes. Moving the selector is browsing.
 
 ### Satellite (write-through)
 
-1. Walk the parent pointer to find which setting we're writing.
-2. Advance in the satellite's current alts list (the valid values for that setting).
+1. Read `currentSetting` directly off the shared `SelectorSatelliteEntry` — no pointer-walk needed, since selector and satellite are fields on the same object.
+2. Advance to the next valid value for that setting (looked up fresh from the registry).
 3. Call the script to persist: `set <setting> <newValue>`.
-4. **Update the integration's in-memory current-values mirror immediately** so runtime consumers see the change before the next config reload.
+4. **Update the runtime's in-memory config state immediately** (`ConfigLoader.opencuesState`) so downstream consumers see the change before the next hot-reload pass.
 5. Rewrite only the satellite word in the text.
 
 The in-memory mirror update (step 4) is what makes cycling feel live — without it, downstream gates would lag behind by a hot-reload cycle.

--- a/docs/features/shipped-defaults.md
+++ b/docs/features/shipped-defaults.md
@@ -13,7 +13,7 @@ It is *not* picked up as an ambient project config — devs working on opencues 
 
 ## What lives in `defaults/`
 
-Same shape as any user-level `~/.cues/` or project-level `.cues/`:
+There is no top-level `CUES.md`/`BLANKS.md` in `defaults/` today — only the always-present runtime-settings and auditor master files, plus the folder-based cue/blank/auditor sources (`opencues init` generates fresh, empty `CUES.md`/`BLANKS.md`/`AUDITORS.md` templates for a NEW project — that's a separate code path from `seed-configs`, not a copy from `defaults/`):
 
 ```
 defaults/
@@ -21,32 +21,46 @@ defaults/
 │                        # llm-provider, agent-debounce-ms, ...) — frontmatter only.
 │                        # User-level only at runtime; schema declared in @opencues/core
 │                        # via FEATURES + MENU_TUNABLES.
-├── CUES.md              # Cue master: project metadata + ## Tips / ## Ignore /
-│                        # ## Prompt cue sources. User OR project level.
-│                        # Ships here so `seed-configs` can drop a starter file.
+├── AUDITORS.md           # Auditor master (always-present template).
+├── IDENTITY.md          # Personal-data template, fully commented out.
 ├── cues/                # Folder-based cue sources (one folder per source)
-│   ├── grammar/CUE.md   # Static cues: body JSON words map
 │   ├── legal/CUE.md     # LLM cues: match:/keywords: in frontmatter, prompt in body
 │   ├── medical/CUE.md
-│   └── financial/CUE.md
+│   ├── financial/CUE.md
+│   ├── more-formal/CUE.md   # scope: sentence cue
+│   ├── spelling/CUE.md      # catch-all, lowest priority
+│   ├── tips-{claude-code,opencode,gemini-cli,shell}/CUE.md
+│   └── example/CUE.md       # minimal worked example for authors
+├── auditors/
+│   ├── grammar/AUDITOR.md
+│   └── clarity/AUDITOR.md   # disabled by default; opt in
 └── blanks/              # Folder-based cue-blanks + colocated scripts
     ├── volume/
     │   ├── BLANK.md
-    │   ├── volume.sh
     │   ├── volume-blank.sh
     │   └── VolCtl.cs
     ├── brightness/
     │   ├── BLANK.md
-    │   └── brightness.sh
+    │   ├── brightness-blank.sh
+    │   └── BrightCtl.cs
     ├── stocks/BLANK.md
     ├── weather/BLANK.md
     ├── hackernews/BLANK.md
-    ├── prompt/BLANK.md
-    ├── answer/BLANK.md
-    ├── affirmations/BLANK.md
-    ├── numbers/BLANK.md
-    └── opencues/BLANK.md
+    ├── countries/BLANK.md
+    ├── crypto/BLANK.md
+    ├── dictionary/BLANK.md
+    ├── claude-status/BLANK.md
+    ├── gh-issues/{BLANK.md,blank.js}
+    ├── sentinel/BLANK.md
+    ├── opencues/BLANK.md        # the settings selector+satellite blank
+    └── example/{BLANK.md,time-blank.sh}
 ```
+
+The `prompt`/`answer`/`affirmations`/`numbers` blanks referenced in older
+revisions of this doc no longer exist — `prompt`/`answer` were retired
+(their intents now route through FluidBlank/TransformBlank on the
+user's configured provider instead of a bespoke Groq-only blank), and
+`affirmations`/`numbers` were removed in the same slim-down.
 
 ---
 
@@ -54,9 +68,9 @@ defaults/
 
 | Consumer | When | What it does |
 |---|---|---|
-| `opencues seed-configs` | On every invocation (standalone or chained from `opencues install <host>`) | Four phases: (1) **SEED** first-time copy to `~/.cues/` — preserves non-empty user files; (2) **SYNC** library files (`.sh` / `.cs` / `.ps1`) from `defaults/{blanks,scripts}/` every run — overwrites stale, never overwrites `.md`; (3) **HEAL** re-seed 0-byte `OPENCUES.md` (the runtime settings file — empty would silently break `opencues ___` / `config ___` blank-fills); (4) **COMPILE** colocated `.cs` → `.exe` (WSL only). |
-| Chrome `esbuild.config.mjs` | Every `pnpm --filter @opencues/chrome build` | Inlines `defaults/cues/*`, `defaults/blanks/*`, and `defaults/CUES.md` into the bundle as `__DEFAULT_*__` constants. The runtime uses these as fallbacks when the bundled `configs/` dir is absent or hasn't been sync'd. |
-| `packages/opencues-core/src/cues-md.test.ts` | Unit test | Reads `defaults/CUES.md` and `defaults/BLANKS.md` as real-world fixtures (the "real CUES.md" / "real BLANKS.md" describe blocks). |
+| `opencues seed-configs` | On every invocation (standalone or chained from `opencues install <host>`) | Four phases: (1) **SEED** first-time copy of `OPENCUES.md` + `AUDITORS.md` + the `cues/`/`blanks/`/`auditors/`/`scripts/` folders to `~/.cues/` — preserves non-empty user files; (2) **SYNC** library files (`.sh` / `.cs` / `.ps1`) from `defaults/{blanks,scripts}/` every run — overwrites stale, never overwrites `.md`; (3) **HEAL** re-seed a 0-byte `OPENCUES.md` (the runtime settings file — empty would silently break every runtime-settings read); (4) **COMPILE** colocated `.cs` → `.exe` (WSL only). It never touches `CUES.md`/`BLANKS.md` — those aren't shipped in `defaults/` at all. |
+| Chrome `esbuild.config.mjs` | Every `pnpm --filter @opencues/chrome build` | Inlines `defaults/cues/*` and `defaults/blanks/*` into the bundle as `__DEFAULT_*__` constants. The runtime uses these as fallbacks when the bundled `configs/` dir is absent or hasn't been sync'd. |
+| `packages/opencues-core/src/cues-md.test.ts` | Unit test | Has `describe` blocks that would read `defaults/CUES.md`/`defaults/BLANKS.md` as real-world fixtures, but both are guarded by `existsSync` and self-skip via `it.skip` since neither file exists today — this coverage is currently dormant, not active. |
 
 Nothing reads `defaults/` at host runtime. The runtime only reads `~/.cues/` (user-level), `<cwd>/.cues/` (project-level), and — for chrome — the synced `dist/configs/` bundle.
 

--- a/docs/features/tip-priority.md
+++ b/docs/features/tip-priority.md
@@ -1,102 +1,47 @@
 ---
-last_updated: 2026-04-09
+last_updated: 2026-07-04
 ---
 
 # Tip Priority
 
-Every highlighted word can show a tip in the secondary display (status line). Tips come from multiple sources. When a word matches more than one source, a fixed priority order determines which tip wins.
+Every highlighted word can show a tip in the secondary display (status line). Tips come from multiple sources. When a word matches more than one source, a fixed priority order determines which tip wins. Implemented in `Statusline.snapshot()` (`packages/opencues-runtime/src/modules/statusline.ts`).
 
 ---
 
 ## Priority Table
 
-| Priority | Word type | Example | Tip shown | Source |
-|---|---|---|---|---|
-| 1 | Satellite (per-value) | `active` under selector `voice-mode` | "TTS reads tips aloud on navigation" | `OPENCUES.md` (settings menu auto-derived from `FEATURES` + `MENU_TUNABLES`), nested value line |
-| 2 | Satellite (fallback) | `on` under selector `debug-mode`, no per-value tip defined | "Enable debug logging output" | `OPENCUES.md` (settings menu auto-derived from `FEATURES` + `MENU_TUNABLES`), setting-level line |
-| 3 | Selector | `voice-mode` | "Gates TTS globally" | `OPENCUES.md` (settings menu auto-derived from `FEATURES` + `MENU_TUNABLES`), setting-level line |
-| 4 | Cue-blank value | `72` after `volume` | "System volume" | Blank's `BLANK.md` `tip` field |
-| 5 | Cue-blank keyword | `volume` (the trigger word) | "85" (live reading) | `blankInvoke get` output; falls back to `tip` in `BLANK.md` |
-| 6 | Local cue (folder-based) | `ultrathink` | "Add 'ultrathink' to prompt for max reasoning" | `cues/<name>/CUE.md` body JSON via `cueMap` (built in `ConfigLoader`) |
-| 7 | LLM-analyzed word | `happy` | "glad, joyful, content" | LLM response via opencues-core resolver |
+Checked in this order — the first match wins:
+
+| Priority | Word type | Tip shown |
+|---|---|---|
+| 1 | Selector (settings menu) | The setting's own `tip` from the `FEATURES`/`MENU_TUNABLES` registry definition |
+| 1 | Satellite (settings menu) | The setting's per-value tip (`valueTips.get(currentValue)`) |
+| 2 | Span-fill (any word inside an active consume-all or list-blank span) | The blank's `tip` (e.g. "Daily affirmations") |
+| 3 | Blank-attributed value (e.g. `50%` after `volume`) | **None — suppressed on purpose.** The value is already visible in the buffer; a tip would be redundant ("system volume blank 50%"). |
+| 4 | General word (including blank keywords like the word `volume` itself, and plain LLM/local cue words) | `configLoader.lookup(word).cueTip`, preferring `altCueTips[currentAlt]` when set |
+
+**Important correction from earlier revisions of this doc**: a blank's *value* word never shows a live "current reading" tip via a `blankInvoke get` call — there is no such code path in the current statusline. A blank's *keyword* word (the trigger, e.g. "volume") gets whatever static/LLM tip its cue-lookup entry has, formatted with `cueBlank: true` (the consumer prints the tip alone, without a "(N/M)" alt-position suffix) — it does not invoke the blank's script live.
+
+`tips-mode: off` suppresses the tip text at every priority level (word/alts data still gets exposed for the status line, just no tip string).
 
 ---
 
 ## How Priority Is Enforced
 
-### Display path (which tip is shown)
+`Statusline.snapshot()` checks four branches in order, each an early return:
 
-The navigation export code checks three branches in order. The first match wins; the rest are skipped:
+1. **Selector/satellite** — is the highlighted word index within the active `SelectorSatelliteState`'s selector or satellite range? If so, look up the tip from `configLoader.opencuesState.definitions.get(currentSetting)` (selector: `.tip`; satellite: `.valueTips.get(currentValue)`).
+2. **Span-fill** — is the highlighted word index inside the active `SpanFillState`? If so, use the span's own `tip`.
+3. **Blank-attributed DynDef** (`def?.blankName` set) — return with `cueTip: null` unconditionally. This is priority-3 in the table above.
+4. **Everything else** — look up the word (using its *original* word, stable across cycling) via `configLoader.lookup()`; prefer `altCueTips[currentDisplayedWord]` over the primary `cueTip` if the lookup has per-alt tips. Whether this word is `cueBlank: true` (tip-alone display) is decided separately, by checking if the word is in `configLoader.blanksByWord` — independent of whether the lookup itself found a tip.
 
-1. **Blank-bound word** — the WordDef has `metadata.blankName` set (auto-populated by the blank pipeline)
-   - Selector/satellite sub-branch (`metadata.selectorWord` or `metadata.satelliteWord`): reads `OPENCUES.md` (settings menu auto-derived from `FEATURES` + `MENU_TUNABLES`) (priorities 1-3)
-   - Regular cue-blank value: reads `cueTip` from the WordDef, set by `tip` in the blank's `BLANK.md` (priority 4)
-2. **Cue-blank keyword** — the word text matches a registered `blankKeywords` entry
-   - Calls `blankInvoke({ action: 'get' })` for a live reading; falls back to `tip` from `BLANK.md` (priority 5)
-3. **General word** — no blank metadata, not a cue-blank keyword
-   - Reads `cueTip` from `_dynDefs`, populated by local cue lookup or LLM analysis (priorities 6-7)
-   - Local cues resolve instantly (~0ms); LLM results arrive asynchronously and overwrite if they carry a tip
-
-The guard that prevents branch 3 from overriding branches 1-2 is the `!_cbDw` and `!_isCA` condition on the general branch. Blank-bound words and cue-blank keywords are never read from `_dynDefs` for display.
-
-### Analysis path (which words get sent to the LLM)
-
-The same word types are protected from unnecessary LLM analysis, but using different mechanisms that achieve the same result:
-
-| Word type | How it's skipped | Mechanism |
-|---|---|---|
-| **Cue-blank keyword** | blank-keyword check | Explicit skip before the `_hasAlts` check |
-| **Cue-blank value** (including selector/satellite) | `_hasAlts` check | WordDef already has `alts.length > 1` from auto-populate, so it's treated as already resolved |
-| **Local cue match** | `_tipsHandled` check | `lookupMultiple` found a match in `_localCueMap`, so no LLM needed |
-| **Common word** (the, a, is, ...) | Stopword regex | Hard-coded skip list |
-| **Ignored word** | `_cuesIgnoreWords` set | User-authored `ignore:` array in `CUES.md` frontmatter |
-
-The result is consistent: blank-bound words, cue-blank keywords, and locally-resolved words are never sent to the LLM, and their tips are never overwritten by LLM results.
-
-### Cycling path (which tip is shown after cycling)
-
-When a word is cycled, the tip is updated inline within each cycling branch:
-
-- **Selector cycling**: reads `_openCuesTips[nextSetting]`
-- **Satellite cycling**: reads `_openCuesSatTips[setting][newValue]`, falls back to `_openCuesTips[setting]`
-- **Regular cue-blank cycling**: tip is unchanged (stays as `tip` from `BLANK.md`)
-- **General word cycling**: `cueTip` stays from the WordDef; `altCueTips[newAlt]` replaces it in the export if present
+A word inside a multi-word blank/fluid/transform substitute span resolves to the ORIGINATING def (via `DynDefs.findSpanContaining`) before any of the above runs, so e.g. highlighting "email" inside an LLM-drafted email body doesn't surface an unrelated word-cue tip for "email" as a standalone word.
 
 ---
 
 ## The settings menu (registry-derived)
 
-Settings, valid values, and tips are declared in `@opencues/core`'s `FEATURES` + `MENU_TUNABLES` registry (`packages/opencues-core/src/feature-registry.ts`). The runtime derives the cycling menu at boot. Users who want a custom menu can ship a `settings:` block in `OPENCUES.md` frontmatter as an overlay — when present, the file-level block fully replaces the registry defaults. Example registry entry shape:
-
-```yaml
----
-version: 1
-voice-mode: active
-settings:
-  voice-mode:
-    tip: Gates TTS globally
-    values:
-      active: TTS reads tips aloud on navigation
-      inactive: TTS is silenced
----
-```
-
-- **Setting name**: any indented line with a key and no value after the colon (e.g. `voice-mode:`)
-- **`tip:`**: reserved key — selector tip shown when this setting is highlighted
-- **`values:`**: reserved key — opens the valid-values block
-- **Value entries**: any line inside `values:` with a key and value (e.g. `active: TTS reads tips aloud`)
-
-Indentation depth does not matter — the parser detects structure by key names and whether a value is present after the colon, not by counting spaces.
-
-The parser hydrates two globals on every hot-reload cycle:
-
-| Global | Type | Contents |
-|---|---|---|
-| `_openCuesTips` | `Record<string, string>` | Setting name to selector tip (from `tip:` lines) |
-| `_openCuesSatTips` | `Record<string, Record<string, string>>` | Setting name to { value: tip } (from value entries) |
-| `_openCuesSettings` | `Record<string, string[]>` | Setting name to list of valid values (keys from value entries) |
-
-Satellite tip resolution: `_openCuesSatTips[setting][value]` first, then `_openCuesTips[setting]` as fallback.
+Settings, valid values, and tips are declared in `@opencues/core`'s `FEATURES` + `MENU_TUNABLES` registry (`packages/opencues-core/src/feature-registry.ts`), not in per-cue `CUE.md` files or a raw parsed `settings:` block held in module-level globals. `ConfigLoader` derives `opencuesState.definitions` (a `Map` from setting name to `{ tip, values, valueTips, ... }`) from the registry at boot and on every hot-reload; `Statusline` reads directly from that map. See [`docs/architecture/feature-registry.md`](../architecture/feature-registry.md) for the registry's full shape.
 
 ---
 
@@ -107,12 +52,11 @@ Satellite tip resolution: `_openCuesSatTips[setting][value]` first, then `_openC
 - `CueResult.cueTip` carries the primary tip for any word
 - `CueResult.altCueTips` maps each alternative to its own tip (for per-alt display during cycling)
 - Cue-blanks use `tip` from the blank's config
-- Selector/satellite tips are derived from `@opencues/core`'s `FEATURES` + `MENU_TUNABLES` registry, not from per-cue `CUE.md` files (file-level `settings:` block in `OPENCUES.md` is an optional override)
+- Selector/satellite tips are derived from `@opencues/core`'s `FEATURES` + `MENU_TUNABLES` registry, not from per-cue `CUE.md` files
 
 ### Integration responsibilities
 
-- Implement the three-branch display priority: blank-bound words first, then cue-blank keywords, then general words
-- Ensure blank-bound words and cue-blank keywords are excluded from LLM analysis (either by explicit skip or by the `_hasAlts` guard)
-- For selector/satellite words, read tips from the backing config's `settings:` block and hot-reload them
-- Update the cycling tip inline within each cycling branch — don't rely on a separate refresh
+- Implement the four-branch priority order: selector/satellite, then span-fill, then blank-value-suppression, then general word lookup
+- Suppress the tip (not the whole status entry) for blank-attributed values — the value is already visible in the buffer
+- For selector/satellite words, read tips from the registry-derived definitions and hot-reload them
 - When no tip resolves for a word, suppress the secondary display entirely (don't show an empty tip)

--- a/docs/features/transform-blank.md
+++ b/docs/features/transform-blank.md
@@ -99,8 +99,12 @@ won't be re-triggered on the rewritten text.
 
 ## What kinds of instructions work
 
-The benchmark covers **212 cases across 18 categories**. Median pass
-rate ~83%, ~1.4s per case end-to-end on Groq gpt-oss-120b.
+The benchmark has grown since this doc was first written — 212 cases
+across 18 categories originally, expanded to **487 cases across 19
+categories** as of the 2026-07 suite (`tests/benchmarks/transform-blank/cases.ts`
++ `cases-expansion.ts`). Overall pass rate ~83% on gpt-oss-120b
+(`tests/results/gemma-benchmark-2026-07-01/FINDINGS.md`), ~1.4s per
+case end-to-end on Groq gpt-oss-120b.
 
 ### Strong categories (90-100% pass rate)
 

--- a/docs/features/visual-cues.md
+++ b/docs/features/visual-cues.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-04-06
+last_updated: 2026-07-04
 ---
 
 # Visual Cues
@@ -10,62 +10,45 @@ Visual cues are the styling changes applied to words in the input to indicate wh
 
 ## How It Works
 
-1. **Render pass**: On every render, the integration strips existing ANSI codes from the input to get clean text, splits on whitespace to get a word list, then iterates character-by-character to apply styling
-2. **Dim pass**: For each word, the system checks whether it should be dimmed (see What Gets Dimmed below). Dimmed words are collected into `_numRanges` — an array of `{start, end}` character ranges
-3. **Highlight pass**: The highlight range (`_hlStart`, `_hlEnd`) covers the focused word and any span words (via `spanLength`). Linked words are NOT visually highlighted together — they share cycling behaviour but are rendered independently
-4. **Character loop**: Each character in the rendered value is checked against the ranges. If inside a highlight range, highlight styling is applied. If inside a dim range, dim styling is applied. Otherwise, the original styling passes through
-5. **External highlights**: Words that have external highlights (e.g., shimmer effects from the host editor) are excluded from both dim and highlight overrides to avoid conflicts
+Implemented by the `DimRender` module (`packages/opencues-runtime/src/modules/dim-render.ts`), which computes a set of dim ranges plus (at most) one highlight range, expressed as a `RenderDirectives` object the host applies over its own already-rendered text.
+
+1. **Compute dim ranges**: for every word that's navigable (same cueMap/DynDef rule Navigation uses) and isn't the currently-highlighted word or inside an active span/selector/satellite block, add its character range to `dimRanges`. Multi-word spans emit one range covering the whole span, not one per word.
+2. **Compute the highlight range**: if a word is highlighted (`HighlightState.active`), its range — extended across the whole span if it's part of one, or across both halves if it's an active selector/satellite pair — becomes the single highlight range.
+3. **Host applies directives**: `packages/opencues-runtime/src/render-directives.ts`'s `applyRenderDirectives` walks the host's already-ANSI-rendered string character-by-character, distinguishing visible chars from existing escape sequences, and inserts the dim/highlight ANSI codes at the directive boundaries. Existing ANSI codes (the host's own syntax highlighting) are preserved.
 
 ---
 
 ## What Gets Dimmed
 
-A word at index `_ni` is added to `_numRanges` (and therefore dimmed) if any of the following conditions are true and it is not the currently highlighted word:
+A word is dimmed if it's navigable per the same rule `Navigation.computeTargets()` uses (cueMap match, or a `DynDef` entry — LLM alternatives, blank-fill value, span member), it isn't the highlighted word, and it isn't inside the currently-active span/selector/satellite block (those get one whole-region highlight instead of per-word dim, so they don't look like random word-fading). A few refinements on top:
 
-| Condition | Check | Source |
-|-----------|-------|--------|
-| **Cue-blank keyword** | `blanksByWord.has(_w.toLowerCase())` — word is a registered blank keyword | `writeDynamicRendering` |
-| **Tip word** | `globalThis._localCueMap.has(_w.toLowerCase())` — word exists in the local cue map (case-insensitive). Checked directly in the render loop for instant dimming without waiting for the analysis pipeline | `writeDynamicRendering` |
-| **Dynamic alternative** | `_dynDef` found where `d.alts.length > 1 && d.alts.indexOf(_w) >= 0` — the LLM returned multiple alternatives and the current word is among them | `writeDynamicRendering` |
-| **Cue-blank value** (1-alt exception) | `d.metadata && d.metadata.blankName` — dimmed even when `alts.length` is 0 or 1. The only case where a word with fewer than 2 alternatives gets dimmed | `writeDynamicRendering` |
-| **Span member** | `globalThis._dynSpans[_ni]` is set — the word is part of a multi-word span (e.g., "Bezos" in "Jeff Bezos"). Excluded if the span is currently highlighted (`_spanInfo.originalIndex === _hlWordIdx`) | `writeDynamicRendering` |
+- **Multi-word spans** — each span's *origin* emits one dim range covering the whole span; inner positions don't get their own range.
+- **CJK / spaceless substitutes** — when a def carries a live-matching character span (`spanStart`/`spanEnd`), that's used instead of the word-derived range, so a spaceless CJK substitute (fewer whitespace-tokens than characters) dims completely rather than partially. A stale span (buffer edited, def not yet cleared) is skipped rather than painted over new text.
+- **Bare blank keywords are gated** — a word that's ONLY a blank keyword (not also a word-cue match or `## Tips` entry) doesn't dim until `_` is nearby. Otherwise every prose mention of "volume" or "bitcoin" would falsely suggest it's interactive when no `_` is in play.
 
 ---
 
 ## Rendering
 
-Styling is applied per-character using raw ANSI escape codes. Each code starts with `\x1b[0m` (reset) to clear any prior styling and prevent leaks between adjacent characters.
+Two ANSI attribute pairs (`packages/opencues-runtime/src/render-directives.ts`), not per-color escape codes:
 
 ### Dim
 
 ```
-\x1b[0m\x1b[90m  +  char  +  \x1b[0m
+\x1b[2m  (dim attribute ON)  ...  \x1b[22m  (normal intensity, OFF)
 ```
 
-SGR 90 is dark gray foreground. All dimmed words use this single style regardless of their dim reason (tip, blank, span member, etc.).
+This dims via the terminal's own "faint" SGR attribute, not a specific gray foreground color — so it composes with whatever foreground color the host's own syntax highlighting already applied.
 
 ### Highlight
 
-The highlight color is configurable. Default is bold bright white:
+```
+\x1b[97m  (bright white foreground ON)  ...  \x1b[39m  (default foreground, OFF)
+```
 
-| Color | ANSI sequence | SGR codes |
-|-------|---------------|-----------|
-| white (default) | `\x1b[0m\x1b[1;97m` | bold + bright white |
-| cyan | `\x1b[0m\x1b[1;96m` | bold + bright cyan |
-| yellow | `\x1b[0m\x1b[1;93m` | bold + bright yellow |
-| inverse | `\x1b[0m\x1b[7m` | reverse video |
-| underline | `\x1b[0m\x1b[4m` | underline |
+Deliberately a foreground-color change, not inverse video (`\x1b[7m`) — inverse washed out the dim layer underneath on some terminals; bright-white-on-dim reads better. There is no user-configurable highlight color today (no scalar for it in `feature-registry.ts` — the closest related knob, `dim-mix`, is a chrome-only CSS blend-strength setting for the browser integration, not an ANSI color choice).
 
-When a highlighted word is part of a multi-word span (`spanLength > 1`), the highlight range extends across all words in the span.
-
-### Precedence
-
-The character loop applies styles in this order:
-
-1. **Inverse mode** (`\x1b[7m` active) — pass through unchanged (cursor styling)
-2. **Highlight** — if character is in `[_hlStart, _hlEnd)`, apply highlight color
-3. **Dim** — if character is in any `_numRanges` entry, apply dim
-4. **Normal** — pass through original styling
+Markdown-styled ranges (bold/italic/code-span/strikethrough/headings, emitted by TransformBlank's markdown-aware substitution) use their own separate ANSI pairs layered independently of the dim/highlight logic above.
 
 ---
 
@@ -73,16 +56,12 @@ The character loop applies styles in this order:
 
 ### Standard (opencues-core)
 
-- `WordDef.alts` length determines whether a word is navigable (dimmed vs. normal)
-- `metadata.blankName` identifies cue-blank values, which are dimmed even with only 1 alt (the 1-alt exception)
-- Linked word indices (`CueResult.linked`) define which words share cycling behaviour (they are not visually highlighted together)
-- The three visual states (normal, dimmed, highlighted) are defined by the standard; rendering is not
+- `CueResult.alternatives` length and `metadata.blankName` together determine whether a word is navigable/dimmable (same signal `Navigation` and `DimRender` both key off)
+- The three visual states (normal, dimmed, highlighted) are a runtime-layer concept — opencues-core classifies words, it doesn't decide how they're painted
 
 ### Integration responsibilities
 
+- Implement `applyRenderDirectives`-equivalent logic, or supply the primitives (`onRender` hook applying dim/highlight ranges) the shared runtime's `DimRender` calls into
 - Render the three visual states using platform-appropriate styling (ANSI codes, CSS classes, editor decorations, etc.)
-- Apply dimmed state to all words where `alts.length > 1`, plus cue-blank keywords, tip words, cue-blank values, and span members
-- Apply highlighted state to the currently focused word and any span words (linked words share cycling but are rendered independently)
 - Update visual states in real time as the user navigates and as new analysis results arrive
-- Respect external highlight regions (e.g., host editor shimmer) by skipping visual overrides for those words
-- Ensure styling does not interfere with the editor's own syntax highlighting or theme
+- Ensure styling does not interfere with the editor's own syntax highlighting or theme — the shared runtime's approach (dim = brightness attribute, highlight = foreground color swap) is designed to compose with existing colors rather than reset them


### PR DESCRIPTION
## Summary
Five docs (`navigation.md`, `cycling.md`, `visual-cues.md`, `cursor-preservation.md`, `auto-submit.md`) described a fully retired `globalThis`-based CC-patch architecture (`_hlState`, `_dynDefs`, `_localCueMap`, `_cycleAlt`, ...) with zero references anywhere in the current `@opencues/runtime` modular system. Full rewrites against actual current source:

- **navigation.md** — `Navigation.computeTargets()`'s real cueMap/DynDef rule, `HighlightState`'s actual 3-field shape, the real step()-from-the-right walk.
- **cycling.md** — `Cycling.step()`'s real 5-level priority chain (selector/satellite -1, span-fill 0, list-blank 1, blank-step 2, static-alts 3) — the old 3-level chain didn't match, and disagreed with the already-verified architecture doc.
- **visual-cues.md** — the real ANSI codes (dim = `\x1b[2m` attribute, not a gray-fg color; highlight = `\x1b[97m` fg swap) — the old "5 configurable highlight colors" table is fictional, no such scalar exists.
- **cursor-preservation.md** — the real 3-way cursor rule (before/after/**inside** the replaced range), replacing a 2-way conditional that missed the inside-the-word case entirely.
- **auto-submit.md** — the real single-500ms-debounce + immediate-`_`-trigger-bypass + generation-counter-cancellation design, replacing a fictional "three-tier 50ms/300ms" system.

Two more described mechanisms with no current equivalent or a different one:
- **linked-words.md** — confirmed dead end-to-end: the field still exists in types, but nothing produces or consumes it. Rewrote as an explicit "not implemented" page.
- **per-word-clearing.md** — its role is now `DynDefs.pruneStale()`'s keep/move/drop algorithm; rewrote to point at that instead of a superseded model.

Targeted fixes (backwards claims, fictional features, stale numbers):
- `tip-priority.md` had the tip-suppression rule for blank VALUES **backwards** (docs said live tip shown; code explicitly suppresses it).
- `selector-satellite.md` described a fictional per-word data model — actual state is one shared `SelectorSatelliteEntry` object.
- `cue-blanks.md`'s "~50ms debounced spawn" traces only to an unimplemented proposal; every keypress spawns immediately. Added the missing 5th flavour (selector+satellite).
- `blank-as-context.md` said "not yet wired to production" — it's fully shipped.
- `identity-context.md` said "off by default" — default changed to `safe` on 2026-06-18 (#161), which understated the shipped privacy posture.
- `shipped-defaults.md` referenced a `defaults/CUES.md` that doesn't exist, wrong script filenames, and retired blank folders.
- `chrome-hot-reload.md` described the pre-May-2026 `.version`-poll mechanism as current; fully removed, replaced by the native-messaging push model.
- `max-thinking.md`/`claude-cli-provider.md` repeated the architecture-tier bugs plus 2 NEW wrong ceiling rows (openrouter, opencode-zen) that sweep didn't catch.
- `host-compat.md`'s `HOSTS`/`NATIVE_HOSTS` tables were still 4 entries, missing `shell`.
- `agent-task.md` referenced an entire deleted benchmark suite with fictional files and a stale pass-rate — replaced with the real `tests/benchmarks/agent-rewrite/` structure.
- `resolver-skip-filter.md`'s "four conditions" were actually five, missing a guard, plus a stale line pointer.
- `deterministic-relocate.md`/`transform-blank.md`: stale line numbers and a stale case count (212/18 → 487/19).

Round 1 (carried onto this branch first): `README.md` gained 4 missing feature entries; minor rename-drift link fixes; `host-compat.md` had a ~20-line duplicated section removed.

## Test plan
- [x] Full link-check across `docs/` before/after — no new breaks
- [x] Every rewrite traced to current source (`navigation.ts`, `cycling.ts`, `render-directives.ts`, `dyn-defs.ts`, `statusline.ts`, `resolver.ts`, model-thinking tables, `host-compat.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CrGD7J1LHUxx9vjZuSv6p