### PR TITLE
docs: structural cleanup — Auditors framing consistency, missing indices, dedup risk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This document provides context for Claude sessions working on this project.
 
 ## Project Overview
 
-**OpenCues** provides LLM-powered word alternatives and `_`-gated blank fill-ins for text editors. The system reduces to two ideas: **Cues** (LLM → user, on plain text) and **Blanks** (user → system, on `_`). See `concept.md` at the repo root.
+**OpenCues** provides LLM-powered word alternatives and `_`-gated blank fill-ins for text editors. The system reduces to two ideas: **Cues** (LLM → user, on plain text) and **Blanks** (user → system, on `_`). **Auditors** are a continuous, whole-buffer variant of the Cues direction — one declared concern (grammar, clarity, tone, ...) applied as an ongoing, revertable rewrite rather than a per-word cycle. See `concept.md` at the repo root and `spec/auditor-spec.md`.
 
 **Architecture** (two libraries + integrations):
 - **`@opencues/core`** — *what alternatives exist*. Pure TypeScript: parsers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,15 @@
 # Security Policy
 
+> **Three security docs exist in this repo, scoped differently:** this file
+> covers *how to report a vulnerability* + a summary trust model. The
+> **canonical, actively-maintained technical threat model** (26 numbered
+> attack classes with current defenses + residual risk) lives at
+> [`docs/architecture/security-audit.md`](docs/architecture/security-audit.md)
+> — if this file's "Boundaries" / "Threat actors" / "Known gaps" sections
+> below ever seem to disagree with that one, trust `security-audit.md`. The
+> open standard's own security claims (what a conformant third-party runtime
+> MUST honour) live at [`spec/SECURITY.md`](spec/SECURITY.md).
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in OpenCues, please report it

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,9 +1,17 @@
-# Cues Specification
+# OpenCues Specification
 
 **Current version: `0.4` (draft)**
 
-This document declares the **Cues spec** — the durable, host-agnostic format that
-describes word-cues and blank-fills. It is separate from any single
+This document is a short front door. The full standard — **Cues**, **Blanks**,
+and **Auditors**, plus the shared `core.md` rules and the `identity-context`
+sentinel format — lives in [`spec/`](spec/README.md); start there for the
+complete surface-by-surface breakdown, the JSON schemas, and the conformance
+fixture tree. This file exists for the version policy and a top-level pointer;
+it deliberately doesn't duplicate `spec/README.md`'s content, to avoid the two
+drifting out of sync.
+
+The durable, host-agnostic format described by the standard covers word-cues,
+blank-fills, and inline-rewrite auditors. It is separate from any single
 implementation. A conforming reader is anything that can parse the formats
 below and surface them to a user; this repo ships the reference implementation
 (`@opencues/core` + `@opencues/runtime`), but the spec is intended to be
@@ -14,7 +22,8 @@ and third-party readers pin to it the same way bundlers pin to ESM levels.
 
 ## What the spec covers
 
-The `0.1` spec defines the wire format of:
+See [`spec/README.md`](spec/README.md#documents) for the full per-file
+breakdown. Summary — the spec defines the wire format of:
 
 1. **`CUES.md`** — the cue master config: frontmatter (project metadata) +
    `## Tips` / `## Ignore` / `## Prompt` sections (LLM cue source declarations).
@@ -74,7 +83,8 @@ The `0.1` spec defines the wire format of:
    defence) and bracket-strings already present in the user's
    buffer MUST be preserved verbatim. The mode is gated by the
    `identity-context-mode` scalar in `OPENCUES.md` (`off` /
-   `safe` / `raw`; default `off`).
+   `safe` / `raw`; default `safe` since PR #161, 2026-06-18 — was
+   `off` before that).
 
 ## What the spec does NOT cover
 
@@ -103,7 +113,8 @@ The `0.1` spec defines the wire format of:
 
 ## Where the spec lives
 
-- This file — high-level overview + version policy.
+- This file — top-level pointer + version policy.
+- [`spec/`](spec/README.md) — the full per-surface spec files, JSON schemas, and conformance fixtures. Canonical.
 - `packages/opencues-core/src/spec-version.ts` — the exported constant.
 - The canonical parsers (`cues-md.ts`, `discover.ts`, frontmatter readers
   across the sources tree) — the executable form of the spec.

