### PR TITLE
fix(windows): verify-before-restore + verify-before-write in the shim's paste/animation paths

### DIFF
--- a/integrations/windows/CLAUDE.md
+++ b/integrations/windows/CLAUDE.md
@@ -173,6 +173,39 @@ declines and falls through to the whole-value path — where
 big, non-tail write) always takes a whole-value path — typing is only
 for the small frames.
 
+## Verify-before-write + verify-before-restore (2026-07-14 incident pair)
+
+Two silent races shipped in the write paths and both fired live on the
+same day; the fixes share one primitive, `TryReadCurrentField` (an
+on-demand, mode-aware read of the attached field), and are pinned by
+`tests/clipboard-invariants.mjs` (in pre-pr):
+
+1. **Clipboard restore raced the app's async paste read.** `PasteReplace`
+   saved the user's clipboard, set the substitution, sent Ctrl+V, slept
+   a fixed 300ms, restored. Electron consumes the clipboard
+   asynchronously — Discord under load was observed reading >1.1s after
+   Ctrl+V — so when the restore won, the paste delivered the USER'S OLD
+   CLIPBOARD into the focused app (live: a copied email address landed
+   in a Discord input instead of the substitution). That is a clipboard
+   LEAK into whatever app is focused. Now: poll the field until it
+   reflects the pasted text (EolNorm-folded), THEN restore; on timeout
+   (`OPENCUES_CLIPBOARD_RESTORE_MAX_MS`, default 3000) FAIL SAFE — skip
+   the restore and warn. Losing old clipboard contents is an annoyance;
+   pasting them into the foreground app is a leak.
+
+2. **Write diffs computed against a stale field model.** Both
+   `TryTypeMicroEdit` (animation frames) and `PasteReplace`'s backspace
+   path diffed against the shim's belief (`_lastSentText` / the
+   daemon's `oldText`). Phase 1 has no keyboard hook, so USER keystrokes
+   are invisible between reads — a stale model turns the backspace burst
+   into user-content deletion (live: "congratulations" typed mid-
+   animation lost its leading "con"). Now: read the field immediately
+   before acting; micro-frames DROP on divergence (cosmetic — the final
+   write is the absolute anchor), PasteReplace REBASES its diff on the
+   fresh read. Known trade: on very slow editors a frame whose
+   predecessor hasn't rendered yet reads as divergence and gets dropped
+   — the animation stalls a frame; never a wrong write.
+
 ## Multi-buffer state — MUST reset on focus change
 
 The Windows host attaches to **many** independent fields across apps in

--- a/integrations/windows/native/OpenCuesWindows.cs
+++ b/integrations/windows/native/OpenCuesWindows.cs
@@ -1774,6 +1774,29 @@ namespace OpenCues
             return 3000;
         }
 
