### PR TITLE
docs(cli-reference): add quick-orientation section

### DIFF
--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -30,6 +30,21 @@ status + command list `--help` prints, so scripting is unaffected.
 
 ---
 
+## The 5 you'll actually use
+
+| Command | What it does |
+|---|---|
+| `opencues install <host>` | One-time setup for an editor/host |
+| `opencues run <host>` | Launch it |
+| `opencues set-key <provider> <key>` | Add an LLM API key |
+| `opencues doctor` | Something's wrong — diagnostics |
+| `opencues update` | Pull latest + rebuild everything |
+
+Everything below is the full reference. For every command sorted by
+frequency instead, see the [cheat sheet](cli-cheatsheet.md).
+
+---
+
 ## Setup
 
 ### `install <host>` — install a host integration


### PR DESCRIPTION
## Summary
- `docs/guides/cli-reference.md` dropped straight from the intro into the full 27-subcommand reference (Setup/Authoring/Run-inspect) with no on-ramp — someone landing here (e.g. from the README's new CLI badge) got exhaustive detail before orientation.
- Added a short "The 5 you'll actually use" table right after the intro: `install`, `run`, `set-key`, `doctor`, `update` — the commands a new user actually needs — then points to `cli-cheatsheet.md` for the full by-frequency list instead of duplicating it.

## Test plan
- [x] `bash scripts/lint-legacy-names.sh` — clean
- [x] `bash scripts/lint-version-bump.sh` — clean (docs-only)
- [x] New section heading anchor (`#the-5-youll-actually-use`) verified against GitHub's slug rules for the linking README PR

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013CrGD7J1LHUxx9vjZuSv6p