--- a/concept.md
+++ b/concept.md
@@ -33,6 +33,10 @@ That's it. Every feature in OpenCues is one of these two things, dressed up.
                          └── settings         (opencues _, voice-mode _)
 ```
 
+## A continuous variant: Auditors
+
+Auditors are the same **LLM → you** direction as Cues, stretched to cover the whole buffer instead of one word at a time. Where a cue proposes alternatives you cycle through, an auditor declares one ongoing concern (grammar, clarity, tone, jargon, ...) and the runtime keeps a rewrite applying itself as you type — shown as dimmed text you can revert, never something you have to accept first. Same direction, same "the system offers, you didn't ask" contract; the difference is scope (whole buffer, not one word) and cadence (continuous, not per-word). See `spec/auditor-spec.md` and `docs/guides/adding-an-auditor.md`.
+
 ## Why the split matters
 
 The two surfaces have **fundamentally different contracts**:
@@ -65,14 +69,16 @@ The two surfaces have **fundamentally different contracts**:
 
 The shape: **`_` for anything that touches the world. Plain text is LLM-only. Nothing else.**
 
-## Settings (`OPENCUES.md` frontmatter) — every cue surface is opt-in
+## Settings (`OPENCUES.md` frontmatter) — opt-in per surface
 
 ```yaml
-fluid-blank-mode: on          # free-form `_` lookups
 word-cues-mode: on            # domain synonym cycling on plain text (per-source match/keywords)
+transform-blank-mode: on      # imperative `_` instructions + agent-task lifecycle
+# Fluid-blank (free-form `_` lookup) has no toggle — it's the always-on
+# base layer every `_` not claimed by a shape falls through to.
 # Spelling: ships as a regular cue at `~/.cues/cues/spelling.md` —
 # enabled by default like any other cue. No separate flag.
 ```
 
-Missing setting → off. Shipped defaults turn all three on; flip to `off` to disable a surface.
+Missing setting → off. Shipped defaults turn both real toggles on; flip either to `off` to disable that surface.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,12 @@ docs/
 ├── install.md                 # deep per-host install reference (the top-level README has the quickstart)
 ├── configuration.md           # every OPENCUES.md scalar + the CUES.md/BLANKS.md/AUDITORS.md masters
 ├── prompt-design-learnings.md # cross-cutting prompt-engineering lessons
-├── install/                   # install-process deep-dives (walkthrough, tmux prebuilt publishing)
+├── install/                   # install-process deep-dives — see install/README.md
+├── benchmarks/                # dated benchmark write-ups (snapshots) — see benchmarks/README.md;
+│                               # live numbers + runnable bench code live in tests/benchmarks/ instead
+├── launch/                    # pre-launch runbooks (e.g. npm-name handover) — see root CLAUDE.md § Pre-launch
+├── maintainers/                # maintainer-only docs (e.g. PUBLISHING.md)
+├── blog/, blog-resources/     # content-creation working area — separate from reference docs, out of scope here
 ├── guides/                    # task-oriented how-tos — see guides/README.md
 ├── architecture/              # implementation reference docs — see architecture/README.md
 └── features/                  # feature concept reference — see features/README.md

--- a/docs/architecture/security-audit.md
+++ b/docs/architecture/security-audit.md
@@ -18,6 +18,12 @@ Companion deep-dives:
   invariant, structural reliance on "OpenCues has no tool / exec
   layer for fluid-blank prompts."
 
+Two sibling security docs, differently scoped: root [`SECURITY.md`](../../SECURITY.md)
+(how to report a vulnerability + a coarser trust-model summary) and
+[`spec/SECURITY.md`](../../spec/SECURITY.md) (the open standard's own
+normative security claims — what a conformant third-party runtime MUST
+honour, independent of this reference implementation).
+
 ## Load-bearing structural invariants
 
 These are the structural properties the whole security model

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,0 +1,15 @@
+---
+last_updated: 2026-07-04
+---
+
+# Benchmark write-ups (dated snapshots)
+
+This directory holds narrative, point-in-time benchmark reports — human-readable write-ups of a specific comparison run on a specific date. It is **not** the live benchmark system.
+
+For current numbers, the runnable bench code, and the up-to-date cross-bench landing page, go to **[`tests/benchmarks/`](../../tests/benchmarks/BENCHMARKS.md)** instead — specifically:
+
+- [`tests/benchmarks/BENCHMARKS.md`](../../tests/benchmarks/BENCHMARKS.md) — the current cross-bench landing page ("given my task and constraints, which provider × mode should I pick?").
+- [`tests/benchmarks/CLAUDE.md`](../../tests/benchmarks/CLAUDE.md) — how the bench harness is laid out, and how to add a new provider/model.
+- Each pipeline's own `EXPERIMENTS.md` (e.g. `tests/benchmarks/transform-blank/EXPERIMENTS.md`) — the running experiment log with every design decision's accuracy delta.
+
+A file here (e.g. [`2026-05-08-provider-bench.md`](2026-05-08-provider-bench.md)) is a **snapshot** — pricing, latency, and default-provider framing reflect what was true on that date and may since be stale. Treat it as historical evidence for a past decision, not a live reference.

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,0 +1,13 @@
+---
+last_updated: 2026-07-04
+---
+
+# Install deep-dives
+
+Supplementary detail for [`docs/install.md`](../install.md) — read that first; these are the "I need to know exactly what touches the system" documents, not a starting point.
+
+| Doc | What it covers |
+|---|---|
+| [`dependencies.md`](dependencies.md) | The complete dependency surface — every tool an install touches, who owns installing it (contained / vendored / system-with-consent / daemon-client), and who owns uninstalling it. |
+| [`walkthrough.md`](walkthrough.md) | A click-by-click, touch-counted walkthrough of all five integrations from "never heard of OpenCues" to working — what the installer does internally vs. what the user has to do by hand. |
+| [`tmux-prebuilt.md`](tmux-prebuilt.md) | How the shell integration's `oc-install-tmux` prebuilt tmux tarballs are built and published, so a fresh `opencues install shell` can skip the C-toolchain build path. |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,7 +10,7 @@ For the full list of features any integration should implement, see `features/RE
 
 ## Overview
 