+        // Lowercased-alphanumeric fold for paste-consumption matching.
+        // Discord/Slate re-dress pasted text in accValue readbacks (emoji
+        // as object chars, markdown handling, trailing dress), so byte
+        // equality — even EolNorm-folded — can fail on a paste that
+        // plainly landed, and the fail-safe would then eat the user's
+        // clipboard restore on EVERY big substitution (observed live
+        // 2026-07-14 18:35: paste landed, bracket reconciled, verify
+        // still timed out). Folding both sides to [a-z0-9] and checking
+        // the readback CONTAINS a prefix window of the pasted text
+        // survives any dress the app applies to punctuation/emoji/EOLs.
+        static string AlnumFold(string s, int max)
+        {
+            if (s == null) return "";
+            var sb = new StringBuilder(Math.Min(s.Length, max));
+            for (int i = 0; i < s.Length && sb.Length < max; i++)
+            {
+                char c = s[i];
+                if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) sb.Append(c);
+                else if (c >= 'A' && c <= 'Z') sb.Append((char)(c + 32));
+            }
+            return sb.ToString();
+        }
+
         static void PasteReplace(string text, string oldText)
         {
             string saved = null;
@@ -1868,15 +1891,19 @@ namespace OpenCues
                 bool consumed = false;
                 int deadline = unchecked(Environment.TickCount + _clipRestoreMaxMs);
                 string want = EolNorm(text);
+                // Fold-tolerant fallback: >=12 fold chars required so a
+                // short/generic paste ("ok") can't false-match text that
+                // was already in the field; shorter pastes verify by the
+                // exact path only.
+                string wantFold = AlnumFold(text, 24);
+                bool foldUsable = wantFold.Length >= 12;
                 while (unchecked(deadline - Environment.TickCount) > 0)
                 {
                     Thread.Sleep(50);
                     string now;
-                    if (TryReadCurrentField(out now) && now != null && EolNorm(now) == want)
-                    {
-                        consumed = true;
-                        break;
-                    }
+                    if (!TryReadCurrentField(out now) || now == null) continue;
+                    if (EolNorm(now) == want) { consumed = true; break; }
+                    if (foldUsable && AlnumFold(now, 4000).Contains(wantFold)) { consumed = true; break; }
                 }
                 if (consumed)
                 {

--- a/integrations/windows/native/OpenCuesWindows.cs
+++ b/integrations/windows/native/OpenCuesWindows.cs
@@ -1637,6 +1637,24 @@ namespace OpenCues
             if (del > MSAA_TYPE_MAX || add > MSAA_TYPE_MAX) return false;
             string tail = text.Substring(p);
             if (tail.IndexOf('\n') >= 0 || tail.IndexOf('\r') >= 0) return false;
+            // Read-before-write: the diff above is computed against
+            // `_lastSentText` — the shim's MODEL of the field, which goes
+            // stale the instant the USER types (phase 1 has no keyboard
+            // hook, so user keystrokes are invisible until the next event
+            // read). Sending backspaces against a stale model deletes user
+            // content — live incident 2026-07-14: an animation frame burst
+            // ate the leading chars of "congratulations" mid-typing. Verify
+            // the field still matches the model; on divergence DROP the
+            // frame (animation is cosmetic — the final substitution write
+            // is an absolute anchor that never depends on frames landing).
+            // Read failure keeps the prior trust-the-model behaviour.
+            string live;
+            if (TryReadCurrentField(out live) && live != null && EolNorm(live) != EolNorm(cur))
+            {
+                Log("debug", "micro-frame skipped: field diverged from model ("
+                    + cur.Length + " -> " + live.Length + " chars; user typing?)");
+                return true;   // swallow the frame; never write against a stale model
+            }
             NoteSelfWrite(text);
             var inputs = new INPUT[del * 2 + tail.Length * 2];
             int k = 0;
@@ -1716,10 +1734,64 @@ namespace OpenCues
             if (!string.IsNullOrEmpty(v) && int.TryParse(v, out m) && m >= 0 && m <= 4000) return m;
             return 40;
         }
+        // Read the attached field's CURRENT text on demand, mode-aware.
+        // Used by the write paths to verify their model of the field
+        // (`oldText` / `_lastSentText`) against reality IMMEDIATELY before
+        // acting, and by PasteReplace to verify paste consumption before
+        // restoring the user's clipboard. Returns false when no readable
+        // field is attached (write paths then fall back to their prior
+        // trust-the-model behaviour).
+        static bool TryReadCurrentField(out string cur)
+        {
+            cur = null;
+            try
+            {
+                if (_attachMode == AttachMode.Msaa)
+                {
+                    int nodeId;
+                    return TryReadFocusedElectron(out cur, out nodeId) && cur != null;
+                }
+                var el = _hookedEl;
+                if (el == null) return false;
+                cur = ReadValue(el);
+                return cur != null;
+            }
+            catch { return false; }
+        }
+
+        // How long PasteReplace waits for the target app to CONSUME the
+        // paste before restoring the user's previous clipboard. Discord
+        // under load was observed consuming >1.1s after Ctrl+V; the old
+        // fixed 300ms restore raced it and the paste delivered the
+        // RESTORED (user's) clipboard into the field — live incident
+        // 2026-07-14: a copied email address replaced the substitution.
+        static readonly int _clipRestoreMaxMs = ReadClipRestoreMaxMs();
+        static int ReadClipRestoreMaxMs()
+        {
+            var v = Environment.GetEnvironmentVariable("OPENCUES_CLIPBOARD_RESTORE_MAX_MS");
+            int m;
+            if (!string.IsNullOrEmpty(v) && int.TryParse(v, out m) && m >= 300 && m <= 15000) return m;
+            return 3000;
+        }
+
         static void PasteReplace(string text, string oldText)
         {
             string saved = null;
             try { saved = GetClipboardText(); } catch { }
+
+            // Verify the field model against reality before computing the
+            // diff. `oldText` is the daemon's last read — if the user typed
+            // (or the app edited) since, backspacing `oldLen - p` chars
+            // deletes USER content (the 2026-07-14 "congratulations" →
+            // "gratulations" class). A fresh read supersedes the parameter;
+            // read failure keeps the prior trust-the-model behaviour.
+            string fresh;
+            if (TryReadCurrentField(out fresh) && fresh != oldText)
+            {
+                Log("debug", "diff-paste: field diverged from model (" + (oldText != null ? oldText.Length : 0)
+                    + " -> " + fresh.Length + " chars), rebasing diff on fresh read");
+                oldText = fresh;
+            }
 
             int oldLen = oldText != null ? oldText.Length : 0;
             int p = CommonPrefixLen(oldText, text);   // unchanged head we keep
@@ -1775,10 +1847,50 @@ namespace OpenCues
                     KeyChord(VK_CONTROL, VK_V);   // paste into the empty field
                 }
             }
