### PR TITLE
fix(readme): badge SVGs — no WebKit squash, no GitHub background pill, cache-proof URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      then "use their svgs for now" per explicit instruction. -->
 
 <div align="right">
-  <a href="#"><img width="180" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/OpenCues_logo.svg"></a>
+  <a href="#"><img width="180" height="29" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/OpenCues_logo.svg"></a>
 </div>
 
 <br><br>
@@ -18,7 +18,7 @@
 
 #
 
-<p align="left"><a href="#"><img width="109" alt="Associations:" src="assets/associations.svg"></a><a href="https://www.reddit.com/user/inventor_black/" target="_blank" rel="noopener noreferrer"><img width="177" alt="Mod of r/ClaudeAI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Associations-02.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="https://www.reddit.com/user/ClaudeAI-mod-bot/" target="_blank" rel="noopener noreferrer"><img width="168" alt="Bot at r/ClaudeAI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Associations-02.1.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="https://luma.com/OpenSourceIRL" target="_blank" rel="noopener noreferrer"><img width="161" alt="OpenSourceIRL" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Associations-03.svg"></a></p>
+<p align="left"><a href="#"><img width="120" height="18" alt="Associations:" src="assets/associations.svg"></a><a href="https://www.reddit.com/user/inventor_black/" target="_blank" rel="noopener noreferrer"><img width="177" height="18" alt="Mod of r/ClaudeAI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Associations-02.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="https://www.reddit.com/user/ClaudeAI-mod-bot/" target="_blank" rel="noopener noreferrer"><img width="168" height="18" alt="Bot at r/ClaudeAI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Associations-02.1.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="https://luma.com/OpenSourceIRL" target="_blank" rel="noopener noreferrer"><img width="161" height="18" alt="OpenSourceIRL" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Associations-03.svg"></a></p>
 
 <br><br><br>
 
@@ -49,7 +49,7 @@ OpenCues is platform, model, and provider agnostic, engineered from the ground u
 
 #
 
-<p align="left"><a href="LICENSE"><img width="216" alt="Apache-2.0 License" src="assets/license.svg"></a><a href="spec/README.md"><img width="157" alt="Open Standard" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Ownership-05.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="spec/blank-spec.md"><img width="121" alt="Blanks.md" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Ownership-06.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="spec/cue-spec.md"><img width="112" alt="Cues.md" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Ownership-07.svg"></a></p>
+<p align="left"><a href="LICENSE"><img width="216" height="18" alt="Apache-2.0 License" src="assets/license.svg"></a><a href="spec/README.md"><img width="157" height="18" alt="Open Standard" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Ownership-05.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="spec/blank-spec.md"><img width="121" height="18" alt="Blanks.md" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Ownership-06.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="spec/cue-spec.md"><img width="112" height="18" alt="Cues.md" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Ownership-07.svg"></a></p>
 
 <br><br><br><br>
 
