### PR TITLE
spec(conformance): close identity fixtures + JSON schema gaps; refresh stale 0.1/0.5 version drift

### DIFF
--- a/packages/opencues-core/src/conformance.test.ts
+++ b/packages/opencues-core/src/conformance.test.ts
@@ -43,6 +43,8 @@ import { join } from 'node:path';
 import { parseSingleCueMd, parseSingleAuditorMd, parseCuesMaster, parseBlanksMaster, parseAuditorsMaster, type SingleCueFrontmatter } from './cues-md';
 import { parseAlternatives } from './sources/parsers';
 import { unknownHostNames } from './host-compat';
+import { parseIdentityMd, deriveToken } from './identity-context';
+import { validateSentinelWrite } from './identity-validator';
 
 // Path to spec/conformance/, resolved from this file's location at
 // packages/opencues-core/src/conformance.test.ts
@@ -469,6 +471,71 @@ describe('routing/*.json', () => {
           });
         }
       }
+    });
+  }
+});
+
+// ─── identity surface (IDENTITY.md) ─────────────────────────────────────────
+// parseIdentityMd + validateSentinelWrite both live in @opencues/core, so the
+// identity fixtures are exercised here. (Kata's parser lives in
+// @opencues/runtime, so its fixtures are driven from that package's
+// kata.test.ts for the same reason.)
+
+describe('valid/identity/*.md', () => {
+  const dir = join(ROOT, 'valid', 'identity');
+  if (!existsSync(dir)) return;
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.md')) continue;
+    it(`${file} parses and derives well-formed tokens`, () => {
+      const content = readFileSync(join(dir, file), 'utf8');
+      const id = parseIdentityMd(content);
+      // At least one catalog field survived the parse.
+      expect(id.fields.length).toBeGreaterThan(0);
+      for (const f of id.fields) {
+        // Parser drops empty values, so every surviving field has one.
+        expect(f.value.length).toBeGreaterThan(0);
+        // Token is the canonical derivation of the key…
+        expect(f.token).toBe(deriveToken(f.key));
+        // …with the [UPPER SPACED] shape the spec mandates.
+        expect(f.token).toMatch(/^\[[A-Z0-9][A-Z0-9 ]*\]$/);
+      }
+      // The catalog maps exactly one token per field (no dropped/dup tokens).
+      expect(id.catalog.size).toBe(id.fields.length);
+    });
+  }
+});
+
+// Invalid identity fixtures represent a WRITE that MUST be refused. A whole
+// IDENTITY.md is never "rejected" as a file — parseIdentityMd is deliberately
+// lenient (it silently drops bad fields), so the write-time validator is the
+// gate. We replay each fixture's raw frontmatter fields IN ORDER through
+// validateSentinelWrite (NOT parseIdentityMd, which would pre-drop the
+// offender) and assert the first rejection matches the expected error code.
+describe('invalid/identity/*.md', () => {
+  const dir = join(ROOT, 'invalid', 'identity');
+  if (!existsSync(dir)) return;
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.md')) continue;
+    const expected: ExpectedRejection = JSON.parse(
+      readFileSync(join(dir, file.replace('.md', '.expected.json')), 'utf8'),
+    );
+    it(`${file} is REFUSED by validateSentinelWrite (${expected.rule})`, () => {
+      const content = readFileSync(join(dir, file), 'utf8');
+      const fm = content.match(/^---\n([\s\S]*?)\n---/);
+      const lines = fm ? fm[1].split('\n') : [];
+      let fields: { key: string; value: string }[] = [];
+      let firstError: string | null = null;
+      for (const raw of lines) {
+        if (!raw.trim() || /^\s*#/.test(raw)) continue; // skip blanks + comments
+        const m = raw.match(/^\s*(.+?):\s*(.*)$/);
+        if (!m) continue;
+        const key = m[1].trim().replace(/^["']|["']$/g, '');
+        const value = m[2].trim().replace(/^["']|["']$/g, '');
+        const res = validateSentinelWrite(fields, { op: 'set', key, value });
+        if (!res.ok) { firstError = res.error; break; }
+        fields = [...res.fields];
+      }
+      expect(firstError).toBe(expected.rule);
     });
   }
 });

--- a/spec/README.md
+++ b/spec/README.md
@@ -38,6 +38,7 @@ The standard covers three source-folder entry files (`CUE.md`, `BLANK.md`, `AUDI
 | [`schemas/blank.schema.json`](./schemas/blank.schema.json) | JSON Schema for `BLANK.md` frontmatter. |
 | [`schemas/auditor.schema.json`](./schemas/auditor.schema.json) | JSON Schema for `AUDITOR.md` frontmatter. |
 | [`schemas/kata.schema.json`](./schemas/kata.schema.json) | JSON Schema for `KATA.md` frontmatter. |
+| [`schemas/identity.schema.json`](./schemas/identity.schema.json) | JSON Schema for `IDENTITY.md` frontmatter (the personal-data catalog). Key shape + value cap are schema-expressible; token-collision and the field-count cap are write-time validator contracts noted in the schema description. |
 | [`schemas/cues-master.schema.json`](./schemas/cues-master.schema.json) | JSON Schema for the `CUES.md` master file. |
 | [`schemas/blanks-master.schema.json`](./schemas/blanks-master.schema.json) | JSON Schema for the `BLANKS.md` master file. |
 | [`schemas/auditors-master.schema.json`](./schemas/auditors-master.schema.json) | JSON Schema for the `AUDITORS.md` master file. |

--- a/spec/conformance/README.md
+++ b/spec/conformance/README.md
@@ -1,4 +1,4 @@
-# Conformance suite — opencues/0.1-alpha
+# Conformance suite — opencues/0.6-alpha
 
 A corpus of fixtures any conformant OpenCues implementation can exercise against. This suite is the bridge between "I read [`../cue-spec.md`](../cue-spec.md)" and "the parser actually matches the standard". Used today by `@opencues/core` as its parser regression net (adding a fixture this week caught one drift); designed so a future second runtime could exercise the same fixtures.
 
@@ -15,6 +15,7 @@ conformance/
 │   ├── blank/<name>.md             ← valid BLANK.md examples
 │   ├── auditor/<name>.md           ← valid AUDITOR.md examples
 │   ├── kata/<name>.md              ← valid KATA.md examples (0.5-alpha)
+│   ├── identity/<name>.md          ← valid IDENTITY.md examples (0.2-alpha)
 │   └── masters/<MASTER>.md         ← valid CUES.md / BLANKS.md / AUDITORS.md / OPENCUES.md
 │
 ├── invalid/                        ← MUST be rejected by any conformant runtime
@@ -25,7 +26,9 @@ conformance/
 │   ├── auditor/<name>.md
 │   ├── auditor/<name>.expected.json
 │   ├── kata/<name>.md              ← invalid KATA.md examples (0.5-alpha)
-│   └── kata/<name>.expected.json
+│   ├── kata/<name>.expected.json
+│   ├── identity/<name>.md          ← invalid IDENTITY.md examples (0.2-alpha)
+│   └── identity/<name>.expected.json
 │
 ├── wire/
 │   ├── README.md
@@ -45,7 +48,7 @@ conformance/
 
 The suite is `@opencues/core`'s regression net. The runner at [`packages/opencues-core/src/conformance.test.ts`](../../packages/opencues-core/src/conformance.test.ts) loads every fixture and asserts the reference parsers + wire-format handler + routing algorithm agree with what the spec describes.
 
-Run it: `cd packages/opencues-core && npx vitest run src/conformance.test.ts`. 54 tests pass; 6 are `.todo` markers naming linter rule codes the parser doesn't emit yet (visible-by-design gaps for a follow-up parser-side change).
+Run it: `cd packages/opencues-core && npx vitest run src/conformance.test.ts`. 70 tests pass; a few `.todo` markers name linter rule codes the parser doesn't emit yet (visible-by-design gaps for a follow-up parser-side change). KATA.md and IDENTITY.md fixtures add their own runners — kata from `@opencues/runtime`'s `kata.test.ts`, identity from this same core runner.
 
 This is the everyday value of the suite today — every parser change runs against the fixture tree before merge.
 
@@ -175,25 +178,27 @@ contract (the coaching runtime is reference-impl, not standard; see
 
 ## Versioning
 
-The suite versions with the spec. Files declare:
+The suite versions with the spec. A fixture MAY pin its target version in frontmatter:
 
 ```yaml
 spec: opencues/0.1-alpha
 ```
 
-When the spec bumps to `0.2-alpha`, the suite forks: `conformance/0.1-alpha/` and `conformance/0.2-alpha/` coexist for one minor cycle, so an implementer running against `0.1-alpha` still has the fixtures pinned at that version.
+…but in practice almost all fixtures omit it (see below). The versioning *model* is a per-version fork: when the spec bumps, `conformance/<old>/` and `conformance/<new>/` would coexist for one minor cycle so an implementer pinned to the old version keeps its fixtures. **In practice that fork has never been cut** — the suite grows in place as a single flat tree. Fixtures omit `spec:` and are read at the omit-default (`opencues/0.1-alpha`); surfaces added by later minors (kata at `0.5`, identity's dehydration at `0.6`) are additive and don't invalidate an older reader's fixtures, so the flat tree has held.
 
-**Status (`0.2-alpha` cut, June 2026).** The spec bumped to `0.2-alpha`
-(IDENTITY.md, `as-context:` / `contextTtl:` on BLANK.md, spec-mandated
-OPENCUES.md scalars). The fork has NOT yet happened — the suite is
-still `0.1-alpha` flat. **Coverage gap** until the fork lands:
+**Status (`0.6-alpha`, July 2026).** The spec has moved `0.1 → 0.6`
+(IDENTITY.md + `as-context:` / `contextTtl:` at `0.2`, Kata at `0.5`,
+bidirectional identity-context dehydration at `0.6`). The suite tracks
+it in place. Surfaces now covered: cue / blank / auditor / masters /
+wire / routing (in `@opencues/core`'s runner), KATA.md (driven from
+`@opencues/runtime`'s `kata.test.ts` — `parseKataMd` lives there), and
+**IDENTITY.md** (`valid/identity/` + `invalid/identity/`, driven from
+`@opencues/core`'s `conformance.test.ts`: valid files MUST parse and
+derive well-formed tokens; invalid files replay their frontmatter
+through `validateSentinelWrite` and MUST be refused with the expected
+error code — `invalid-key` / `value-too-long` / `collision` /
+`capacity-exceeded`). **Remaining coverage gap:**
 
-- `valid/identity/` — IDENTITY.md fixtures (frontmatter + expected
-  derived-token sets) covering the canonical token-derivation
-  algorithm in `identity-context-spec.md`.
-- `invalid/identity/` — files that MUST be rejected (bad key shape,
-  control chars, oversize values, token collisions, capacity
-  overflow).
 - `post-processor/` — LLM-output → post-processed-output pairs for
   verbatim resolve, unknown-strip, originalBody preserve, tolerant
   matching.
@@ -202,16 +207,16 @@ still `0.1-alpha` flat. **Coverage gap** until the fork lands:
 - `routing/` — mode-gate composition (the rule that
   `blank-context-mode: raw` MUST downgrade to `safe` when
   `identity-context-mode` is NOT `raw`).
-- `dehydration/` (`0.5-alpha` surface) — buffer-text → dehydrated-text
+- `dehydration/` (`0.6-alpha` surface) — buffer-text → dehydrated-text
   pairs pinning the matching floor (case-insensitive, word-boundary,
   longest-value-first, CJK adjacency) + round-trip pairs pinning the
   hydrate-restores-original invariant and the both-present
   preserve-wins precedence. See `identity-context-spec.md`
   § Dehydration.
 
-A second implementation targeting `0.2-alpha` or later should treat
+A second implementation targeting `0.6-alpha` should treat
 the spec text in `identity-context-spec.md` and `blank-spec.md`
-§ Sentinel aspects as authoritative until these fixtures land.
+§ Sentinel aspects as authoritative until these remaining fixtures land.
 (The reference implementation's executable equivalents:
 `packages/opencues-core/src/dehydrate.test.ts` +
 `sources/dehydration-outbound.test.ts`.)
@@ -271,7 +276,7 @@ Wrap with whatever test framework you use. The reference implementation's runner
 
 ## Status
 
-The 0.1-alpha suite is **seed**, not exhaustive. Coverage:
+The 0.6-alpha suite is **seed**, not exhaustive. Coverage:
 
 | Area | Fixtures | Notes |
 |---|---|---|
@@ -279,11 +284,13 @@ The 0.1-alpha suite is **seed**, not exhaustive. Coverage:
 | Valid BLANK.md | 5 | stepValues, blankScript, impl, full-frontmatter, selector-satellite |
 | Valid AUDITOR.md | 2 | Minimal, full-frontmatter |
 | Valid KATA.md | 2 | Full-frontmatter, minimal (no frontmatter) |
+| Valid IDENTITY.md | 2 | Minimal single-field, typical multi-field (camelCase / snake_case / kebab-case token derivation) |
 | Valid masters | 4 | CUES.md, BLANKS.md, AUDITORS.md, OPENCUES.md |
 | Invalid CUE.md | 5 | Missing name, missing trigger, empty body, unknown host, spec-too-new |
 | Invalid BLANK.md | 5 | Missing name, missing keywords, no binding, multiple bindings, script missing |
 | Invalid AUDITOR.md | 2 | Missing name, empty body |
 | Invalid KATA.md | 1 | No steps |
+| Invalid IDENTITY.md | 4 | Bad key (invalid-key), oversize value (value-too-long), token collision, capacity overflow |
 | Wire fixtures | 10 | Single/multi-line, whitespace tolerance, numeric skip, `=` synonym |
 | Routing scenarios | 4 | Per-word dispatch, priority tiebreak, catch-all fallback, blank shapes |
 

--- a/spec/conformance/invalid/cue/spec-too-new.expected.json
+++ b/spec/conformance/invalid/cue/spec-too-new.expected.json
@@ -1,5 +1,5 @@
 {
   "rule": "spec-too-new",
   "severity": "error",
-  "summary": "File declares spec: opencues/99.0 — runtime supports only opencues/0.5"
+  "summary": "File declares spec: opencues/99.0 — runtime supports only opencues/0.6"
 }

--- a/spec/conformance/invalid/identity/bad-key.expected.json
+++ b/spec/conformance/invalid/identity/bad-key.expected.json
@@ -1,0 +1,5 @@
+{
+  "rule": "invalid-key",
+  "severity": "error",
+  "summary": "IDENTITY.md field key \"../etc/passwd\" fails the [A-Za-z][A-Za-z0-9_-]* shape — path-traversal / shell-meta / unicode keys MUST be rejected at write time"
+}

--- a/spec/conformance/invalid/identity/bad-key.md
+++ b/spec/conformance/invalid/identity/bad-key.md
@@ -1,0 +1,8 @@
+---
+"../etc/passwd": some-value
+---
+
+# IDENTITY.md with a path-traversal key. The key `../etc/passwd` does
+# not match the required shape [A-Za-z][A-Za-z0-9_-]* and MUST be
+# rejected at write time (error: invalid-key). Shell-meta keys
+# (`foo;rm`), leading digits, and unicode tricks fail the same gate.

--- a/spec/conformance/invalid/identity/capacity-exceeded.expected.json
+++ b/spec/conformance/invalid/identity/capacity-exceeded.expected.json
@@ -1,0 +1,5 @@
+{
+  "rule": "capacity-exceeded",
+  "severity": "error",
+  "summary": "65 fields exceeds the 64-field default cap (DEFAULT_SENTINEL_CAPS.maxFields) — the 65th add MUST be rejected"
+}

--- a/spec/conformance/invalid/identity/capacity-exceeded.md
+++ b/spec/conformance/invalid/identity/capacity-exceeded.md
@@ -1,0 +1,71 @@
+---
+field01: value1
+field02: value2
+field03: value3
+field04: value4
+field05: value5
+field06: value6
+field07: value7
+field08: value8
+field09: value9
+field10: value10
+field11: value11
+field12: value12
+field13: value13
+field14: value14
+field15: value15
+field16: value16
+field17: value17
+field18: value18
+field19: value19
+field20: value20
+field21: value21
+field22: value22
+field23: value23
+field24: value24
+field25: value25
+field26: value26
+field27: value27
+field28: value28
+field29: value29
+field30: value30
+field31: value31
+field32: value32
+field33: value33
+field34: value34
+field35: value35
+field36: value36
+field37: value37
+field38: value38
+field39: value39
+field40: value40
+field41: value41
+field42: value42
+field43: value43
+field44: value44
+field45: value45
+field46: value46
+field47: value47
+field48: value48
+field49: value49
+field50: value50
+field51: value51
+field52: value52
+field53: value53
+field54: value54
+field55: value55
+field56: value56
+field57: value57
+field58: value58
+field59: value59
+field60: value60
+field61: value61
+field62: value62
+field63: value63
+field64: value64
+field65: value65
+---
+
+# 65 catalog fields — one over the 64-field default cap
+# (DEFAULT_SENTINEL_CAPS.maxFields). Replayed as sequential writes, the
+# 65th add MUST be rejected (error: capacity-exceeded).

--- a/spec/conformance/invalid/identity/token-collision.expected.json
+++ b/spec/conformance/invalid/identity/token-collision.expected.json
@@ -1,0 +1,5 @@
+{
+  "rule": "collision",
+  "severity": "error",
+  "summary": "keys firstName and first_name both derive the token [FIRST NAME] — the second write MUST be rejected so one token never owns two values"
+}

--- a/spec/conformance/invalid/identity/token-collision.md
+++ b/spec/conformance/invalid/identity/token-collision.md
@@ -1,0 +1,8 @@
+---
+firstName: Wilfred
+first_name: Wilfred
+---
+
+# Two keys that derive the SAME token: `firstName` and `first_name`
+# both derive `[FIRST NAME]`. The second write MUST be rejected
+# (error: collision) so a single token never maps to two values.

--- a/spec/conformance/invalid/identity/value-too-long.expected.json
+++ b/spec/conformance/invalid/identity/value-too-long.expected.json
@@ -1,0 +1,5 @@
+{
+  "rule": "value-too-long",
+  "severity": "error",
+  "summary": "value for key bio is 300 chars, over the 256-char default cap (DEFAULT_SENTINEL_CAPS.maxValueLength) — MUST be rejected at write time"
+}

--- a/spec/conformance/invalid/identity/value-too-long.md
+++ b/spec/conformance/invalid/identity/value-too-long.md
@@ -1,0 +1,7 @@
+---
+bio: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+---
+
+# The value for `bio` is 300 characters — over the 256-char default
+# cap (DEFAULT_SENTINEL_CAPS.maxValueLength). It MUST be rejected at
+# write time (error: value-too-long).

--- a/spec/conformance/valid/identity/minimal.md
+++ b/spec/conformance/valid/identity/minimal.md
@@ -1,0 +1,7 @@
+---
+firstName: Wilfred
+---
+
+# IDENTITY.md — minimal single-field example.
+# Frontmatter is the catalog; this body is reserved and ignored by
+# conformant readers. `firstName` MUST derive the token `[FIRST NAME]`.

--- a/spec/conformance/valid/identity/typical-user.md
+++ b/spec/conformance/valid/identity/typical-user.md
@@ -1,0 +1,20 @@
+---
+firstName: Wilfred
+last_name: Kasekende
+work-city: London
+email: wilfred@example.com
+phoneE164: "+441234567890"
+signOff: Best from London  # description: my email sign-off
+---
+
+# IDENTITY.md — typical multi-field catalog exercising all three key
+# styles the token-derivation algorithm accepts (camelCase, snake_case,
+# kebab-case) plus an inline `# description:` override.
+#
+# Expected derived tokens (see identity-context-spec.md § Token derivation):
+#   firstName  -> [FIRST NAME]
+#   last_name  -> [LAST NAME]
+#   work-city  -> [WORK CITY]
+#   email      -> [EMAIL]
+#   phoneE164  -> [PHONE E164]
+#   signOff    -> [SIGN OFF]   (description: "my email sign-off")

--- a/spec/identity-context-spec.md
+++ b/spec/identity-context-spec.md
@@ -172,7 +172,7 @@ raw:     [FIRST NAME] — first name (value: Wilfred)
 The exact prompt shape is implementation-defined — the standard
 fixes the catalog being injected, not the prose around it.
 
-### Dehydration (outbound) — new in `0.5`
+### Dehydration (outbound) — new in `0.6`
 
 `safe` mode's guarantee is bidirectional: PII must not reach the
 provider even when the user TYPED it into the buffer. Before any
@@ -263,7 +263,7 @@ the other is a footgun the spec closes deliberately.
   the provider — both the catalog direction (token-only prompt
   blocks) and the buffer direction (outbound dehydration, § above).
   A reader implementing only the catalog half MUST NOT describe
-  itself as `safe`-conformant against `0.5`.
+  itself as `safe`-conformant against `0.6`.
 - **Validator chokepoint.** Every code path that mutates
   `IDENTITY.md` MUST go through a single write-validator. Adding a
   second site that bypasses the validator is a regression — see

--- a/spec/schemas/identity.schema.json
+++ b/spec/schemas/identity.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opencues.org/schemas/identity.schema.json",
+  "title": "OpenCues IDENTITY.md frontmatter",
+  "description": "JSON Schema for the YAML frontmatter of ~/.cues/IDENTITY.md — the user's personal-data catalog. Spec: opencues/0.6-alpha. See /spec/identity-context-spec.md. Frontmatter is the catalog; the markdown body is reserved and ignored by conformant readers. Each `<key>: <value>` entry derives a canonical [UPPER SPACED] bracket-token (a sentinel) the LLM emits without the value reaching the prompt. Two write-time contracts are NOT expressible in JSON Schema and are enforced by the validator (validateSentinelWrite): (1) no two keys may derive the same token (collision), and (2) the field-count cap (64 by default).",
+  "type": "object",
+  "properties": {
+    "spec": {
+      "type": "string",
+      "pattern": "^opencues/\\d+\\.\\d+(-[a-z]+)?$",
+      "default": "opencues/0.1-alpha",
+      "description": "Optional spec-version pin. IDENTITY.md is new in 0.2-alpha; bidirectional dehydration in safe mode is normative from 0.6-alpha. A reader older than the file's declared spec ignores the catalog."
+    }
+  },
+  "patternProperties": {
+    "^[A-Za-z][A-Za-z0-9_-]*$": {
+      "type": "string",
+      "maxLength": 256,
+      "pattern": "^[^\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F\\u007F]*$",
+      "description": "A catalog field. The key derives a [UPPER SPACED] token (firstName / first_name / first-name all -> [FIRST NAME]); the value is the private data substituted in for that token in safe mode after the LLM responds. Value is capped at 256 chars and MUST NOT contain control characters."
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## What

Second PR from the doc-vs-code audit (companion to #268, which handled pure documentation drift). This one closes **real spec-surface gaps** the audit surfaced in the conformance suite and adds testable artifacts.

Two findings drove it:
1. The **identity (`IDENTITY.md`) surface** was the *only* spec surface with **no conformance fixtures and no JSON schema** — a documented gap in `spec/conformance/README.md` and a blind spot for any schema-driven third-party validator.
2. The conformance suite's own version banners had frozen at `0.1-alpha` with a *"0.2-alpha cut, June 2026 — the fork has NOT yet happened"* narrative, while the spec is actually at **0.6** and kata fixtures had since been added.

**No `SPEC_VERSION` bump** — these fixtures/schema are for the *existing* 0.2/0.6 identity surface; `SPEC_VERSION` is already 0.6.

## Additions

### JSON schema
- `spec/schemas/identity.schema.json` — mirrors the kata/opencues schema conventions (draft 2020-12, `opencues.org` `$id`, shared `spec` block). `patternProperties` enforces the `[A-Za-z][A-Za-z0-9_-]*` key shape + 256-char value cap + control-char ban. The two contracts that JSON Schema **can't** express (token collision, field-count cap) are named in the description as write-validator concerns. Added to `spec/README.md`'s schema table. Hand-verified against the fixtures (no `ajv` in the tree).

### Conformance fixtures + runner
- `spec/conformance/valid/identity/` (2): `minimal` single-field, `typical-user` multi-field exercising camelCase / snake_case / kebab-case → token derivation.
- `spec/conformance/invalid/identity/` (4): `bad-key` (invalid-key), `value-too-long`, `token-collision`, `capacity-exceeded`.
- Runner wiring in `packages/opencues-core/src/conformance.test.ts`:
  - valid → each parses via `parseIdentityMd` and derives well-formed `[UPPER SPACED]` tokens.
  - invalid → each fixture's raw frontmatter is replayed through `validateSentinelWrite` (**not** `parseIdentityMd`, which is lenient and would pre-drop the offender) and MUST be refused with the expected error code.
  - This mirrors how kata fixtures are driven from `@opencues/runtime`'s `kata.test.ts` (parser lives there); `parseIdentityMd`/`validateSentinelWrite` live in core, so identity is driven from the core runner.

## Version-drift fixes
- `spec/conformance/README.md`: title + Status + coverage table + tree diagram `0.1-alpha` → `0.6-alpha`; rewrote the "fork has NOT happened" narrative to reflect reality (the per-version fork was never cut — the suite grows in place); dehydration `0.5-alpha` → `0.6-alpha`; test count `54` → `70`.
- `spec/identity-context-spec.md`: dehydration "new in `0.5`" → `0.6` and "safe-conformant against `0.5`" → `0.6` (bidirectional dehydration is the 0.6 spec bump per `spec/CHANGELOG.md`; the doc's own banner is already `0.6-alpha`).
- `spec/conformance/invalid/cue/spec-too-new.expected.json` summary "supports only 0.5" → 0.6.

## Testing
- `npx vitest run src/conformance.test.ts` → **70 pass** (was 64); all 6 new identity tests confirmed running via `--reporter=verbose`.
- Full `@opencues/core` suite: **12 files, 294 passed + 1 expected-fail**.
- `tsc --noEmit` clean; `lint-legacy-names.sh` green.
- Schema regexes compile + agree with the fixtures (valid pass; bad-key → key-shape, value-too-long → maxLength; collision/capacity correctly validator-only).

Carries `[skip version-bump]` — the only `src/` change is the test file; the schema + fixtures live under `spec/`, and no shipped runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)