### PR TITLE
docs: retire the boy/girl/kid word-swap example

### DIFF
--- a/docs/architecture/transform-blank.md
+++ b/docs/architecture/transform-blank.md
@@ -39,8 +39,8 @@ substitutes an answer at `_`. But people often want the opposite:
 instruction.
 
 ```
-You type:   the boy ran fast change boy to girl _
-You see:    the girl ran fast
+You type:   she don't like it when he go there fix grammar _
+You see:    she doesn't like it when he goes there
 ```
 
 That's transform-blank. The instruction is the imperative phrase next
@@ -83,7 +83,7 @@ non-transform `_` is acceptable for the cleanliness gain.
 
 ```
 <TARGET> <INSTRUCTION> _
-e.g.  the boy ran fast change boy to girl _
+e.g.  she don't like it when he go there fix grammar _
 ```
 
 This is the only shape live typing can produce: `_` triggers the
@@ -213,7 +213,7 @@ carry real semantic load and should NOT be pruned. The notable ones:
 - **Composed instructions** ("X and Y") — pipe-join in `INSTRUCTION`
   (`make past tense | remove pronouns`) and apply BOTH simultaneously;
   the result must be grammatical under both constraints. Don't split a
-  single edit (`change boy to girl`, `make it formal`).
+  single edit (`fix grammar`, `make it formal`).
 - **Preserve structure** — `\n\n` paragraph breaks round-trip verbatim;
   multi-paragraph in → multi-paragraph out.
 - **Markdown styling** — `make X bold` / `italicize Y` / etc. decorate
@@ -518,10 +518,10 @@ determined by benchmarks, not preference.
 With `debug-mode: on`, the source emits a structured trace:
 
 ```
-TransformBlank: starting (textLen=42, blankIdx=4)
+TransformBlank: starting (textLen=48, blankIdx=10)
 TransformBlank: identity-context: injected (mode=safe, 3 fields)
-TransformBlank FUSED (351ms, max_tokens=820): verdict=TRANSFORM, instruction="change boy to girl"
-TransformBlank: substituting "the boy ran fast change boy to girl _" → "the girl ran fast" (origLen=42, rewriteLen=18, defAt=0)
+TransformBlank FUSED (351ms, max_tokens=820): verdict=TRANSFORM, instruction="fix grammar"
+TransformBlank: substituting "she don't like it when he go there fix grammar _" → "she doesn't like it when he goes there" (origLen=48, rewriteLen=38, defAt=0)
 ```
 
 The log function is wired in `resolver.ts:rebuildResolver` as

--- a/docs/blog-resources/05-inline-prompting-blanks.md
+++ b/docs/blog-resources/05-inline-prompting-blanks.md
@@ -30,7 +30,7 @@ unicode for em dash _         → "U+2014"
 4 * 12 = _                    → "48"
 nvda _                        → "121.45"     (live stock price)
 agentically fix typos _ ...   → arms a continuous LLM editing loop
-change boy to girl _ the boy ran fast → "the girl ran fast"
+fix grammar _ she don't like it when he go there → "she doesn't like it when he goes there"
 ```
 
 Same character, doing wildly different jobs depending on context.

--- a/docs/blog-resources/06-inline-agents.md
+++ b/docs/blog-resources/06-inline-agents.md
@@ -4,8 +4,8 @@ For blog post #5: "Inline Agents".
 
 OpenCues has TWO inline-agent surfaces, both invoked through `_`:
 
-1. **Transform-blank** (one-shot) — type `change boy to girl _ the boy ran
-   fast`, the system rewrites the surrounding text once.
+1. **Transform-blank** (one-shot) — type `fix grammar _ she don't like it
+   when he go there`, the system rewrites the surrounding text once.
 2. **Agent-task** (continuous) — type `agentically correct spelling _`, the
    system arms a debounced loop that re-evaluates the whole document on
    every pause and applies edits inline.
@@ -24,13 +24,13 @@ From `docs/architecture/transform-blank.md`:
 > to **edit** the text around `_` per an instruction.
 >
 > ```
