### PR TITLE
fix(blank-fill): named [err] fill when a blank has config but no host implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — a blank with config but no host implementation now says so instead of doing nothing (`@opencues/runtime` 0.16.0 → 0.16.1)
+
+`~/.cues` is shared across hosts but runtime bundles are per-host, and ANY host's install seeds the shared config — so a BLANK.md can legitimately run ahead of another host's installed bundle. When that happened on a blankInvoke-capable host with a runtime-served (scriptless) blank, the dispatch hit the registry miss and skipped in TOTAL silence: no log, no fill, slot dead. Live case (July 2026): the loading-animation blank's config seeded by an opencode install while the CC fork was still one runtime behind — "it didn't seem to do anything". The same silent shape covers factories that skip registration over a missing prerequisite (e.g. stocks without a Finnhub key).
+
+Now: a named `[err] <blank>: not available on this host — stale bundle or missing prerequisite. Try \`opencues install <host>\`` fill (the `[err]` path replaces only the `_`, so the typed command survives), plus a once-per-blank warn in the log with the fuller diagnostic. Loading-animation claim released correctly (no forever-spin). Pinned by three journeys in `blank-fill.test.ts`: named fill + command survival, once-per-blank warn dedup across re-fires, and animator release.
+
 ### Fixed — launch-time self-heal no longer rebuilds forks BACKWARD from a stale clone (`opencues` CLI 0.2.44 → 0.2.45)
 
 The `opencues run <host>` srcHash self-heal treated ANY marker/source mismatch as "stale" — but srcHash is direction-blind. A second clone, a git worktree, or an old branch checked out in the same clone would silently rebuild every fork it launched back to its own older source; and because installers copy without deleting, the result was a MIXED bundle (new files present, `blanks/index.js` + package.json stale) — the dual-clone variant of the May 2026 drift class. Hit live July 2026: `opencues run` from a wip-branch checkout (runtime 0.13.5) clobbered a fork freshly installed from master (0.16.0) minutes earlier.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/blank-fill.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.test.ts
@@ -1888,3 +1888,80 @@ describe('model blank routing (shapes from defaults/blanks/model/BLANK.md)', () 
     expect(adapter.blankInvokeCalls[0]).toMatchObject({ blankName: 'dictionary' });
   });
 });
