### PR TITLE
docs: fix instruction-first TransformBlank examples, use a bigger rewrite

### DIFF
--- a/docs/architecture/transform-blank.md
+++ b/docs/architecture/transform-blank.md
@@ -39,8 +39,8 @@ substitutes an answer at `_`. But people often want the opposite:
 instruction.
 
 ```
-You type:   she don't like it when he go there fix grammar _
-You see:    she doesn't like it when he goes there
+You type:   hey can u send me that report when u get a sec make this formal _
+You see:    Could you please send me that report at your earliest convenience?
 ```
 
 That's transform-blank. The instruction is the imperative phrase next
@@ -83,7 +83,7 @@ non-transform `_` is acceptable for the cleanliness gain.
 
 ```
 <TARGET> <INSTRUCTION> _
-e.g.  she don't like it when he go there fix grammar _
+e.g.  hey can u send me that report when u get a sec make this formal _
 ```
 
 This is the only shape live typing can produce: `_` triggers the
@@ -518,10 +518,10 @@ determined by benchmarks, not preference.
 With `debug-mode: on`, the source emits a structured trace:
 
 ```
-TransformBlank: starting (textLen=48, blankIdx=10)
+TransformBlank: starting (textLen=65, blankIdx=15)
 TransformBlank: identity-context: injected (mode=safe, 3 fields)
-TransformBlank FUSED (351ms, max_tokens=820): verdict=TRANSFORM, instruction="fix grammar"
-TransformBlank: substituting "she don't like it when he go there fix grammar _" → "she doesn't like it when he goes there" (origLen=48, rewriteLen=38, defAt=0)
+TransformBlank FUSED (351ms, max_tokens=820): verdict=TRANSFORM, instruction="make this formal"
+TransformBlank: substituting "hey can u send me that report when u get a sec make this formal _" → "Could you please send me that report at your earliest convenience?" (origLen=65, rewriteLen=66, defAt=0)
 ```
 
 The log function is wired in `resolver.ts:rebuildResolver` as

--- a/docs/blog-resources/05-inline-prompting-blanks.md
+++ b/docs/blog-resources/05-inline-prompting-blanks.md
@@ -30,7 +30,7 @@ unicode for em dash _         → "U+2014"
 4 * 12 = _                    → "48"
 nvda _                        → "121.45"     (live stock price)
 agentically fix typos _ ...   → arms a continuous LLM editing loop
-fix grammar _ she don't like it when he go there → "she doesn't like it when he goes there"
+hey can u send me that report when u get a sec make this formal _ → "Could you please send me that report at your earliest convenience?"
 ```
 
 Same character, doing wildly different jobs depending on context.

--- a/docs/blog-resources/06-inline-agents.md
+++ b/docs/blog-resources/06-inline-agents.md
@@ -4,8 +4,9 @@ For blog post #5: "Inline Agents".
 
 OpenCues has TWO inline-agent surfaces, both invoked through `_`:
 
-1. **Transform-blank** (one-shot) — type `fix grammar _ she don't like it
-   when he go there`, the system rewrites the surrounding text once.
+1. **Transform-blank** (one-shot) — type `hey can u send me that report
+   when u get a sec make this formal _`, the system rewrites the surrounding
+   text once.
 2. **Agent-task** (continuous) — type `agentically correct spelling _`, the
    system arms a debounced loop that re-evaluates the whole document on
    every pause and applies edits inline.
@@ -24,16 +25,16 @@ From `docs/architecture/transform-blank.md`:
 > to **edit** the text around `_` per an instruction.
 >
 > ```
-> You type:   fix grammar _ she don't like it when he go there
-> You see:    she doesn't like it when he goes there
+> You type:   hey can u send me that report when u get a sec make this formal _
+> You see:    Could you please send me that report at your earliest convenience?
 > ```
 
-Two layouts both work:
-- `<INSTRUCTION> _ <TARGET>` — `fix grammar _ she don't like it when he go there`
-- `<TARGET> <INSTRUCTION> _` — `she don't like it when he go there fix grammar _`
-
-> Real users mostly do (b) — they type their text first, then realize they
-> want to transform it, and add the imperative at the end.
+`_` fires the moment you type it, so live typing can only ever produce
+`<TARGET> <INSTRUCTION> _` — you type the body first, then realize you
+want to transform it, and add the imperative at the end. (The parser
+also accepts an inverted `<INSTRUCTION> _ <TARGET>` shape and a
+sandwiched form, for pasted text or bench inputs that arrive as one
+complete string — see `docs/architecture/transform-blank.md`.)
 
 ### The 3-pass pipeline
 

--- a/docs/features/transform-blank.md
+++ b/docs/features/transform-blank.md
@@ -5,15 +5,16 @@ runtime rewrites the surrounding text per the instruction (or generates
 new content from scratch when no surrounding text is given).
 
 ```
-You type:   she don't like it when he go there fix grammar _
-You see:    she doesn't like it when he goes there
-Press ↓ :   she don't like it when he go there fix grammar _   (revert)
-Press ↑ :   she doesn't like it when he goes there              (apply)
+You type:   hey can u send me that report when u get a sec make this formal _
+You see:    Could you please send me that report at your earliest convenience?
+Press ↓ :   hey can u send me that report when u get a sec make this formal _   (revert)
+Press ↑ :   Could you please send me that report at your earliest convenience?  (apply)
 ```
 
 Where **fluid-blank** answers questions at `_` ("capital of france _" → Paris),
