### PR TITLE
docs(cli): document opencues init's AUDITORS.md scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs — document `opencues init`'s `AUDITORS.md` scaffold (`opencues` CLI 0.2.41 → 0.2.42)
+
+Follows the CLI-bugfix PR that made `opencues init` scaffold `AUDITORS.md`. The scaffolded project `README.md` template now lists `AUDITORS.md` in its file table (it was creating the file without explaining it); `docs/guides/cli-reference.md`'s `init` section now names the four files it actually writes (`CUES.md`/`BLANKS.md`/`AUDITORS.md`/`README.md`) instead of the inaccurate "`cues/` and `blanks/` folder layout"; and `docs/guides/adding-an-auditor.md` §6 notes that `init` scaffolds a starter `AUDITORS.md`. Template-file (`src/templates/README.md`) change → patch bump.
+
 ### Fixed — outbound PII floor corrupted the prompt's own instruction examples, killing identity fills on real hosts (`@opencues/core` 0.18.0 → 0.18.1, `@opencues/runtime` 0.13.3 → 0.13.4, issues #279 + #280)
 
 **Root cause (found via byte-diffing the live wire body against a passing repro):** in `identity-context-mode: safe`, the `dispatchChat` outbound-dehydration floor scrubbed catalog values from EVERY message — including the SYSTEM message, whose static instruction examples can legitimately contain text equal to a user's real catalog values. The catalog RULES' own rule-10 examples hardcoded `https://github.com/wkasekende` (a real handle) and the Ofcom dummy phone; for any user whose stored values matched, the floor rewrote the prompt's examples into self-contradictions (`buffer "wkasekende _" + label "GitHub URL" → "[GITHUB]" (NOT [GITHUB])`), and gpt-oss-120b answered `SPAN: NONE` to every identity lookup (`i work at _` → nothing). The floor's warning fired but went to `console.warn`, which the CC TUI swallows. Scenario 54 failed on every host while every bench passed — the benches never register the floor guard.

--- a/docs/guides/adding-an-auditor.md
+++ b/docs/guides/adding-an-auditor.md
@@ -144,6 +144,8 @@ disable: [british-english]
 
 The auditor is filtered out at this layer's composition. cd out of the project, it fires again. Same `disable:` mechanic cues and blanks have, scoped per-surface.
 
+`opencues init` scaffolds a starter `AUDITORS.md` (with an empty `disable: []`) alongside `CUES.md`/`BLANKS.md`, so a project already has the file to edit.
+
 ## 7. Test it
 
 1. Drop your `AUDITOR.md` in `~/.cues/auditors/<name>/AUDITOR.md`.

--- a/docs/guides/cli-reference.md
+++ b/docs/guides/cli-reference.md
@@ -171,9 +171,10 @@ whether the key or the network is the problem.
 
 ### `init` — scaffold `<cwd>/.cues/`
 
-Creates the directory + starter folder layout (`cues/` and `blanks/`)
-with comments explaining each block. Idempotent — won't clobber
-existing files.
+Creates the directory with four starter files — `CUES.md`, `BLANKS.md`,
+`AUDITORS.md`, and a `README.md` explaining the layout — each with
+comments describing its blocks (`--minimal` writes empty `.md` files
+instead). Idempotent — won't clobber existing files.
 
 ```bash
 cd ~/my-project

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "private": true,
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "bin": {

--- a/packages/opencues-cli/src/templates/README.md
+++ b/packages/opencues-cli/src/templates/README.md
@@ -8,6 +8,7 @@ project (`cd <project> && claude-cues` or equivalent).
 |---|---|
 | `CUES.md` | LLM cue sources (word alternatives) |
 | `BLANKS.md` | Blank declarations (typed `_` triggers a fill, scripted blanks, etc.) |
+| `AUDITORS.md` | Auditor surface config — the `disable:` list scopes which auditors run in this project |
 | `cues/<name>/CUE.md` | Folder-based cue sources |
 | `blanks/<name>/BLANK.md` + `<name>.sh` | Folder-based blanks (with optional colocated script) |
 


### PR DESCRIPTION
Follow-up to the CLI-bugfix PR (#285), which made `opencues init` scaffold an `AUDITORS.md` — but left the surrounding docs describing a 3-file/old scaffold. This closes that gap.

## Changes

1. **`packages/opencues-cli/src/templates/README.md`** — the README `init` drops into a project sat right next to the new `AUDITORS.md` but its file table never listed it. Added the row.
2. **`docs/guides/cli-reference.md`** — the `init` section claimed it scaffolds a *"`cues/` and `blanks/` folder layout"*, which was never accurate. Now names the four files it actually writes (`CUES.md`/`BLANKS.md`/`AUDITORS.md`/`README.md`), and mentions `--minimal`.
3. **`docs/guides/adding-an-auditor.md` §6** — notes that `init` scaffolds a starter `AUDITORS.md` (empty `disable: []`), so a project already has the file to edit.

## Version

`src/templates/README.md` is a shipped artifact (it's what `init` writes), so per the version-bump policy: `opencues` CLI 0.2.41 → 0.2.42. CHANGELOG updated. No `@opencues/core`/`runtime` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)