### PR TITLE
fix(install): node-http-adapter.js must land at core's package ROOT on OC + gemini; fatal resolve probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — OC + gemini installers copied `node-http-adapter.js` one layer too deep; every LLM dispatch on those hosts was silently dead (`@opencues/opencode` 0.2.6 → 0.2.7, `@opencues/gemini-cli` 0.2.6 → 0.2.7)
+
+Found by the full agentic-suite validation pass (2026-07-14): 27 scenarios failed with `*.started` events never firing — the resolver's fallback `require('@opencues/core/node-http-adapter')` (a package-ROOT specifier; core has no exports map) could not resolve because both setup.sh files copied the hand-written CJS into `$core_dest/dist/`. History: the copy USED to land at the root because the old installer flattened `dist/*` into the package root; the un-flattening fix (dist/ subdir layout, DEP0128) kept the explicit copy pointed at dist/ — reintroducing REPAIR.md LF-7 through the back door with no probe to catch it. Sources still built, so nothing logged until first dispatch, and every prior host check this week happened to exercise only deterministic blanks. Shell's installer was already correct (root); CC flattens, so it was immune.
+
+Fix: copy to the package ROOT (+ dist/ belt-and-braces) in both installers, plus a FATAL post-copy resolve probe (`bun`/`node -e "require('@opencues/core/node-http-adapter')"` from the fork root) so a wrong-layer copy fails the install instead of shipping dead dispatch. REPAIR.md § LF-7 updated with the recurrence.
+
 ### Fixed — the registry-miss `[err]` fill was dropped on hosts whose text state lags the dispatch (`@opencues/runtime` 0.16.1 → 0.16.2)
 
 Live-CC follow-up to the previous entry, caught during slot-2 validation: the warn fired but the `[err]` never appeared. The miss branch was the ONLY fill running synchronously inside the text-change dispatch, and CC's `adapter.getText()` is one keystroke stale at that instant — `words[slot.index]` missed and `applyAsyncFill`'s staleness guard silently dropped the fill. Every other fill path is naturally deferred past the state update by script/LLM latency, and the MockAdapter commits text BEFORE dispatch, which hid the class from the unit journeys.

--- a/integrations/gemini-cli/package.json
+++ b/integrations/gemini-cli/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@opencues/gemini-cli",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
-  "description": "OpenCues for Gemini CLI — native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
+  "description": "OpenCues for Gemini CLI \u2014 native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "compatibility": {
     "gemini-cli": "0.41.x"
   },

--- a/integrations/gemini-cli/patches/setup.sh
+++ b/integrations/gemini-cli/patches/setup.sh
@@ -134,9 +134,26 @@ install_into_fork() {
   cp -r "$OPENCUES_ROOT/packages/opencues-core/dist" "$core_dest/"
   cp "$OPENCUES_ROOT/packages/opencues-core/package.json" "$core_dest/"
   # node-http-adapter.js isn't compiled by tsc but Resolver requires it
-  # at runtime; copy explicitly so LLM resolution doesn't silently die.
+  # at runtime via the PACKAGE-ROOT specifier `@opencues/core/node-http-adapter`
+  # (no exports map, so `pkg/subpath` resolves at the package root — see
+  # the file's own header + REPAIR.md LF-7). The copy MUST land at the
+  # root: when the un-flattening fix (dist/ subdir layout, DEP0128) kept
+  # this copy pointed at dist/, the specifier silently died and every
+  # LLM dispatch on the host went dark — found 2026-07-14 when the full
+  # agentic suite ran 27 scenarios into 5s timeouts. dist/ copy kept as
+  # belt-and-braces for anything resolving relative to main.
   if [[ -f "$OPENCUES_ROOT/packages/opencues-core/node-http-adapter.js" ]]; then
+    cp "$OPENCUES_ROOT/packages/opencues-core/node-http-adapter.js" "$core_dest/"
     cp "$OPENCUES_ROOT/packages/opencues-core/node-http-adapter.js" "$core_dest/dist/"
+  fi
+  # Probe the resolve the way the runtime will (LF-7 verify): a copy
+  # that lands in the wrong layer must FAIL the install here, not
+  # surface as silent dead LLM dispatch at first use.
+  if command -v node >/dev/null 2>&1; then
+    if ! (cd "$GEMINI_DIR" && node -e "require('@opencues/core/node-http-adapter')" >/dev/null 2>&1); then
+      echo "setup.sh: FATAL — @opencues/core/node-http-adapter does not resolve from the fork root (LF-7)." >&2
+      exit 1
+    fi
   fi
 }
 