-**transform-blank** edits text around `_` ("she don't like it fix grammar _"
-→ "she doesn't like it") OR generates new content ("write a poem _" → a poem).
+**transform-blank** rewrites the surrounding text per the instruction (a full
+register change, a tense flip, a reformat — not just a word swap) OR generates
+new content from scratch ("write a poem _" → a poem).
 
 ---
 
@@ -41,7 +42,7 @@ fluid-blank-mode: on  # both blank handlers can coexist; instructions go to
 
 ```
 <TARGET> <INSTRUCTION> _
-e.g.  she don't like it when he go there fix grammar _
+e.g.  hey can u send me that report when u get a sec make this formal _
 ```
 
 Body first, instruction last, `_` triggers the rewrite. This is the
@@ -170,9 +171,9 @@ With `debug-mode: on` the runtime emits a trace for the fused call to
 `/tmp/opencues.log`:
 
 ```
-TransformBlank: starting (textLen=48, blankIdx=10)
-TransformBlank FUSED (351ms, max_tokens=820, source=trailing): verdict=TRANSFORM, instruction="fix grammar", target="she don't like it when he go there", rewrite="she doesn't like it when he goes there"
-TransformBlank: substituting "she don't like it when he go there fix grammar _" → "she doesn't like it when he goes there" (origLen=48, rewriteLen=38, defAt=0)
+TransformBlank: starting (textLen=65, blankIdx=15)
+TransformBlank FUSED (351ms, max_tokens=820, source=trailing): verdict=TRANSFORM, instruction="make this formal", target="hey can u send me that report when u get a sec", rewrite="Could you please send me that report at your earliest convenience?"
+TransformBlank: substituting "hey can u send me that report when u get a sec make this formal _" → "Could you please send me that report at your earliest convenience?" (origLen=65, rewriteLen=66, defAt=0)
 ```
 
 Composed instructions show the pipe-joined instruction in the same

--- a/packages/opencues-core/src/sources/build-sources.ts
+++ b/packages/opencues-core/src/sources/build-sources.ts
@@ -136,7 +136,7 @@ export interface BuildSourcesOptions {
    * Enable the transform-blank source — a single-call FUSED handler
    * for IMPERATIVE instructions placed next to `_`. Where
    * fluid-blank handles "capital of france _", transform-blank handles
-   * "fix grammar _ she don't like it when he go there". Priority 93 — sits ABOVE
+   * "hey can u send me that report make this formal _". Priority 93 — sits ABOVE
    * fluid-blank (92) and only claims when the surrounding text starts
    * with an imperative verb. See transform-blank-source.ts and
    * tests/benchmarks/transform-blank/.
@@ -646,7 +646,7 @@ export function buildSourcesFromConfig(
 
   // Transform-blank: IMPERATIVE-instruction handler (EXTRACT + APPLY +
   // VERIFY). Priority 93 — sits ABOVE fluid-blank (92), so an
-  // imperative-shaped input ("fix grammar _ ...") routes here
+  // imperative-shaped input ("... make this formal _") routes here
   // instead of being treated as a lookup. Cedes to keyword-bound
   // BlankSource if applicable AND only claims when the surrounding text
   // starts with an imperative verb (heuristic in supports()).

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -1057,7 +1057,7 @@ export class Resolver {
 
       // Pass the diff-based freshness signal through so the debounced
       // resolve also unblocks blank sources when the `_` is mid-buffer
-      // (e.g. `fix grammar _ she don't like it when he go there` — TransformBlank-
+      // (e.g. `make this formal _ hey can u send me that report` — TransformBlank-
       // style "instruction _ target"). Without this, only trailing-`_`
       // patterns would arm via the diff fallback; middle-`_` patterns
       // would silently no-op because the explicit-keystroke arm path


### PR DESCRIPTION
## Summary
- The prior boy/girl retirement pass (#242) accidentally introduced `fix grammar _ <target>` — instruction before the blank, target after — in `docs/blog-resources/05` and `06`. That's the wrong shape for a user-facing example: `docs/architecture/transform-blank.md` already states the rule explicitly (`_` fires the instant you type it, so anything after it never reaches the source; user-facing examples should use `<TARGET> <INSTRUCTION> _` exclusively). Fixed both files back to the correct shape.
- Also upgraded the example itself: swapped the small "fix grammar" nitpick for a bigger, more representative rewrite (`hey can u send me that report ... make this formal _` → a properly formalised sentence) across every doc that used it — grammar-nitpick examples read as weak/word-level next to what TransformBlank is actually good at (full-register rewrites, tense/format changes).
- Recomputed every debug-log trace's `textLen`/`blankIdx`/`origLen`/`rewriteLen` to match the new example string.
- `resolver.ts`'s comment is a deliberate exception — it's specifically illustrating the mid-buffer (paste/edit) `_` case, so it keeps the instruction-first shape on purpose (that's the point being made), just with the upgraded example text.

## Test plan
- [x] Grepped all six files for the old text and for any remaining instruction-first shape in user-facing docs — clean
- [x] `bash scripts/lint-legacy-names.sh` — clean
- [x] `bash scripts/lint-version-bump.sh` — clean (docs/comments only)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013CrGD7J1LHUxx9vjZuSv6p