@@ -72,7 +72,7 @@ Full walkthrough, prerequisites, and per-host detail: [`docs/install.md`](docs/i
 
 #
 
-<p align="left"><a href="docs/guides/cli-reference.md#the-5-youll-actually-use"><img width="178" alt="OpenCues CLI" src="assets/opencues-cli.svg"></a><a href="docs/features/README.md"><img width="109" alt="Features" src="assets/features.svg"></a></p>
+<p align="left"><a href="docs/guides/cli-reference.md#the-5-youll-actually-use"><img width="178" height="18" alt="OpenCues CLI" src="assets/opencues-cli.svg"></a><a href="docs/features/README.md"><img width="109" height="18" alt="Features" src="assets/features.svg"></a></p>
 
 <br><br><br><br>
 
@@ -92,7 +92,7 @@ Each pins its own upstream fork and never touches your native host install.
 
 #
 
-<p align="left"><a href="#integrations"><img width="91" alt="Supports:" src="assets/supports.svg"></a><a href="integrations/opencode/README.md"><img width="129" alt="OpenCode" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Supports-09.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="integrations/claude-code/README.md"><img width="144" alt="Claude Code" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Supports-10.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="integrations/gemini-cli/README.md"><img width="126" alt="Gemini CLI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Supports-11.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="integrations/chrome/README.md"><img width="130" alt="Chrome" src="assets/chrome.svg"></a><a href="integrations/shell/README.md"><img width="82" alt="Shell" src="assets/shell.svg"></a></p>
+<p align="left"><a href="#integrations"><img width="91" height="18" alt="Supports:" src="assets/supports.svg"></a><a href="integrations/opencode/README.md"><img width="129" height="18" alt="OpenCode" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Supports-09.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="integrations/claude-code/README.md"><img width="144" height="18" alt="Claude Code" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Supports-10.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="integrations/gemini-cli/README.md"><img width="126" height="18" alt="Gemini CLI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Supports-11.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="integrations/chrome/README.md"><img width="130" height="18" alt="Chrome" src="assets/chrome.svg"></a><a href="integrations/shell/README.md"><img width="82" height="18" alt="Shell" src="assets/shell.svg"></a></p>
 
 <br><br><br><br>
 
@@ -128,7 +128,7 @@ Full reference: [`docs/configuration.md`](docs/configuration.md) · [`docs/guide
 
 #
 
-<img width="92" alt="Providers:" src="assets/providers.svg"><a href="https://cloud.cerebras.ai" target="_blank" rel="noopener noreferrer"><img width="200" alt="Cerebras Systems" src="assets/cerebras-systems.svg"></a><a href="https://groq.com" target="_blank" rel="noopener noreferrer"><img width="107" alt="Groq" src="assets/groq.svg"></a><a href="https://ai.google.dev" target="_blank" rel="noopener noreferrer"><img width="122" alt="Gemini" src="assets/gemini.svg"></a><a href="https://www.anthropic.com" target="_blank" rel="noopener noreferrer"><img width="141" alt="Anthropic" src="assets/anthropic.svg"></a><a href="https://openai.com" target="_blank" rel="noopener noreferrer"><img width="102" alt="OpenAI" src="assets/openai.svg"></a>
+<img width="92" height="18" alt="Providers:" src="assets/providers.svg"><a href="https://cloud.cerebras.ai" target="_blank" rel="noopener noreferrer"><img width="200" height="18" alt="Cerebras Systems" src="assets/cerebras-systems.svg"></a><a href="https://groq.com" target="_blank" rel="noopener noreferrer"><img width="107" height="18" alt="Groq" src="assets/groq.svg"></a><a href="https://ai.google.dev" target="_blank" rel="noopener noreferrer"><img width="122" height="18" alt="Gemini" src="assets/gemini.svg"></a><a href="https://www.anthropic.com" target="_blank" rel="noopener noreferrer"><img width="141" height="18" alt="Anthropic" src="assets/anthropic.svg"></a><a href="https://openai.com" target="_blank" rel="noopener noreferrer"><img width="102" height="18" alt="OpenAI" src="assets/openai.svg"></a>
 
 <br><br><br><br>
 
@@ -174,7 +174,7 @@ Join the community — questions, feedback, and the people building alongside yo
 
 #
 
-<p align="left"><img width="85" alt="Community:" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Community-12.svg"><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="https://github.com/opencues/opencues/graphs/contributors"><img width="161" alt="Contributors" src="assets/contributors.svg"></a><a href="https://x.com/openCues_" target="_blank" rel="noopener noreferrer"><img width="142" alt="X / Twitter" src="assets/x-twitter.svg"></a><a href="https://www.reddit.com/r/OpenCues/" target="_blank" rel="noopener noreferrer"><img width="118" alt="Reddit" src="assets/reddit.svg"></a><a href="https://www.instagram.com/opencues/" target="_blank" rel="noopener noreferrer"><img width="117" alt="Instagram" src="assets/instagram.svg"></a></p>
+<p align="left"><img width="85" height="18" alt="Community:" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Community-12.svg"><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="https://github.com/opencues/opencues/graphs/contributors"><img width="161" height="18" alt="Contributors" src="assets/contributors.svg"></a><a href="https://x.com/openCues_" target="_blank" rel="noopener noreferrer"><img width="142" height="18" alt="X / Twitter" src="assets/x-twitter.svg"></a><a href="https://www.reddit.com/r/OpenCues/" target="_blank" rel="noopener noreferrer"><img width="118" height="18" alt="Reddit" src="assets/reddit.svg"></a><a href="https://www.instagram.com/opencues/" target="_blank" rel="noopener noreferrer"><img width="117" height="18" alt="Instagram" src="assets/instagram.svg"></a></p>
 
 <!-- TODO[community]: add Discord + GitHub Discussions once live (tracked in .internal/pre-launch-readme.md) -->
 
@@ -188,4 +188,4 @@ Join the community — questions, feedback, and the people building alongside yo
 
 #
 
-<p align="left"><img width="75" alt="Design" src="assets/design.svg"><a href="https://jbrandford.com" target="_blank" rel="noopener noreferrer"><img width="128" alt="Author" src="assets/j-brandford.svg"></a></p>
+<p align="left"><img width="75" height="18" alt="Design" src="assets/design.svg"><a href="https://jbrandford.com" target="_blank" rel="noopener noreferrer"><img width="128" height="18" alt="Author" src="assets/j-brandford.svg"></a></p>

--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@
      then "use their svgs for now" per explicit instruction. -->
 
 <div align="right">
-  <a href="#"><img width="180" height="29" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/OpenCues_logo.svg"></a>
+  <a href="#"><img width="180" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/OpenCues_logo.svg"></a>
 </div>
 
 <br><br>
 
 <div align="center">
-  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Hero.svg"></a>
+  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Hero.svg"></a>
 </div>
 
 <br><br>
 
 #
 
-<p align="left"><a href="#"><img width="120" height="18" alt="Associations:" src="assets/associations.svg"></a><a href="https://www.reddit.com/user/inventor_black/" target="_blank" rel="noopener noreferrer"><img width="177" height="18" alt="Mod of r/ClaudeAI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Associations-02.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="https://www.reddit.com/user/ClaudeAI-mod-bot/" target="_blank" rel="noopener noreferrer"><img width="168" height="18" alt="Bot at r/ClaudeAI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Associations-02.1.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="https://luma.com/OpenSourceIRL" target="_blank" rel="noopener noreferrer"><img width="161" height="18" alt="OpenSourceIRL" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Associations-03.svg"></a></p>
+<p align="left"><a href="#"><img width="120" alt="Associations:" src="assets/associations.svg"></a><a href="https://www.reddit.com/user/inventor_black/" target="_blank" rel="noopener noreferrer"><img width="177" alt="Mod of r/ClaudeAI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Associations-02.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/spacer.svg"><a href="https://www.reddit.com/user/ClaudeAI-mod-bot/" target="_blank" rel="noopener noreferrer"><img width="168" alt="Bot at r/ClaudeAI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Associations-02.1.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/spacer.svg"><a href="https://luma.com/OpenSourceIRL" target="_blank" rel="noopener noreferrer"><img width="161" alt="OpenSourceIRL" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Associations-03.svg"></a></p>
 
 <br><br><br>
 
@@ -35,7 +35,7 @@ Rather than navigating to a chat interface or AI-enabled input box, define a que
      GitHub-hosted asset (renders inline): ![demo](https://github.com/opencues/opencues/assets/.../demo.mp4)
      YouTube (GitHub won't inline-embed it — link a thumbnail instead):
      [![Demo](assets/hero-thumb.png)](https://youtu.be/VIDEO_ID) -->
-<a href="#"><img width="100%" alt="Video placeholder — hero demo" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Video_placeholder_1200x300.svg"></a>
+<a href="#"><img width="100%" alt="Video placeholder — hero demo" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Video_placeholder_1200x300.svg"></a>
 
 OpenCues is platform, model, and provider agnostic, engineered from the ground up to enable native inline AI.
 
@@ -49,7 +49,7 @@ OpenCues is platform, model, and provider agnostic, engineered from the ground u
 
 #
 
-<p align="left"><a href="LICENSE"><img width="216" height="18" alt="Apache-2.0 License" src="assets/license.svg"></a><a href="spec/README.md"><img width="157" height="18" alt="Open Standard" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Ownership-05.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="spec/blank-spec.md"><img width="121" height="18" alt="Blanks.md" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Ownership-06.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="spec/cue-spec.md"><img width="112" height="18" alt="Cues.md" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Ownership-07.svg"></a></p>
+<p align="left"><a href="LICENSE"><img width="216" alt="Apache-2.0 License" src="assets/license.svg"></a><a href="spec/README.md"><img width="157" alt="Open Standard" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Ownership-05.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/spacer.svg"><a href="spec/blank-spec.md"><img width="121" alt="Blanks.md" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Ownership-06.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/spacer.svg"><a href="spec/cue-spec.md"><img width="112" alt="Cues.md" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Ownership-07.svg"></a></p>
 
 <br><br><br><br>
 
@@ -68,11 +68,11 @@ Full walkthrough, prerequisites, and per-host detail: [`docs/install.md`](docs/i
 
 <!-- VIDEO: quickstart walkthrough (~30-45s), replace this comment with the
      real embed once available. -->
-<a href="#"><img width="100%" alt="Video placeholder — quickstart walkthrough" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Video_placeholder_1200x300.svg"></a>
+<a href="#"><img width="100%" alt="Video placeholder — quickstart walkthrough" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Video_placeholder_1200x300.svg"></a>
 
 #
 
-<p align="left"><a href="docs/guides/cli-reference.md#the-5-youll-actually-use"><img width="178" height="18" alt="OpenCues CLI" src="assets/opencues-cli.svg"></a><a href="docs/features/README.md"><img width="109" height="18" alt="Features" src="assets/features.svg"></a></p>
+<p align="left"><a href="docs/guides/cli-reference.md#the-5-youll-actually-use"><img width="178" alt="OpenCues CLI" src="assets/opencues-cli.svg"></a><a href="docs/features/README.md"><img width="109" alt="Features" src="assets/features.svg"></a></p>
 
 <br><br><br><br>
 
@@ -92,7 +92,7 @@ Each pins its own upstream fork and never touches your native host install.
 
 #
 
-<p align="left"><a href="#integrations"><img width="91" height="18" alt="Supports:" src="assets/supports.svg"></a><a href="integrations/opencode/README.md"><img width="129" height="18" alt="OpenCode" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Supports-09.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="integrations/claude-code/README.md"><img width="144" height="18" alt="Claude Code" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Supports-10.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="integrations/gemini-cli/README.md"><img width="126" height="18" alt="Gemini CLI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Supports-11.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="integrations/chrome/README.md"><img width="130" height="18" alt="Chrome" src="assets/chrome.svg"></a><a href="integrations/shell/README.md"><img width="82" height="18" alt="Shell" src="assets/shell.svg"></a></p>
+<p align="left"><a href="#integrations"><img width="91" alt="Supports:" src="assets/supports.svg"></a><a href="integrations/opencode/README.md"><img width="129" alt="OpenCode" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Supports-09.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/spacer.svg"><a href="integrations/claude-code/README.md"><img width="144" alt="Claude Code" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Supports-10.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/spacer.svg"><a href="integrations/gemini-cli/README.md"><img width="126" alt="Gemini CLI" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Supports-11.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/spacer.svg"><a href="integrations/chrome/README.md"><img width="130" alt="Chrome" src="assets/chrome.svg"></a><a href="integrations/shell/README.md"><img width="82" alt="Shell" src="assets/shell.svg"></a></p>
 
 <br><br><br><br>
 
@@ -110,14 +110,14 @@ Full feature catalogue (44 concepts): [`docs/features/README.md`](docs/features/
 
 <!-- VIDEO: feature tour (~30s of cues + blanks in action), replace this
      comment with the real embed once available. -->
-<a href="#"><img width="100%" alt="Video placeholder — feature tour" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Video_placeholder_1200x300.svg"></a>
+<a href="#"><img width="100%" alt="Video placeholder — feature tour" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Video_placeholder_1200x300.svg"></a>
 
 <br><br><br><br>
 
 # Configuration & LLM providers
 
 <div align="center">
-  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Hero-2.svg"></a>
+  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Hero-2.svg"></a>
 </div>
 
 <br>
@@ -128,7 +128,7 @@ Full reference: [`docs/configuration.md`](docs/configuration.md) · [`docs/guide
 
 #
 
-<img width="92" height="18" alt="Providers:" src="assets/providers.svg"><a href="https://cloud.cerebras.ai" target="_blank" rel="noopener noreferrer"><img width="200" height="18" alt="Cerebras Systems" src="assets/cerebras-systems.svg"></a><a href="https://groq.com" target="_blank" rel="noopener noreferrer"><img width="107" height="18" alt="Groq" src="assets/groq.svg"></a><a href="https://ai.google.dev" target="_blank" rel="noopener noreferrer"><img width="122" height="18" alt="Gemini" src="assets/gemini.svg"></a><a href="https://www.anthropic.com" target="_blank" rel="noopener noreferrer"><img width="141" height="18" alt="Anthropic" src="assets/anthropic.svg"></a><a href="https://openai.com" target="_blank" rel="noopener noreferrer"><img width="102" height="18" alt="OpenAI" src="assets/openai.svg"></a>
+<img width="92" alt="Providers:" src="assets/providers.svg"><a href="https://cloud.cerebras.ai" target="_blank" rel="noopener noreferrer"><img width="200" alt="Cerebras Systems" src="assets/cerebras-systems.svg"></a><a href="https://groq.com" target="_blank" rel="noopener noreferrer"><img width="107" alt="Groq" src="assets/groq.svg"></a><a href="https://ai.google.dev" target="_blank" rel="noopener noreferrer"><img width="122" alt="Gemini" src="assets/gemini.svg"></a><a href="https://www.anthropic.com" target="_blank" rel="noopener noreferrer"><img width="141" alt="Anthropic" src="assets/anthropic.svg"></a><a href="https://openai.com" target="_blank" rel="noopener noreferrer"><img width="102" alt="OpenAI" src="assets/openai.svg"></a>
 
 <br><br><br><br>
 
@@ -158,7 +158,7 @@ Full threat model: [`docs/architecture/security-audit.md`](docs/architecture/sec
 # Contributing
 
 <div align="center">
-  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Hero-3.svg"></a>
+  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Hero-3.svg"></a>
 </div>
 
 <br>
@@ -174,7 +174,7 @@ Join the community — questions, feedback, and the people building alongside yo
 
 #
 
-<p align="left"><img width="85" height="18" alt="Community:" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/Community-12.svg"><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@main/assets/spacer.svg"><a href="https://github.com/opencues/opencues/graphs/contributors"><img width="161" height="18" alt="Contributors" src="assets/contributors.svg"></a><a href="https://x.com/openCues_" target="_blank" rel="noopener noreferrer"><img width="142" height="18" alt="X / Twitter" src="assets/x-twitter.svg"></a><a href="https://www.reddit.com/r/OpenCues/" target="_blank" rel="noopener noreferrer"><img width="118" height="18" alt="Reddit" src="assets/reddit.svg"></a><a href="https://www.instagram.com/opencues/" target="_blank" rel="noopener noreferrer"><img width="117" height="18" alt="Instagram" src="assets/instagram.svg"></a></p>
+<p align="left"><img width="85" alt="Community:" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/Community-12.svg"><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/a1rtight/tester@05be775041f9211c444ec0f642812ab7379a13d3/assets/spacer.svg"><a href="https://github.com/opencues/opencues/graphs/contributors"><img width="161" alt="Contributors" src="assets/contributors.svg"></a><a href="https://x.com/openCues_" target="_blank" rel="noopener noreferrer"><img width="142" alt="X / Twitter" src="assets/x-twitter.svg"></a><a href="https://www.reddit.com/r/OpenCues/" target="_blank" rel="noopener noreferrer"><img width="118" alt="Reddit" src="assets/reddit.svg"></a><a href="https://www.instagram.com/opencues/" target="_blank" rel="noopener noreferrer"><img width="117" alt="Instagram" src="assets/instagram.svg"></a></p>
 
 <!-- TODO[community]: add Discord + GitHub Discussions once live (tracked in .internal/pre-launch-readme.md) -->
 
@@ -188,4 +188,4 @@ Join the community — questions, feedback, and the people building alongside yo
 
 #
 
-<p align="left"><img width="75" height="18" alt="Design" src="assets/design.svg"><a href="https://jbrandford.com" target="_blank" rel="noopener noreferrer"><img width="128" height="18" alt="Author" src="assets/j-brandford.svg"></a></p>
+<p align="left"><img width="75" alt="Design" src="assets/design.svg"><a href="https://jbrandford.com" target="_blank" rel="noopener noreferrer"><img width="128" alt="Author" src="assets/j-brandford.svg"></a></p>

--- a/assets/anthropic.svg
+++ b/assets/anthropic.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 230.5117 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="141" height="18" viewBox="0 0 230.5117 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/associations.svg
+++ b/assets/associations.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 194.2695 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="120" height="18" viewBox="0 0 194.2695 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/cerebras-systems.svg
+++ b/assets/cerebras-systems.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 326.876 29.3778">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="200" height="18" viewBox="0 0 326.876 29.3778">
   <defs>
     <style>
       .cls-1 {

--- a/assets/chrome.svg
+++ b/assets/chrome.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210.7096 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="130" height="18" viewBox="0 0 210.7096 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/contributors.svg
+++ b/assets/contributors.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 262.0978 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="161" height="18" viewBox="0 0 262.0978 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/design.svg
+++ b/assets/design.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 122.0527 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="75" height="18" viewBox="0 0 122.0527 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/features.svg
+++ b/assets/features.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 178.1973 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="109" height="18" viewBox="0 0 178.1973 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/gemini.svg
+++ b/assets/gemini.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 198.0703 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="122" height="18" viewBox="0 0 198.0703 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/groq.svg
+++ b/assets/groq.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 175.3232 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="107" height="18" viewBox="0 0 175.3232 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/instagram.svg
+++ b/assets/instagram.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 191.173 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="117" height="18" viewBox="0 0 191.173 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/j-brandford.svg
+++ b/assets/j-brandford.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 208.9333 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="128" height="18" viewBox="0 0 208.9333 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/license.svg
+++ b/assets/license.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 351.4571 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="216" height="18" viewBox="0 0 351.4571 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/openai.svg
+++ b/assets/openai.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 166.6699 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="102" height="18" viewBox="0 0 166.6699 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/opencues-cli.svg
+++ b/assets/opencues-cli.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 289.8502 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="178" height="18" viewBox="0 0 289.8502 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/providers.svg
+++ b/assets/providers.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 149.0127 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="92" height="18" viewBox="0 0 149.0127 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/reddit.svg
+++ b/assets/reddit.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192.5109 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="118" height="18" viewBox="0 0 192.5109 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/shell.svg
+++ b/assets/shell.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 133.6862 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="82" height="18" viewBox="0 0 133.6862 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/supports.svg
+++ b/assets/supports.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 148.0566 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="91" height="18" viewBox="0 0 148.0566 29.2154">
   <defs>
     <style>
       .cls-1 {

--- a/assets/x-twitter.svg
+++ b/assets/x-twitter.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 231.1554 29.2154">
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" width="142" height="18" viewBox="0 0 231.1554 29.2154">
   <defs>
     <style>
       .cls-1 {


### PR DESCRIPTION
## Problem

On github.com (Safari/WebKit specifically), some README badges rendered visibly squashed — e.g. on the integrations strip, Gemini CLI and Shell were crushed while Claude Code and Chrome looked fine. VS Code's preview showed no problem.

## Root cause

The badge SVGs shipped `viewBox`-only (no intrinsic `width`/`height`), and the README `<img>` tags declared width-only. Each badge's derived height lands between 17.9 and 18.1px — and WebKit floors SVG intrinsic heights to whole pixels. Badges whose ideal height fell just under 18 (Gemini CLI 17.97, Shell 17.92, supports 17.96, …) rendered at 17px next to 18px neighbours: a ~5% vertical squash. Chromium keeps fractional heights, which is why VS Code looked fine.

First attempt (3a78f45f) added explicit `height="18"` img attributes — which fixed the squash but surfaced a second GitHub behaviour: the React view stamps `background-color: var(--bgColor-muted); border-radius: 6px` inline on any README img declaring **both** width and height, painting grey pills behind the transparent badges.

## Fix (5166d04d)

- **Bake intrinsic integer `width`/`height` into every badge SVG root** — 19 local `assets/*.svg` here, plus the 11 jsdelivr-hosted ones in `a1rtight/tester@05be775`. Intrinsic height is exactly 18 (logo 29), so WebKit has nothing to floor.
- **Keep README imgs width-only** — GitHub stamps nothing but `max-width:100%` on those, so no background pill.
- **Pin all 25 jsdelivr URLs `@main` → `@05be775…`** — immutable ref; neither jsdelivr's edge cache (12h) nor GitHub's camo proxy (up to 7d) can serve the stale viewBox-only files, and pinned refs can't intermittently re-resolve (the historical `?`-broken-image failure mode).
- Retuned `associations.svg` width 109 → 120 so it renders 18px like every sibling label (was 16.4px).

## Verification

Rendered the GitHub-API-rendered README HTML in headless **Chromium and WebKit** (Playwright): all 30 badges report natural and rendered size of exactly `W×18` (logo `180×29`) in both engines, all loaded `200` / `image/svg+xml` from the pinned URLs.

Note: the same two commits are currently also on `feat/apple-notes-integration` (#260) where they were first made; git dedupes identical changes on merge, whichever lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)