--- a/integrations/opencode/package.json
+++ b/integrations/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/opencode",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "description": "OpenCues for OpenCode \u2014 native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "compatibility": {

--- a/integrations/opencode/patches/setup.sh
+++ b/integrations/opencode/patches/setup.sh
@@ -140,9 +140,26 @@ install_into_fork() {
   cp -r "$OPENCUES_ROOT/packages/opencues-core/dist" "$core_dest/"
   cp "$OPENCUES_ROOT/packages/opencues-core/package.json" "$core_dest/"
   # node-http-adapter.js isn't compiled by tsc but Resolver requires it
-  # at runtime; copy explicitly so LLM resolution doesn't silently die.
+  # at runtime via the PACKAGE-ROOT specifier `@opencues/core/node-http-adapter`
+  # (no exports map, so `pkg/subpath` resolves at the package root — see
+  # the file's own header + REPAIR.md LF-7). The copy MUST land at the
+  # root: when the un-flattening fix (dist/ subdir layout, DEP0128) kept
+  # this copy pointed at dist/, the specifier silently died and every
+  # LLM dispatch on the host went dark — found 2026-07-14 when the full
+  # agentic suite ran 27 scenarios into 5s timeouts. dist/ copy kept as
+  # belt-and-braces for anything resolving relative to main.
   if [[ -f "$OPENCUES_ROOT/packages/opencues-core/node-http-adapter.js" ]]; then
+    cp "$OPENCUES_ROOT/packages/opencues-core/node-http-adapter.js" "$core_dest/"
     cp "$OPENCUES_ROOT/packages/opencues-core/node-http-adapter.js" "$core_dest/dist/"
+  fi
+  # Probe the resolve the way the runtime will (LF-7 verify): a copy
+  # that lands in the wrong layer must FAIL the install here, not
+  # surface as silent dead LLM dispatch at first use.
+  if command -v bun >/dev/null 2>&1; then
+    if ! (cd "$OPENCODE_DIR" && bun -e "require('@opencues/core/node-http-adapter')" >/dev/null 2>&1); then
+      echo "setup.sh: FATAL — @opencues/core/node-http-adapter does not resolve from the fork root (LF-7)." >&2
+      exit 1
+    fi
   fi
 
   # User-blank subprocess runner — Bun hosts can't load isolated-vm

--- a/packages/opencues-runtime/adapters/oc/REPAIR.md
+++ b/packages/opencues-runtime/adapters/oc/REPAIR.md
@@ -126,6 +126,21 @@ lives at the opencues-core package root, NOT under `dist/`. The OpenCode
 setup only copied `dist/*` + `package.json`. CC's setup explicitly
 handles this standalone file (its setup.sh line ~254-255).
 
+**RECURRENCE (2026-07-14):** the un-flattening layout fix (keep a
+`dist/` subdir so `main: dist/index.js` resolves without DEP0128)
+left the explicit copy pointed at `$core_dest/dist/` — but the
+runtime's specifier `@opencues/core/node-http-adapter` resolves at the
+PACKAGE ROOT (no exports map), so the copy landed one layer too deep
+and every LLM dispatch went dark again: sources built fine, every
+scenario's `*.started` event just never fired (27 agentic failures,
+all 5s timeouts). Same silent shape on gemini-cli. Fix: copy to the
+package ROOT (+ dist/ as belt-and-braces) AND a fatal post-copy
+resolve probe in both setup.sh files — `bun`/`node -e
+"require('@opencues/core/node-http-adapter')"` from the fork root —
+so a wrong-layer copy fails the INSTALL instead of surfacing as dead
+dispatch at first use. Shell's installer was already correct (root);
+CC flattens dist into the package root, so its layout is immune.
+
 **Fix:** add an explicit copy of `node-http-adapter.js` after the
 `dist/*` cp. Idempotent guard with `[ -f ... ] && cp`.
 


### PR DESCRIPTION
## Found by the validation pass

Running the full agentic suite against merged master (slot-1 validation of the build): **27 scenarios failed**, every one with a `*.started` event that never fired inside 5s. Host log had the single real error:

```
[oc][error] Resolver: NodeHttpAdapter load failed — Cannot find module '@opencues/core/node-http-adapter'
```

`require('@opencues/core/node-http-adapter')` is a **package-root** specifier (core has no `exports` map), but the OC and gemini `setup.sh` both copied the hand-written CJS into `$core_dest/dist/` — one layer too deep. Result: sources built fine, and *every LLM dispatch on both hosts was silently dead*. Nothing logged until first dispatch, and every host check earlier this week happened to exercise only deterministic blanks, so it hid.

## Why it regressed (LF-7, through the back door)

The copy *used* to land at the root — because the old installer **flattened `dist/*` into the package root**. The un-flattening fix (keep a `dist/` subdir so `main: dist/index.js` resolves without DEP0128) kept the explicit copy pointed at `dist/`, silently reintroducing REPAIR.md LF-7. No probe existed to notice. Shell's installer was already correct (root — its file header even documents the contract); CC flattens, so its layout is immune.

## Fix + structural closure

- Both installers now copy to the **package root** (the load-bearing destination) *and* `dist/` (belt-and-braces).
- **Fatal post-copy resolve probe** in both: `bun`/`node -e "require('@opencues/core/node-http-adapter')"` from the fork root — a wrong-layer copy now fails the *install*, not the first LLM call weeks later. Same philosophy as CC's `validateFork` require-probes from the PR #117 class.
- Verified end-to-end: reinstalled the OC fork from this branch — layout resolves, probe green; the previously-failing scenario cluster is rerunning now.
- REPAIR.md § LF-7 updated with the recurrence so the next layout change reads the history first.

`@opencues/opencode` 0.2.6 → 0.2.7 · `@opencues/gemini-cli` 0.2.6 → 0.2.7 · CHANGELOG updated · shell portability lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)