### PR TITLE
style(cli): ●-ring status glyph everywhere — no ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — status output uses the `●`-ring house style everywhere (no ticks) (`opencues` CLI 0.2.34 → 0.2.35, `@opencues/runtime` 0.11.3 → 0.11.4)
+
+The CLI's own rule is "status is a leading coloured `●` — never a tick / cross / dot / ⚠" (`packages/opencues-cli/CLAUDE.md`), but `tag()` still rendered `🗸` / `⚠` / `✗` / `•` against it, across ~128 call sites in 18 command files. Redefined `tag()`'s UTF-8 glyphs to leading `●` rings (green ok / dim info / yellow warn / red err) — one change, every command now consistent, and alignment improves because the old `🗸` / `⚠` are 2-cell-wide emoji while `●` is single-cell. `TAGS_ASCII` (`[ok]` / `[warn]`) is unchanged for no-UTF8 terminals. Also converted the stray literal ticks: `cleanup`'s two `green('✓')`, `which`'s stale help text ("shows ✓ if present" → green `●`), and the **kata coach** line + lesson journal (`✓ Now:` → `● Now:`; runtime statusline surface). No test pinned the glyphs (one kata journal assertion updated to `●`).
+
 ### Added — buffer dehydration: `identity-context-mode: safe` is now bidirectional (`@opencues/core` 0.14.0 → 0.15.0, `@opencues/runtime` 0.11.2 → 0.11.3, `@opencues/chrome` 0.2.60 → 0.2.61, spec 0.5 → 0.6)
 
 **Observability** (core 0.15.0 / runtime 0.11.3): the outbound scrub now emits a structured **`transform-blank.dehydrated` / `fluid-blank.dehydrated`** event (`{ count }`) via the existing source-event channel, making the PII scrub assertable end-to-end on a real host (the buffer stays hydrated by design, so a text assertion can't prove the outbound scrub). Validated live on OpenCode + real Groq; pinned by agentic scenario `67-identity-context-dehydration-event` (asserts the event fired — runtime contract, not LLM output, per the agentic-scenario rule).

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "private": true,
   "description": "OpenCues — single-command front door for installing, configuring, and launching OpenCues across all editor integrations.",
   "bin": {

--- a/packages/opencues-cli/src/commands/cleanup.cjs
+++ b/packages/opencues-cli/src/commands/cleanup.cjs
@@ -25,7 +25,7 @@
 // when you add a new integration whose launch shape is novel.
 
 const { spawnSync } = require('node:child_process');
-const { bold, dim, red, green, yellow } = require('../lib/style.cjs');
+const { bold, dim, red, green, yellow, G } = require('../lib/style.cjs');
 
 // Per-host process matchers. Each entry maps a host name to one or
 // more substring patterns that uniquely identify a running instance.
@@ -176,7 +176,7 @@ module.exports = function cleanup(argv, _ctx) {
   if (orphans.length === 0) {
     if (!args.quiet) {
       const scope = args.host ? ` for host '${args.host}'` : '';
-      console.log(`${green('✓')} no orphan host processes${scope}`);
+      console.log(`${green(G.ringOn)} no orphan host processes${scope}`);
     }
     return 0;
   }
@@ -200,7 +200,7 @@ module.exports = function cleanup(argv, _ctx) {
   }
   if (!args.quiet) {
     const verb = args.force ? 'SIGKILL' : 'SIGTERM';
-    console.log(`${green('✓')} ${verb} ${killed}/${orphans.length}${failed ? ` (${failed} failed)` : ''}`);
+    console.log(`${green(G.ringOn)} ${verb} ${killed}/${orphans.length}${failed ? ` (${failed} failed)` : ''}`);
   }
   return failed > 0 ? 1 : 0;
 };

--- a/packages/opencues-cli/src/commands/which.cjs
+++ b/packages/opencues-cli/src/commands/which.cjs
@@ -108,6 +108,6 @@ function printHelp() {
   console.log('opencues which');
   console.log('');
   console.log('Print every path OpenCues touches: configuration search paths, install dirs');
-  console.log('per host, runtime IPC files, build artefacts. Each path shows ✓ if present,');
-  console.log('- if not. Useful for "is this thing actually installed?" diagnostics.');
+  console.log('per host, runtime IPC files, build artefacts. Each path shows a green ●');
+  console.log('if present, gray if not. Useful for "is this thing actually installed?" diagnostics.');
 }

--- a/packages/opencues-cli/src/lib/style.cjs
+++ b/packages/opencues-cli/src/lib/style.cjs
@@ -50,10 +50,15 @@ function wordmark() {
 // UTF-8: single glyph (visually punchy). ASCII: bracketed word (more
 // scannable when stripped of glyph affordance).
 const TAGS_UTF8 = {
-  ok:   () => green(bold(G.check)),
-  warn: () => yellow(bold(G.warn)),
-  err:  () => red(bold(G.cross)),
-  info: () => dim(G.dot),
+  // House rule: status is a LEADING coloured ● ring — never a tick / cross /
+  // dot / ⚠ (see packages/opencues-cli/CLAUDE.md § "The ● ring is the universal
+  // status glyph"). Colour carries the state; the glyph never changes. The old
+  // 🗸 / ⚠ are 2-cell-wide emoji that raggeded the 2-col gutter — a single-cell
+  // ● aligns cleanly.
+  ok:   () => green(G.ringOn),
+  warn: () => yellow(G.ringOn),
+  err:  () => red(G.ringOn),
+  info: () => dim(G.ringOn),
 };
 const TAGS_ASCII = {
   ok:   () => green('[ok]'),

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/kata.scenarios.test.ts
+++ b/packages/opencues-runtime/src/modules/kata.scenarios.test.ts
@@ -319,8 +319,8 @@ describe('KataCoach journeys (deterministic contracts)', () => {
     await h.type('done _');           // → journals step 2
     const j = (h.coach as unknown as { _journal: string[] })._journal;
     expect(j).toHaveLength(2);
-    expect(j[0]).toContain('Step 1 (Step 1 — first) ✓');
-    expect(j[1]).toContain('Step 2 (Step 2 — second) ✓');
+    expect(j[0]).toContain('Step 1 (Step 1 — first) ●');
+    expect(j[1]).toContain('Step 2 (Step 2 — second) ●');
     // Restarting mid-kata RESUMES — journal restored from the
     // progress file (lesson memory survives a restart by design).
     await h.type('stop kata _');

--- a/packages/opencues-runtime/src/modules/kata.ts
+++ b/packages/opencues-runtime/src/modules/kata.ts
@@ -675,7 +675,7 @@ export class KataCoach {
         : evidence.kind === 'submitted' ? `submitted: "${evidence.text.slice(0, 60)}"`
           : evidence.kind === 'key' ? `pressed: ${evidence.text}${(evidence.count ?? 1) > 1 ? ` (×${evidence.count})` : ''}`
             : `typed: "${evidence.text.slice(0, 60)}"`;
-    this._journal.push(`Step ${from + 1} (${doneStep.title}) ✓ — ${how}`);
+    this._journal.push(`Step ${from + 1} (${doneStep.title}) ● — ${how}`);
     if (from + 1 >= this._doc.steps.length) {
       const name = this._doc.name;
       const title = this._doc.title;
@@ -707,7 +707,7 @@ export class KataCoach {
     this._stepStartedAt = Date.now();
     this.saveProgress({ step: this._stepIndex });
     const next = this._doc.steps[this._stepIndex];
-    this._coachLine = `✓ Now: ${cleanStepTitle(next.title)}`;
+    this._coachLine = `● Now: ${cleanStepTitle(next.title)}`;
     this.maybeSpeak(`Step ${this._stepIndex + 1} of ${this._doc.steps.length}: ${cleanStepTitle(next.title)}`);
     this.adapter.emitEvent?.('kata.step-advanced', {
       name: this._doc.name, fromStep: from + 1, toStep: this._stepIndex + 1, reason,


### PR DESCRIPTION
The CLI's own rule (`packages/opencues-cli/CLAUDE.md` § "The ● ring is the universal status glyph") is *"status is a leading coloured ● — never a tick / cross / dot / ⚠"* — but `tag()` still rendered `🗸` / `⚠` / `✗` / `•`, against it, at **~128 call sites across 18 command files**.

## Fix
- **One root change:** `TAGS_UTF8` in `style.cjs` → leading `●` rings (green ok / dim info / yellow warn / red err). Every `tag()`-using command is now consistent, and alignment improves — the old `🗸`/`⚠` are 2-cell-wide emoji while `●` is single-cell (that's what raggeded the gutters). `TAGS_ASCII` (`[ok]`/`[warn]`) unchanged for no-UTF8 terminals.
- **Stray literal ticks converted:** `cleanup`'s two `green('✓')`, `which`'s stale help text (`"shows ✓ if present"` → green `●`), and the **kata coach** line + lesson journal (`✓ Now:` → `● Now:` — runtime statusline surface, per the "convert the kata coach tick" ask).

## Before / after (`tag()`)
```
before:  🗸 stored GROQ_API_KEY ●        after:  ● stored GROQ_API_KEY      (green ●)
         • checking cerebras…                    ● checking cerebras…       (dim ●)
         ⚠ previous mode was 0644…               ● previous mode was 0644…  (yellow ●)
         ✗ OpenRouter OAuth failed…              ● OpenRouter OAuth failed…  (red ●)
```

## Verification
- No test pinned the glyphs; one kata journal assertion updated to `●`.
- **194/194 CLI tests**, **47/47 kata tests**, runtime typecheck, version-bump + legacy-names gates — all green.

Separate from #256 (which hand-fixed `set-key`'s own oauth output); this fixes the shared root for every other command.