-> You type:   change boy to girl _ the boy ran fast
-> You see:    the girl ran fast
+> You type:   fix grammar _ she don't like it when he go there
+> You see:    she doesn't like it when he goes there
 > ```
 
 Two layouts both work:
-- `<INSTRUCTION> _ <TARGET>` — `change boy to girl _ the boy ran fast`
-- `<TARGET> <INSTRUCTION> _` — `the boy ran fast change boy to girl _`
+- `<INSTRUCTION> _ <TARGET>` — `fix grammar _ she don't like it when he go there`
+- `<TARGET> <INSTRUCTION> _` — `she don't like it when he go there fix grammar _`
 
 > Real users mostly do (b) — they type their text first, then realize they
 > want to transform it, and add the imperative at the end.

--- a/docs/features/transform-blank.md
+++ b/docs/features/transform-blank.md
@@ -5,15 +5,15 @@ runtime rewrites the surrounding text per the instruction (or generates
 new content from scratch when no surrounding text is given).
 
 ```
-You type:   the boy ran fast change boy to girl _
-You see:    the girl ran fast
-Press ↓ :   the boy ran fast change boy to girl _   (revert)
-Press ↑ :   the girl ran fast                        (apply)
+You type:   she don't like it when he go there fix grammar _
+You see:    she doesn't like it when he goes there
+Press ↓ :   she don't like it when he go there fix grammar _   (revert)
+Press ↑ :   she doesn't like it when he goes there              (apply)
 ```
 
 Where **fluid-blank** answers questions at `_` ("capital of france _" → Paris),
-**transform-blank** edits text around `_` ("the boy ran change boy to girl _"
-→ "the girl ran") OR generates new content ("write a poem _" → a poem).
+**transform-blank** edits text around `_` ("she don't like it fix grammar _"
+→ "she doesn't like it") OR generates new content ("write a poem _" → a poem).
 
 ---
 
@@ -41,7 +41,7 @@ fluid-blank-mode: on  # both blank handlers can coexist; instructions go to
 
 ```
 <TARGET> <INSTRUCTION> _
-e.g.  the boy ran fast change boy to girl _
+e.g.  she don't like it when he go there fix grammar _
 ```
 
 Body first, instruction last, `_` triggers the rewrite. This is the
@@ -110,7 +110,7 @@ case end-to-end on Groq gpt-oss-120b.
 
 | Category | Example |
 |---|---|
-| literal swap | `the boy ran change boy to girl _` |
+| literal swap | `the cat sat on the mat change cat to dog _` |
 | multi-span | `price is 10 USD plus 2 USD replace USD with EUR _` |
 | concept | `he gave the book to John he/she swap _` |
 | transform | `I run to the store make past tense _` |
@@ -130,7 +130,7 @@ case end-to-end on Groq gpt-oss-120b.
 | creative-rewrite | `Hello, where is the bathroom? translate to pirate speak _` |
 | format-transform | `I need eggs, milk, bread, cheese convert to bullet points _` |
 | multi-paragraph | `<2-3 paragraph story> change protagonist to wizard _` |
-| conditional | `The boy ran. ... change boy to girl but not in the second sentence _` |
+| conditional | `The cat sat. ... change cat to dog but not in the second sentence _` |
 
 ### Weak categories (50-70%)
 
@@ -170,9 +170,9 @@ With `debug-mode: on` the runtime emits a trace for the fused call to
 `/tmp/opencues.log`:
 
 ```
-TransformBlank: starting (textLen=42, blankIdx=4)
-TransformBlank FUSED (351ms, max_tokens=820, source=trailing): verdict=TRANSFORM, instruction="change boy to girl", target="the boy ran fast", rewrite="the girl ran fast"
-TransformBlank: substituting "the boy ran fast change boy to girl _" → "the girl ran fast" (origLen=42, rewriteLen=18, defAt=0)
+TransformBlank: starting (textLen=48, blankIdx=10)
+TransformBlank FUSED (351ms, max_tokens=820, source=trailing): verdict=TRANSFORM, instruction="fix grammar", target="she don't like it when he go there", rewrite="she doesn't like it when he goes there"
+TransformBlank: substituting "she don't like it when he go there fix grammar _" → "she doesn't like it when he goes there" (origLen=48, rewriteLen=38, defAt=0)
 ```
 
 Composed instructions show the pipe-joined instruction in the same