-            // Electron reads the clipboard ASYNCHRONOUSLY after Ctrl+V; 300ms
-            // clears that read before we restore the user's previous clipboard.
-            Thread.Sleep(300);
-            if (saved != null) { try { SetClipboardText(saved); } catch { } }
+            // Electron reads the clipboard ASYNCHRONOUSLY after Ctrl+V — and
+            // NOT on a bounded schedule: Discord under load was observed
+            // consuming >1.1s later. Restoring the user's clipboard on a
+            // fixed timer therefore RACES the read; when the restore wins,
+            // the paste delivers the user's OLD clipboard into the focused
+            // app (live incident 2026-07-14: a copied email address landed
+            // in a Discord input instead of the substitution — a clipboard
+            // LEAK into whatever app is focused, not just a wrong render).
+            //
+            // Verify consumption instead: poll the field until it reflects
+            // the pasted text (EolNorm both sides — apps re-render newlines,
+            // see the newline-rendering table), THEN restore. On timeout or
+            // an unreadable field, FAIL SAFE: skip the restore entirely —
+            // losing the user's old clipboard contents is an annoyance;
+            // pasting them into the foreground app is a leak. Window is
+            // tunable via OPENCUES_CLIPBOARD_RESTORE_MAX_MS (default 3000).
+            if (saved != null)
+            {
+                bool consumed = false;
+                int deadline = unchecked(Environment.TickCount + _clipRestoreMaxMs);
+                string want = EolNorm(text);
+                while (unchecked(deadline - Environment.TickCount) > 0)
+                {
+                    Thread.Sleep(50);
+                    string now;
+                    if (TryReadCurrentField(out now) && now != null && EolNorm(now) == want)
+                    {
+                        consumed = true;
+                        break;
+                    }
+                }
+                if (consumed)
+                {
+                    try { SetClipboardText(saved); } catch { }
+                    Log("debug", "clipboard restored after verified paste consumption");
+                }
+                else
+                {
+                    Log("warn", "clipboard NOT restored: paste consumption unverified after "
+                        + _clipRestoreMaxMs + "ms — refusing to race the app's async clipboard read"
+                        + " (restoring early can paste the user's old clipboard into the field)."
+                        + " Previous clipboard contents were replaced by the substitution text.");
+                }
+            }
         }
 
         // Length of the longest common prefix of a and b (the unchanged head).

