### PR TITLE
chore(gitignore): ignore integrations/android/ (private repo cloned in)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ tests/benchmarks/fluid-blank/cases-generated.jsonl
 # Internal harness — lives in its own private repo, cloned into this path.
 tests/agentic/
 
+# Android integration — lives in its own private repo, cloned into this path.
+integrations/android/
+
 # Internal docs — strategy, handoffs, audits not for public consumption.
 .internal/
 


### PR DESCRIPTION
The Android integration lives in its own private repo cloned into `integrations/android/`. Add it to `.gitignore` — mirroring how `tests/agentic/` is ignored — so the private repo can't be accidentally staged.

Salvaged from an abandoned worktree branch (`worktree-dapper-exploring-penguin`); the rest of that commit was pnpm-lock churn from the workspace glob picking up the cloned package, which was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)