### PR TITLE
docs(shipped-defaults): note the location blank's `map` keyword

### DIFF
--- a/docs/features/shipped-defaults.md
+++ b/docs/features/shipped-defaults.md
@@ -45,7 +45,7 @@ defaults/
     │   └── BrightCtl.cs
     ├── stocks/BLANK.md
     ├── weather/BLANK.md
-    ├── location/BLANK.md        # place/address/POI lookup via OSM Nominatim
+    ├── location/BLANK.md        # place/address/POI lookup via OSM Nominatim (map keyword → rich card)
     ├── note/BLANK.md            # keyword add/recall/delete (PROTOTYPE, issue #210)
     ├── hackernews/BLANK.md
     ├── countries/BLANK.md


### PR DESCRIPTION
One-line follow-up to #289. The shipped-blank enumeration in `docs/features/shipped-defaults.md` described the location blank as only "place/address/POI lookup via OSM Nominatim" — now notes the `map` keyword (rich OSM location card) that #289 added.

The authoritative per-blank doc (`defaults/blanks/location/BLANK.md`) and the CHANGELOG were both updated in #289 itself; this is the one enumeration comment that lagged. Docs-only, `[skip version-bump]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ri9SsZFEhc32V4CBsrHV4