### PR TITLE
docs(spec): fix hot-reload cadence description in core.md

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -14,6 +14,10 @@ breaking.
 
 ## [Unreleased]
 
+### Fixed
+
+- `core.md` § Hot-reload: corrected the reference-runtime cadence description. The reference implementation reloads config off user input with a ~2s debounce plus a ~5s background poll (`config-loader.ts`), not a ~100ms filesystem poll — the previously cited `event-bridge.ts` `POLL_INTERVAL_MS` timer is the inject-file/state poller, unrelated to config reload. The SHOULD pickup window is restated as "within a couple of seconds" to match the reference implementation (was "a few hundred milliseconds", which the reference runtime itself never met).
+
 ---
 
 ## [0.4.0-alpha] — 2026-06-30

--- a/spec/core.md
+++ b/spec/core.md
@@ -230,7 +230,7 @@ The constants `HOSTS` and `NATIVE_HOSTS` in OpenCues' `@opencues/core` library (
 
 ## Hot-reload
 
-A conformant runtime SHOULD detect changes to any file in the search path and apply them without restart. The reference cadence is a fixed-interval filesystem poll (~100ms in `@opencues/runtime`, see `event-bridge.ts`'s `POLL_INTERVAL_MS`); a runtime MAY instead drive the poll off user-input events as long as edits are picked up within a few hundred milliseconds of saving. Atomic / locked files SHOULD be skipped until they settle.
+A conformant runtime SHOULD detect changes to any file in the search path and apply them without restart, picking edits up within a couple of seconds of saving. The mechanism is the runtime's choice — fixed-interval polling, OS file watchers, or user-input-driven re-checks all qualify. The reference cadence in `@opencues/runtime` is a user-input-driven reload with a ~2s debounce (`config-loader.ts`'s `reloadDebounceMs`) plus a ~5s background poll (`backgroundPollMs`) so edits land even when the user isn't typing. (The ~100ms `POLL_INTERVAL_MS` timer in `event-bridge.ts` is the inject-file/state poller, not config reload — a prior revision of this section cited it in error.) Atomic / locked files SHOULD be skipped until they settle.
 
 A runtime that mutates files in the search path (e.g. an `OpenCuesSettingsBlank`-equivalent) MUST suppress its own re-read for at least 2 seconds after writing, to avoid races where the in-memory state and the file disagree mid-flight.
 


### PR DESCRIPTION
## Summary
`core.md` § Hot-reload claimed the reference cadence is *"a fixed-interval filesystem poll (~100ms …, see `event-bridge.ts`'s `POLL_INTERVAL_MS`)"*. That timer is the **inject-file/state poller**, not config reload. The real config hot-reload in `@opencues/runtime` is keystroke-driven with a **~2s debounce** (`config-loader.ts` `reloadDebounceMs`) plus a **~5s background poll** (`backgroundPollMs`).

Changes:
- Reference cadence now described accurately (config-loader debounce + background poll), with a parenthetical explicitly disambiguating the `event-bridge.ts` timer so the confusion doesn't recur.
- The SHOULD pickup window is restated as **"within a couple of seconds"** — the prior "a few hundred milliseconds" was never met by the reference implementation itself.
- Mechanism is stated as the runtime's choice (polling / watchers / input-driven), consistent with `spec/conformance/README.md` which already says the standard doesn't pin polling intervals.
- `spec/CHANGELOG.md`: entry under `[Unreleased]`.

**No SPEC_VERSION bump** — per the bump rules this is a corrected description, not a wire-format / frontmatter / scalar change. Flagging per the reviewer-eyeball rule for spec-only PRs.

Context: found while auditing opencues.com against the repo — the website had copied the erroneous 100ms claim from this section.

## Testing
- `grep` confirms no other spec file repeats the stale claim.
- Docs-only; `[skip version-bump]` marker included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)