-OpenCues has two directions of intent: **Cues** (LLM → user — alternatives offered on plain text) and **Blanks** (user → system — substitutions summoned via `_`). Cue-Blanks are blanks bound to a keyword, pulling external state (volume, stocks). Everything that touches the world is `_`-gated.
+OpenCues has two directions of intent: **Cues** (LLM → user — alternatives offered on plain text) and **Blanks** (user → system — substitutions summoned via `_`). Cue-Blanks are blanks bound to a keyword, pulling external state (volume, stocks). Everything that touches the world is `_`-gated. **Auditors** extend the Cues direction to the whole buffer — a continuous, revertable rewrite for one declared concern (grammar, clarity, tone, ...) instead of a per-word cycle; see `spec/auditor-spec.md` and [`docs/guides/adding-an-auditor.md`](guides/adding-an-auditor.md).
 
 The architecture has three layers:
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -6,13 +6,14 @@ This directory holds three open file-format standards — **Cues**, **Blanks**, 
 
 ## What the standard is
 
-OpenCues defines three surfaces over text (see [`../concept.md`](../concept.md)):
+The whole system reduces to two directions of intent (see [`../concept.md`](../concept.md)):
 
 | Direction | Surface | Operates on | File format | Trigger |
 |---|---|---|---|---|
 | LLM → user | **Cues** — alternatives surfaced over plain text | one word | [`cue-spec.md`](./cue-spec.md) | regex `match` / `keywords` list |
 | user → system | **Blanks** — `_`-gated value substitutions | one `_` slot | [`blank-spec.md`](./blank-spec.md) | `blankShapes`/`blankKeywords` lead the line, `_` at trailing edge |