--- a/integrations/windows/package.json
+++ b/integrations/windows/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@opencues/windows",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
-  "description": "OpenCues for Windows — a system-wide host. A WSL-side daemon runs the OpenCues runtime against your existing ~/.cues config + keys; a thin Windows-native UI Automation shim mirrors whatever text field you're typing in. Type `_` in Notepad / WordPad / a dialog and it fills. Phase 1: single-answer surface (fluid-blank / transform-blank / compute blanks), no cycling overlay yet.",
+  "description": "OpenCues for Windows \u2014 a system-wide host. A WSL-side daemon runs the OpenCues runtime against your existing ~/.cues config + keys; a thin Windows-native UI Automation shim mirrors whatever text field you're typing in. Type `_` in Notepad / WordPad / a dialog and it fills. Phase 1: single-answer surface (fluid-blank / transform-blank / compute blanks), no cycling overlay yet.",
   "type": "commonjs",
   "bin": {
     "oc-windows": "./bin/oc-windows"
@@ -13,7 +13,7 @@
   "os": [
     "linux"
   ],
-  "//comment-on-os": "The daemon runs in WSL/Linux. The native shim (native/OpenCuesWindows.cs) runs on Windows and is compiled on-demand by OpenCuesWindows.ps1 — it is not an npm-built artifact, so this package's `os` is linux (where the daemon lives).",
+  "//comment-on-os": "The daemon runs in WSL/Linux. The native shim (native/OpenCuesWindows.cs) runs on Windows and is compiled on-demand by OpenCuesWindows.ps1 \u2014 it is not an npm-built artifact, so this package's `os` is linux (where the daemon lives).",
   "scripts": {
     "build": "echo '@opencues/windows: no build (hostd.cjs runs the staged @opencues/runtime dist directly; the Windows shim is Add-Type-compiled on Windows)'"
   },

--- a/integrations/windows/tests/clipboard-invariants.mjs
+++ b/integrations/windows/tests/clipboard-invariants.mjs
@@ -1,0 +1,83 @@
+// Clipboard + stale-model write invariants — a SOURCE guard for the C# shim.
+//
+// Same rationale as newline-invariants.mjs: the shim is Add-Type-compiled
+// C#, Windows-only, and these failure modes are SILENT — the exact classes
+// that cost real time on 2026-07-14:
+//
+//   1. PasteReplace restored the user's clipboard on a FIXED TIMER (300ms)
+//      while Electron consumes the clipboard asynchronously (>1.1s observed
+//      on Discord under load). When the restore won the race, Ctrl+V pasted
+//      the user's OLD clipboard into the focused app — a copied email
+//      address replaced the substitution. That is a clipboard LEAK into
+//      whatever app is focused, not just a wrong render.
+//   2. Write paths computed diffs against the shim's MODEL of the field
+//      (`_lastSentText` / daemon-supplied oldText) without verifying
+//      reality; a stale model turned backspace bursts into user-content
+//      deletion ("congratulations" typed mid-animation lost its "con").
+//
+// If a refactor reintroduces either shape, nothing errors — this catches it.
+//
+// Run: node integrations/windows/tests/clipboard-invariants.mjs
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const shimPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)), '..', 'native', 'OpenCuesWindows.cs');
+const src = fs.readFileSync(shimPath, 'utf8');
+
+let failures = 0;
+const check = (name, ok, detail) => {
+  console.log((ok ? 'ok   ' : 'FAIL ') + name + (!ok && detail ? '  — ' + detail : ''));
+  if (!ok) failures++;
+};
+const has = (re) => re.test(src);
+
+// Slice out PasteReplace's body (up to the next `static ` at the same
+// nesting depth is overkill — grab a generous window).
+const prStart = src.indexOf('static void PasteReplace');
+const pasteReplace = prStart >= 0 ? src.slice(prStart, prStart + 8000) : '';
+
+// 1. The restore must be gated on VERIFIED paste consumption, never a bare
+//    timer. Positive: a consumption flag + a conditional restore.
+check('PasteReplace verifies consumption before restoring the clipboard',
+  /bool consumed = false;[\s\S]*?if \(consumed\)[\s\S]*?SetClipboardText\(saved\)/.test(pasteReplace),
+  'restore must sit inside an `if (consumed)` after a field-readback verify loop');
+
+// 2. The old timer-restore shape must not come back: a Sleep immediately
+//    followed by an unconditional restore.
+check('no timer-raced clipboard restore',
+  !/Thread\.Sleep\(\d+\);\s*\r?\n\s*if \(saved != null\) \{ try \{ SetClipboardText\(saved\)/.test(src),
+  'Thread.Sleep(N) directly followed by an unconditional SetClipboardText(saved) is the raced shape');
+
+// 3. Fail-safe on timeout: the unverified path must SKIP the restore and
+//    say so (losing old clipboard contents is an annoyance; pasting them
+//    into the foreground app is a leak).
+check('unverified consumption skips the restore, loudly',
+  /clipboard NOT restored/.test(pasteReplace),
+  'timeout path must warn and skip SetClipboardText(saved)');
+
+// 4. PasteReplace rebases its diff on a FRESH field read before deleting
+//    anything (stale oldText → backspaces eat user content).
+check('PasteReplace rebases diff on a fresh field read',
+  /TryReadCurrentField\(out fresh\)[\s\S]*?oldText = fresh/.test(pasteReplace),
+  'must re-read the field and supersede stale oldText before computing the backspace count');
+
+// 5. The micro-frame animation path must verify the field still matches
+//    its model before sending backspaces, and DROP the frame on
+//    divergence (animation is cosmetic; the final write is the anchor).
+const tmStart = src.indexOf('static bool TryTypeMicroEdit');
+const tryType = tmStart >= 0 ? src.slice(tmStart, tmStart + 5000) : '';
+check('micro-frames read-before-write and drop on divergence',
+  /TryReadCurrentField\(out live\)[\s\S]*?return true;/.test(tryType) && /micro-frame skipped/.test(tryType),
+  'TryTypeMicroEdit must verify the live field against _lastSentText and swallow the frame on mismatch');
+
+// 6. EOL-blind comparisons everywhere the verify reads back (apps re-dress
+//    newlines; a raw != would false-diverge every multi-line field).
+check('verify comparisons are EolNorm-folded',
+  /EolNorm\(now\) == want/.test(pasteReplace) && /EolNorm\(live\) != EolNorm\(cur\)/.test(tryType),
+  'both verify sites must compare through EolNorm');
+
+console.log(failures === 0 ? '\nall clipboard/stale-model invariants hold' : `\n${failures} invariant(s) FAILED`);
+process.exit(failures === 0 ? 0 : 1);

--- a/integrations/windows/tests/clipboard-invariants.mjs
+++ b/integrations/windows/tests/clipboard-invariants.mjs
@@ -79,5 +79,16 @@ check('verify comparisons are EolNorm-folded',
   /EolNorm\(now\) == want/.test(pasteReplace) && /EolNorm\(live\) != EolNorm\(cur\)/.test(tryType),
   'both verify sites must compare through EolNorm');
 
+// 7. Consumption matching must have the fold-tolerant fallback: apps
+//    re-dress pasted text in readbacks (Discord/Slate emoji + markdown
+//    dress), so exact-equality-only verification times out on pastes
+//    that plainly landed — and the fail-safe then eats the user's
+//    clipboard restore on EVERY big substitution (observed live
+//    2026-07-14 18:35). The fallback must also have a minimum-length
+//    gate so short generic pastes can't false-match pre-existing text.
+check('consumption verify has the AlnumFold fallback with a min-length gate',
+  /wantFold\.Length >= 12/.test(pasteReplace) && /AlnumFold\(now, \d+\)\.Contains\(wantFold\)/.test(pasteReplace),
+  'PasteReplace verify loop must fall back to fold-contains with a >=12 fold-char gate');
+
 console.log(failures === 0 ? '\nall clipboard/stale-model invariants hold' : `\n${failures} invariant(s) FAILED`);
 process.exit(failures === 0 ? 0 : 1);

--- a/integrations/windows/tests/clipboard-restore.manual.md
+++ b/integrations/windows/tests/clipboard-restore.manual.md
@@ -1,0 +1,48 @@
+# Clipboard-restore + stale-model manual checklist (Windows-side)
+
+Companion to `clipboard-invariants.mjs` (which pins the SOURCE shapes on
+any OS). These are the visual/behavioural checks only a real Windows
+session can run — the pattern mirrors `newline-rendering.manual.md`.
+Origin: the 2026-07-14 incident pair (a copied email address pasted
+into Discord instead of the substitution; typed "congratulations"
+losing its leading "con" mid-animation).
+
+Run after any change to `PasteReplace`, `TryTypeMicroEdit`,
+`TryReadCurrentField`, or the clipboard helpers. Restart the tray first
+(the shim is Add-Type-compiled at launch).
+
+## 1. Clipboard leak (the one that matters)
+
+1. Copy a marker string: `CANARY123`.
+2. In Discord, trigger a big substitution:
+   `write a congratz message for discord _`
+3. PASS: the substitution lands AND pasting somewhere neutral yields
+   `CANARY123` — with `clipboard restored after verified paste
+   consumption` in `/tmp/opencues.log`.
+4. ACCEPTABLE (fail-safe): the substitution lands, the log warns
+   `clipboard NOT restored`, and the clipboard holds the substitution
+   text. If this happens EVERY time in an app, the consumption match is
+   too strict for that app's readback dress — extend the AlnumFold
+   fallback, never the timeout alone.
+5. FAIL (the leak): `CANARY123` appears IN THE FIELD instead of the
+   substitution. This must be impossible; if seen, the restore is
+   racing the paste again.
+
+## 2. Eaten keystrokes
+
+1. Trigger any blank and, while its loading animation is running,
+   immediately type a new command without pausing:
+   `congratulations letter _`
+2. PASS: every typed character survives (watch the daemon's
+   `resolveAndApply` lines — the text must start `congratulations`,
+   not `gratulations`). `micro-frame skipped: field diverged` lines in
+   the log are the guard working, not a failure.
+
+## 3. Restore actually happens (anti-lossiness)
+
+After several large substitutions across the app matrix (Discord,
+Slack, Notepad, WordPad), `grep -c 'clipboard restored after verified'
+/tmp/opencues.log` should roughly match the substitution count, with
+only occasional `clipboard NOT restored` warns. A 100% warn rate in
+any app = the consumption match never fires there; catalog the app's
+readback dress and extend the fold.

--- a/scripts/pre-pr.sh
+++ b/scripts/pre-pr.sh
@@ -63,6 +63,7 @@ step "windows native ASCII guard" bash scripts/check-windows-native-ascii.sh
 # refactor can't break the feature with no error. See
 # integrations/windows/IMPLEMENTATION.md § "Newline rendering".
 step "windows newline-rendering invariants" node integrations/windows/tests/newline-invariants.mjs
+step "windows clipboard/stale-model invariants" node integrations/windows/tests/clipboard-invariants.mjs
 
 # ─── 1b. Legacy-names lint ─────────────────────────────────────────
 # Catches the rename-drift class — old feature names lingering in    # LEGACY-NAME-ALLOW: aggregator comment


### PR DESCRIPTION
## The two live incidents (2026-07-14, same session)

**1. Your clipboard pasted into Discord.** `PasteReplace` = save clipboard → set substitution → Ctrl+V → `Thread.Sleep(300)` → restore. Electron consumes the clipboard **asynchronously and unboundedly** — the trace shows Discord's write bracket open 1094ms after the paste keystroke — so the restore won the race and Ctrl+V delivered the user's *old* clipboard (`Izzy.roser@gmail.com`) into the field instead of the substitution. This is a **clipboard leak into whatever app is focused**: swap the copied email for a password or 2FA code and it lands in a Discord input box.

**2. Typed characters eaten.** `congratulations letter _` arrived at the daemon as `gratulations letter _`. `TryTypeMicroEdit` (animation frames) and `PasteReplace`'s backspace path both diff against the shim's *model* of the field (`_lastSentText` / daemon `oldText`); Phase 1 has no keyboard hook, so user keystrokes are invisible between event reads — a stale model turns the backspace burst into user-content deletion.

## The fix — one primitive, three sites

New `TryReadCurrentField` (on-demand, mode-aware: `TryReadFocusedElectron` for MSAA, `ReadValue(_hookedEl)` for UIA):

- **Verify-before-restore**: after Ctrl+V, poll the field until it reflects the pasted text (EolNorm-folded — apps re-dress newlines, per the branch's rendering table), *then* restore the saved clipboard. On timeout (`OPENCUES_CLIPBOARD_RESTORE_MAX_MS`, default 3000ms ≈ 3× worst observed) or unreadable field: **fail safe — skip the restore and warn.** Losing the old clipboard contents is an annoyance; pasting them into the foreground app is a leak.
- **Micro-frames drop on divergence**: read-before-write against `_lastSentText`; mismatch = user typed (or app edited) → swallow the frame. Animation is cosmetic and the final substitution write is an absolute anchor, so a dropped frame costs nothing. Known trade: on a very slow editor, a frame whose predecessor hasn't rendered yet reads as divergence and drops — the animation stalls a frame, never a wrong write.
- **PasteReplace rebases on a fresh read**: `oldText` superseded by the live field before computing the backspace count, killing the eaten-characters class on the paste path too.

All C#5-compatible (Add-Type compile at launch; pre-declared out-vars, concatenation, matches file style).

## Guarding the class

`tests/clipboard-invariants.mjs` — source-invariant guard in the same pattern as `newline-invariants.mjs` (the shim can't be unit-tested off-Windows; the invariants whose loss is silent get pinned instead): consumption-gated restore, no timer-raced restore shape, loud fail-safe, fresh-read rebase, micro-frame divergence drop, EolNorm-folded comparisons. **6/6 green**, wired into `pre-pr.sh` next to the newline guard. Existing newline invariants still ALL PASS.

`@opencues/windows` 0.1.0 → 0.1.1 · windows CLAUDE.md gains a "verify-before-write + verify-before-restore" section documenting the incident pair.

Manual verification checklist (Windows-side, next launch recompiles the shim): (1) copy a known string → trigger a big substitution in Discord → confirm the substitution lands AND clipboard still holds the string (or the warn fires and clipboard holds the substitution — never the reverse paste); (2) type continuously while a slow blank resolves → no leading characters lost; (3) `grep 'micro-frame skipped\|clipboard NOT restored\|rebasing diff' /tmp/opencues.log` to see the guards working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)