--- a/packages/opencues-core/src/sources/build-sources.ts
+++ b/packages/opencues-core/src/sources/build-sources.ts
@@ -136,7 +136,7 @@ export interface BuildSourcesOptions {
    * Enable the transform-blank source — a single-call FUSED handler
    * for IMPERATIVE instructions placed next to `_`. Where
    * fluid-blank handles "capital of france _", transform-blank handles
-   * "change boy to girl _ the boy ran fast". Priority 93 — sits ABOVE
+   * "fix grammar _ she don't like it when he go there". Priority 93 — sits ABOVE
    * fluid-blank (92) and only claims when the surrounding text starts
    * with an imperative verb. See transform-blank-source.ts and
    * tests/benchmarks/transform-blank/.
@@ -646,7 +646,7 @@ export function buildSourcesFromConfig(
 
   // Transform-blank: IMPERATIVE-instruction handler (EXTRACT + APPLY +
   // VERIFY). Priority 93 — sits ABOVE fluid-blank (92), so an
-  // imperative-shaped input ("change boy to girl _ ...") routes here
+  // imperative-shaped input ("fix grammar _ ...") routes here
   // instead of being treated as a lookup. Cedes to keyword-bound
   // BlankSource if applicable AND only claims when the surrounding text
   // starts with an imperative verb (heuristic in supports()).

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -1057,7 +1057,7 @@ export class Resolver {
 
       // Pass the diff-based freshness signal through so the debounced
       // resolve also unblocks blank sources when the `_` is mid-buffer
-      // (e.g. `change boy to girl _ the boy ran fast` — TransformBlank-
+      // (e.g. `fix grammar _ she don't like it when he go there` — TransformBlank-
       // style "instruction _ target"). Without this, only trailing-`_`
       // patterns would arm via the diff fallback; middle-`_` patterns
       // would silently no-op because the explicit-keystroke arm path


### PR DESCRIPTION
## Summary
- "the boy ran fast" / "change boy to girl" was the default illustration for TransformBlank across `docs/features/transform-blank.md`, `docs/architecture/transform-blank.md`, two blog-post resource files, and doc comments in `build-sources.ts` / `resolver.ts` — a weak, overused example.
- Swapped every illustrative occurrence for a sentence-level grammar fix: `fix grammar _ she don't like it when he go there` → `she doesn't like it when he goes there`. TransformBlank is benchmarked on plenty of non-word-swap categories (grammar, tone, tense, formatting) and this is a more representative flagship example than a single-word substitution.
- The two capability-table rows in `docs/features/transform-blank.md` that specifically document the **literal swap** and **conditional** benchmark categories (genuinely about word substitution, by definition) kept the word-swap shape but got a fresh pair (`cat`/`dog`) instead of dropping it.
- Recomputed the debug-log trace numbers (`textLen`/`blankIdx`/`origLen`/`rewriteLen`) to match the new example string exactly, so the log illustration stays internally consistent.

**Scope** (per explicit discussion): docs + code comments only. Untouched on purpose:
- The live `FUSED_SYSTEM` prompt in `transform-blank-source.ts` (editing it requires a cerebras + groq bench re-run per `CLAUDE.md`'s discipline for prompt changes — out of scope for this pass)
- Active test/benchmark fixtures (`transform-blank.scenarios.test.ts`, `tests/benchmarks/transform-blank/cases.ts`, bench scripts)
- `tests/benchmarks/transform-blank/archive/` — retired experiment logs kept as historical record

## Test plan
- [x] Grepped all six touched files for `boy|girl|kid` — clean
- [x] `bash scripts/lint-legacy-names.sh` — clean
- [x] `bash scripts/lint-version-bump.sh` — clean (docs/comments only)
- [x] Verified the two edited `.ts` files only touch comment lines (no code/logic changes)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013CrGD7J1LHUxx9vjZuSv6p