-| LLM → buffer | **Auditors** — composed inline rewrite concerns | the whole buffer | [`auditor-spec.md`](./auditor-spec.md) | every rewrite cycle (no per-source gating) |
+
+**Auditors** are a continuous, whole-buffer variant of the Cues direction — one declared concern (grammar, clarity, tone, ...) applied as an ongoing, revertable rewrite instead of a per-word cycle a user has to accept. Same "the system offers, you didn't ask" contract as Cues; different scope (whole buffer) and cadence (every rewrite tick, not per word). Own file format ([`auditor-spec.md`](./auditor-spec.md)) and own conformance contract, same as the other two — the "variant" framing is conceptual, not a reduction in how normatively it's specified.
 
 The standard covers three source-folder entry files (`CUE.md`, `BLANK.md`, `AUDITOR.md`), the master files that aggregate them (`CUES.md`, `BLANKS.md`, `AUDITORS.md`), and the runtime contracts a conformant implementation must satisfy.
 


### PR DESCRIPTION
## Summary
Follow-up to a full docs-structure survey (root, `docs/`, `spec/`, `integrations/*`, `packages/*`).

**Auditors framing consistency.** `concept.md`, root `CLAUDE.md`, and `docs/overview.md` all still described OpenCues as reducing to "two ideas" (Cues + Blanks) with zero mention of Auditors, while `spec/README.md` already treated Auditors as a third parallel surface ("LLM → buffer"). Per explicit direction: kept the two-idea pitch as the core framing and repositioned Auditors as a continuous, whole-buffer **variant** of the Cues direction (same "system offers, you didn't ask" contract; different scope and cadence) rather than a third pure direction. Applied consistently across `concept.md` (new section + fixed a stale "all three" settings claim — fluid-blank has no toggle, it's hardcoded always-on; the real second toggle is `transform-blank-mode`), `CLAUDE.md`'s Project Overview, `docs/overview.md`, and `spec/README.md`'s surface table.

**Root `SPEC.md`**: was badly stale in its own right — "The `0.1` spec defines..." intro sentence when the file's own header said 0.4-alpha and the content list already spans 0.1–0.4 features (it does cover `AUDITORS.md` as item 5 — I'd initially misread it as missing entirely). Also had the same `identity-context-mode` stale-default bug (documented `off`, actual default `safe` since PR #161) found in every other doc this session. Repositioned as a short front-door pointer to `spec/README.md` (the fuller, better-maintained entry point) rather than duplicating its content — a structural fix for the exact staleness pattern that caused this bug in the first place.

**Missing indices**: `docs/install/` (3 files) and `docs/benchmarks/` (1 file) had no `README.md`, unlike every other `docs/` subdirectory. `docs/benchmarks/` additionally risked real confusion with `tests/benchmarks/` (the actual runnable bench code + live `BENCHMARKS.md` landing page) — added a `README.md` there specifically clarifying it holds dated historical snapshots, not live numbers, and pointing at `tests/benchmarks/` for current data.

**`docs/README.md` completeness**: its own directory tree omitted `docs/benchmarks/`, `docs/launch/`, `docs/maintainers/`, and `docs/blog*/` entirely — fixed to list every real subdirectory, closing the exact "index doesn't list everything" risk the page itself warns about in its own "Keeping this map honest" section.

**Three SECURITY docs, no cross-links**: root `SECURITY.md` (vulnerability reporting + a coarser trust-model summary), `docs/architecture/security-audit.md` (the canonical, actively-maintained technical threat model), and `spec/SECURITY.md` (the standard's own normative security claims) had zero references to each other except `spec/SECURITY.md`'s existing links out. Added the missing cross-links both directions, explicitly stating `security-audit.md` wins if the summaries ever disagree.

Root `SECURITY.md`'s own "Boundaries"/"Threat actors"/"Known gaps" sections substantially duplicate (and look less current than) `security-audit.md`'s 26-row table — flagged via the new cross-link rather than restructured/trimmed in this pass, since deleting real content there is a bigger call than this pass's other fixes.

## Test plan
- [x] Full link-check — zero new broken links (12 pre-existing, unrelated)
- [x] `bash scripts/lint-legacy-names.sh` / `lint-version-bump.sh` both clean (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CrGD7J1LHUxx9vjZuSv6p