+
+// ─── Registry miss — config present, implementation absent ────────────────
+//
+// ~/.cues is shared across hosts but bundles are per-host, so a BLANK.md
+// can legitimately run AHEAD of a host's installed runtime (any host's
+// install seeds the shared config). Pre-fix this dispatched the invoke
+// and then skipped in total silence — no log, no fill — reading as
+// "OpenCues is broken" (July 2026: the loading-animation blank on a
+// stale CC fork). The contract now: a named [err] fill that replaces
+// only the `_` (command survives), plus a once-per-blank warn.
+describe('BlankFill registry miss (blankInvoke null + no blankScript)', () => {
+  const SCRIPTLESS = `---
+type: blank
+name: newblank
+blankKeywords: newblank
+blankProximity: 10
+---
+`;
+
+  async function missSetup() {
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: { '/mock/CUES.md': TIPS, '/proj/blanks/newblank/BLANK.md': SCRIPTLESS },
+      capabilities: [
+        'render-override', 'dim-ranges', 'highlight-range',
+        'file-read', 'file-write', 'force-render', 'change-source',
+        'blank-invoke',
+      ],
+    });
+    // NO stub for 'newblank' — blankInvoke returns null, simulating a
+    // bundle that predates the blank (or a factory that skipped
+    // registration over a missing prerequisite).
+    adapter.stubBlankInvoke('someother:get', 'x');
+    const loader = new ConfigLoader(adapter);
+    await loader.load();
+    const bf = new BlankFill(adapter, loader);
+    bf.subscribe();
+    return { adapter };
+  }
+
+  it('fills a named [err] instead of silent nothing; command text survives', async () => {
+    const { adapter } = await missSetup();
+    adapter.pushText('newblank _');
+    await new Promise(r => setTimeout(r, 0));
+    expect(adapter.blankInvokeCalls.length).toBe(1);
+    // [err] feedback: only the `_` is replaced — keyword + any typed
+    // command remain for the user to see what failed.
+    expect(adapter.getText()).toBe(
+      'newblank [err] newblank: not available on this host — stale bundle or missing prerequisite. Try `opencues install mock`',
+    );
+  });
+
+  it('warns once per blank with the diagnostic; repeat fires do not re-warn', async () => {
+    const { adapter } = await missSetup();
+    adapter.pushText('newblank _');
+    await new Promise(r => setTimeout(r, 0));
+    const warns = () => adapter.logs.filter(l =>
+      l.level === 'warn' && String(l.msg).includes('has config but no implementation'));
+    expect(warns()).toHaveLength(1);
+    expect(warns()[0].msg).toContain('opencues install mock');
+    // Re-fire: fresh buffer, same miss — fill happens again, warn doesn't.
+    adapter.pushText('');
+    adapter.pushText('newblank _');
+    await new Promise(r => setTimeout(r, 0));
+    expect(warns()).toHaveLength(1);
+  });
+
+  it('does not release the loading animation into a forever-spin (stop is called)', async () => {
+    const { adapter } = await missSetup();
+    adapter.pushText('newblank _');
+    await new Promise(r => setTimeout(r, 0));
+    // The [err] fill landed, which means applyAsyncFill ran AFTER the
+    // animator release — if the claim leaked, the staleness guard
+    // would have seen a frame char and dropped the fill.
+    expect(adapter.getText()).toContain('[err] newblank');
+  });
+});

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -67,6 +67,9 @@ export class BlankFill {
   /** INFOSEC F9: blank names we've already warned about for missing
    *  `sandbox:` declaration. One warn per name per process. */
   private _warnedMissingSandboxBlanks = new Set<string>();
+  /** Once-per-blank warn dedup for the config-without-implementation
+   *  case (registry miss + no blankScript). */
+  private _warnedUnavailableBlanks = new Set<string>();
 
   /**
    * Per-blank result cache. Keyed by `<blankName>::<argsKey>` where
@@ -563,12 +566,38 @@ export class BlankFill {
       if (!handle) {
         if (!script) {
           // blankInvoke didn't recognise the blank AND there's no
-          // shell fallback. Drop the dedup so a later state change can
-          // retry, and skip cleanly. Release the loading claim we
-          // just took — without this, the slot would animate forever
-          // (no .then/.catch ever fires to stop it).
+          // shell fallback: the CONFIG for this blank exists (a
+          // BLANK.md matched and formed the slot) but the host has no
+          // IMPLEMENTATION — either the installed bundle predates the
+          // blank (shared ~/.cues is seeded by ANY host's install, so
+          // configs can legitimately run ahead of another host's
+          // bundle), or the blank's factory skipped registration over
+          // a missing prerequisite (e.g. stocks without a Finnhub
+          // key). This used to skip in TOTAL SILENCE — no log, no
+          // fill — and read as "OpenCues is broken" (July 2026, the
+          // loading-animation blank on a stale CC fork). Name it:
+          // an [err] fill replaces only the `_` (the typed command
+          // survives) and a once-per-blank warn carries the detail.
+          // Drop the dedup so a later state change can retry, and
+          // release the loading claim we just took — without this,
+          // the slot would animate forever (no .then/.catch ever
+          // fires to stop it).
           this._pendingScripts.delete(dedupKey);
           this._loadingAnimator().stop(slot.index, 'blank-fill');
+          if (!this._warnedUnavailableBlanks.has(slot.blankName)) {
+            this._warnedUnavailableBlanks.add(slot.blankName);
+            this.adapter.log('warn',
+              `BlankFill: "${slot.blankName}" has config but no implementation on this host — ` +
+              `blankInvoke doesn't know it and its BLANK.md declares no blankScript. ` +
+              `Stale bundle (config newer than the installed runtime) or an unmet ` +
+              `registration prerequisite. Fix: \`opencues install ${this.adapter.hostName}\`.`,
+            );
+          }
+          this.applyAsyncFill(
+            slot,
+            `[err] ${slot.blankName}: not available on this host — stale bundle or missing prerequisite. Try \`opencues install ${this.adapter.hostName}\``,
+            typedAction,
+          );
           return;
         }
         // OS-level sandbox config — populated when the blank's


### PR DESCRIPTION
## The bug (hit live yesterday)

`~/.cues` is shared across hosts; runtime bundles are per-host; and **any** host's install runs seed-configs — so a blank's BLANK.md can legitimately be newer than another host's installed bundle. When a runtime-served (scriptless) blank then fired on a blankInvoke-capable host, `blankInvoke` returned null (not in the registry) and the dispatch skipped in **total silence**: the log showed the match and the invoke, then nothing — no `[err]`, no warn, dead slot. Live case: the `loading animation` blank (#299) seeded into shared config by an opencode install while the CC fork was still on the previous runtime — user-visible as "it didn't seem to do anything". The same silent shape covers factories that skip registration over a missing prerequisite (e.g. stocks without a Finnhub key).

## The fix

In the registry-miss + no-`blankScript` branch of the get dispatch:

- **In-buffer**: `[err] <blank>: not available on this host — stale bundle or missing prerequisite. Try \`opencues install <host>\`` — routed through the existing `[err]` feedback path, so only the `_` is replaced and the typed command survives.
- **In-log**: a once-per-blank warn with the fuller diagnostic (config-newer-than-bundle vs unmet registration prerequisite, and the exact install command with the real host name).
- The loading-animation claim is released before the fill (no forever-spin), and the dedup drop is kept so a later state change can retry after a reinstall.

The set/step dispatch paths are untouched — they already degrade into the read-back get, so the same error surfaces there through this one branch. Hosts without the `blank-invoke` capability never form the slot in the first place (pre-existing gate at slot-forming), so nothing changes for them.

## Tests

Three journeys in `blank-fill.test.ts` (scriptless fixture, `blank-invoke`-capable MockAdapter, no stub = registry miss): exact named fill with command survival, once-per-blank warn dedup across re-fires, and fill-lands-after-animator-release. Full runtime suite green (2000).

`@opencues/runtime` 0.16.0 → 0.16.1 · CHANGELOG updated · no SPEC_VERSION change.

Note: #298 and #299 also bump the runtime version — whichever merges last will need the usual trivial version/CHANGELOG conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)