### PR TITLE
docs: remove references to the retired blank re-evaluation contract

### DIFF
--- a/docs/blog-resources/00-foundations-cues-and-blanks.md
+++ b/docs/blog-resources/00-foundations-cues-and-blanks.md
@@ -82,10 +82,6 @@ This is the rich vein:
    That reframe — autocomplete-the-user-controls vs. autocomplete-the-system-
    controls — is genuinely novel as an interaction primitive.
 
-4. **Re-evaluation contract.** Blanks are *re-evaluated on every edit*. A blank
-   value is never permanent — the surrounding text changing means the blank
-   re-asks. This is unusual; most "fill" operations are commit-once.
-
 ## Where this material lives
 
 - `concept.md` — the canonical 75-line writeup

--- a/docs/blog-resources/05-inline-prompting-blanks.md
+++ b/docs/blog-resources/05-inline-prompting-blanks.md
@@ -88,22 +88,12 @@ single handle through which the user can:
 One character. Six (or more) jobs. Which job runs is decided by the
 *context around the `_`*, not by the user picking a mode.
 
-## Re-evaluation: blanks are never permanent
+## Ownership: what's filled stays filled
 
-From `docs/glossary.md`:
-> Blanks are automatically computed and **re-evaluated on every edit**. When
-> the surrounding text changes, the blank's value updates. This means a
-> blank is never permanently filled — it can always return to `_` and be
-> re-evaluated in its new context.
-
-This is the second novel HCI piece. Most "fill" UI is commit-once: you
-accept a suggestion, it becomes part of your text, the suggestion machinery
-forgets about it. Blanks stay live. Edit the surrounding context and the
-blank value updates.
-
-The implementation lock that keeps the LLM from clobbering a blank value
-*you've already accepted* is `metadata.blankName` on the WordDef. Only the
-user can clear it (by editing the word).
+Once a blank resolves, the result belongs to the user. The implementation
+lock that keeps the LLM from clobbering a blank value *you've already
+accepted* is `metadata.blankName` on the WordDef. Only the user can clear
+it (by editing the word).
 
 ## Keyword matching: the binding rule
 

--- a/docs/blog-resources/11-flow-state-mechanisms.md
+++ b/docs/blog-resources/11-flow-state-mechanisms.md
@@ -107,23 +107,7 @@ re-install. No build.
 For users tuning their own setup, this is enormous. They never have to
 leave the artifact (their prompt) to fix the tool.
 
-## Mechanism 8: Re-evaluation on edit — blanks stay live
-
-From `docs/glossary.md`:
-> Blanks are automatically computed and re-evaluated on every edit. When
-> the surrounding text changes, the blank's value updates. This means a
-> blank is never permanently filled — it can always return to `_` and be
-> re-evaluated in its new context.
-
-If you fix a typo in `4 * 12 = _`'s context, the answer adjusts. The user
-doesn't have to re-trigger anything. The system *stays caught up to the
-text*.
-
-This is the opposite of commit-once autocomplete (which forgets after
-acceptance). Re-evaluation means blanks compose with editing rather than
-fighting it.
-
-## Mechanism 9: Auto-Submit (blanks-only)
+## Mechanism 8: Auto-Submit (blanks-only)
 
 > **Auto-Submit** — Analysis fires automatically after a pause in typing.
 > Only unseen words are sent to the LLM.
@@ -132,7 +116,7 @@ The user doesn't press a "go" button. Pause typing → analysis fires.
 Pulse → results dim words. The flow continues through the implicit-trigger
 moment.
 
-## Mechanism 10: The 500ms debounce — one clock for everything
+## Mechanism 9: The 500ms debounce — one clock for everything
 
 From `docs/architecture/agent-task.md`:
 
@@ -144,7 +128,7 @@ When the agent-task feature was added, it didn't introduce its own debounce
 "the system processes after I pause" rhythm, not multiple competing
 heartbeats.
 
-## Mechanism 11: Cursor-adjacency exclusion — never edit the word you're typing
+## Mechanism 10: Cursor-adjacency exclusion — never edit the word you're typing
 
 From `docs/architecture/agent-task.md`:
 
@@ -158,7 +142,7 @@ Cursor-adjacent words are excluded from evaluation. The user is *typing*
 
 This is a small specific rule with a big flow consequence.
 
-## Mechanism 12: Ownership locks — what's filled stays filled
+## Mechanism 11: Ownership locks — what's filled stays filled
 
 From `docs/features/cue-blanks.md`:
 
@@ -170,7 +154,7 @@ Once a blank is filled (`volume 50%`), no LLM call will overwrite that
 50%. The user-committed value is locked. The user knows the system won't
 silently mutate things behind them.
 
-## Mechanism 13: Stop semantics that respect ongoing work
+## Mechanism 12: Stop semantics that respect ongoing work
 
 From `docs/architecture/agent-task.md`:
 
@@ -185,7 +169,7 @@ When you stop the agent, the agent's existing work doesn't vanish. You
 keep what you wanted, revert what you didn't, at your own pace. No
 modal "do you want to keep all these edits?" dialog.
 
-## Mechanism 14: The "secondary display" abstraction
+## Mechanism 13: The "secondary display" abstraction
 
 The cue-tip is shown in a host-specific surface (status line in CC,
 tooltip in Chrome, footer in OC). It's *outside the input*. The text

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -42,8 +42,6 @@ All three share the same navigable system — you move between words and interac
 
 **Blank** — An underscore (`_`) placed by the user as a cue to the system: "fill this in." The direction is reversed compared to regular cues — the user is cueing the system, not the other way around.
 
-Blanks are automatically computed and **re-evaluated on every edit**. When the surrounding text changes, the blank's value updates. This means a blank is never permanently filled — it can always return to `_` and be re-evaluated in its new context.
-
 Blanks come in two flavours: **keyword-bound** (a registered keyword next to `_` claims the slot — `volume _`, `nvda _`, `define X _`) and **fluid** (no keyword match — `FluidBlankSource` segments the lookup phrase and answers it: `capital of france _` → `Paris`, `4 * 12 = _` → `48`, `unicode for em dash _` → `U+2014`).
 
 **Think of blanks as user-placed autocomplete.** Unlike traditional autocomplete that guesses what comes next, blanks let you decide *where* the completion appears. This works anywhere — LLM prompts, documents, mobile text fields — and enables new interaction paradigms where the user and system collaborate fluidly before submission.


### PR DESCRIPTION
## Summary
The "blanks are re-evaluated on every edit / never permanently filled" contract is retired: a filled blank keeps its value until the user edits it, and an unresolved `_` stays literal. Four docs still advertised it:

- `docs/glossary.md` — paragraph deleted.
- `blog-resources/00-foundations` — "Re-evaluation contract" item deleted (was the last numbered item, no renumbering).
- `blog-resources/05-inline-prompting` — section replaced with the still-true **ownership lock** (`metadata.blankName`, user-only clear), which was buried inside it.
- `blog-resources/11-flow-state-mechanisms` — Mechanism 8 deleted, 9–14 renumbered to 8–13.

Swept and confirmed clean: `concept.md`, `spec/`, code comments, `docs/blog/posts/` (its "re-evaluated against the new prompt" lines are the agent-task feature, untouched). The website's three references (FAQ hub answer, glossary entry, vs-autocomplete page) are removed in the website repo alongside this PR.

## Noticed while in there (not changed)
`blog-resources/11`'s cursor-adjacency mechanism (now Mechanism 10) claims a word-level "never edit the word you're typing" exclusion; the actual protections are the prompt's in-flight-sentence rule + the three-way merge. Same class of stale claim — flagging for a follow-up rather than expanding this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)