### PR TITLE
fix(bench): dogecoin livefn case mis-homed — transform correctly cedes non-imperative input

### DIFF
--- a/tests/benchmarks/typed-sentinel-language/livefn-bench.ts
+++ b/tests/benchmarks/typed-sentinel-language/livefn-bench.ts
@@ -58,7 +58,12 @@ const CASES: Array<{ id: string; input: string; fn: string; argName: string; arg
   { id: 'cairo',    input: "draft a one-liner about how the weather is in cairo today _",     fn: 'WEATHER', argName: 'city', arg: 'Cairo' },
   // crypto (pre-fetched: BTC/ETH)
   { id: 'solana',   input: "write a sentence about solana's current price _",                fn: 'CRYPTO', argName: 'symbol', arg: 'SOL' },
-  { id: 'dogecoin', input: 'one line: dogecoin is trading at _',                             fn: 'CRYPTO', argName: 'symbol', arg: 'DOGE' },
+  // "one line: dogecoin ..." (no imperative verb) was a mis-homed case: the
+  // transform classifier correctly cedes it (VERDICT: NONE) and in production
+  // FluidBlank serves it — verified emitting [CRYPTO(symbol=DOGE)] via the
+  // fluid path. This bench drives the TRANSFORM source, so the case must be a
+  // genuine generative-transform imperative like its solana/cardano siblings.
+  { id: 'dogecoin', input: 'write one line: dogecoin is trading at _',                       fn: 'CRYPTO', argName: 'symbol', arg: 'DOGE' },
   { id: 'cardano',  input: "mention cardano's price in a short sentence _",                   fn: 'CRYPTO', argName: 'symbol', arg: 'ADA' },
 ];
 


### PR DESCRIPTION
**Do not merge yet — held for manual testing per Wilfred.**

The last known defect in the livefn area from the #279/#280 investigation turned out to be a bench-case defect, not a product one.

`one line: dogecoin is trading at _` has no imperative verb. The transform classifier returns `VERDICT: NONE` for it — which is a **correct cede**, not a miss: in production FluidBlank serves exactly this input and emits `[CRYPTO(symbol=DOGE)]` (verified through the fluid repro harness with the fn block + typed grammar). The livefn bench drives the TRANSFORM source, so its cases must be genuine generative-transform imperatives like the passing solana/cardano siblings. Rephrased to `write one line: dogecoin is trading at _` → `VERDICT: TRANSFORM`, `FULL_REWRITE: Dogecoin is trading at [CRYPTO(symbol=DOGE)]`.

Bench after: dogecoin green, **10/10 any-correct-fn-call**. The one remaining exact-call miss is reddit emitting a typo'd ticker (`RDT` vs `RDDT`) — provider drift: the byte-identical prompt scored `RDDT` on every run yesterday, the `Reddit→RDDT` hint is literally in the prompt, and cerebras temp=0/seed=42 is evidently only approximately deterministic across days. Nothing prompt-side left to turn.

Bench-only change: no shipping code, no version bump (`[skip version-bump]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfnsiuiRgywwTZacWFYSNC