### PR TITLE
docs(glossary): drop Linked Words entry + 'linked behaviour' from Cue

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -22,15 +22,13 @@ All three share the same navigable system — you move between words and interac
 
 ## Cues
 
-**Cue** — The complete package: a word that OpenCues has enriched with alternatives, a tip, linked behaviour, or other functionality. When someone says "I added a cue for ultrathink," they mean the word now appears indicated and has OpenCues functionality behind it.
+**Cue** — The complete package: a word that OpenCues has enriched with alternatives, a tip, or other functionality. When someone says "I added a cue for ultrathink," they mean the word now appears indicated and has OpenCues functionality behind it.
 
 **Indicated Cue** — The visual signal within the text that a cue exists. For example, a word appearing dimmed signals that alternatives and other information are available. The indicated cue is what the user sees; the cue is the full data behind it.
 
 **Alternatives** — The set of values a word can be replaced with when the user cycles (e.g., "happy" → "sad", "excited", "content"). The original word is always at index 0.
 
 **Cue-Tip** — Hint text displayed in the secondary display area when a word is highlighted. Provides context about what the word means or why an alternative was suggested. Sometimes shortened to "tip" in config files.
-
-**Linked Words** — Words that must change together when any one of them cycles. For example, changing "boy" also changes "his" to "her" to maintain agreement. Part of the cues system.
 
 **Multi-Word Group** — An alternative that consists of multiple words (e.g., "Sundar Pichai"). Tracked as a single unit that cycles together.
 


### PR DESCRIPTION
## Summary
Removes **Linked Words** from `docs/glossary.md` and the "linked behaviour" phrase from its Cue entry. The feature isn't shipping: `@opencues/core` carries a `linked?: number[]` field and the resolver merges it, but the runtime has **zero non-test consumers** — no cycling path changes linked words together. The website's FAQ glossary entry is removed in the website repo alongside this.

## Left for a product decision (not changed here)
The deeper references still describe linked words as a feature:
- `docs/features/linked-words.md` (whole feature doc) + its `docs/features/README.md` index row
- `docs/guides/porting-to-new-integration.md` steps 2-3 (instructs implementers to update all linked words' `currentAltIndex` on cycle)
- `docs/blog-resources/04-inline-cues.md` § "Linked words — agreement preservation"
- `docs/features/selector-satellite.md`'s "why this is not linked words" comparison
- `packages/opencues-core/prompts/linked.txt` + the `linked` field itself

If linked words is retired (not just unshipped), those want the same sweep plus a `lint-legacy-names` path pattern; if it's planned, they can stay. Flagging rather than deciding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)