### PR TITLE
fix(blank-fill): defer the registry-miss [err] fill past the host's text-state catch-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — the registry-miss `[err]` fill was dropped on hosts whose text state lags the dispatch (`@opencues/runtime` 0.16.1 → 0.16.2)
+
+Live-CC follow-up to the previous entry, caught during slot-2 validation: the warn fired but the `[err]` never appeared. The miss branch was the ONLY fill running synchronously inside the text-change dispatch, and CC's `adapter.getText()` is one keystroke stale at that instant — `words[slot.index]` missed and `applyAsyncFill`'s staleness guard silently dropped the fill. Every other fill path is naturally deferred past the state update by script/LLM latency, and the MockAdapter commits text BEFORE dispatch, which hid the class from the unit journeys.
+
+Fix: defer the `[err]` fill one tick with one guarded retry (`tryErrFill` probes for the slot's `_`/frame char before filling; a buffer that legitimately moved on drops the retry via the same staleness guard as any late script callback). Harness gap closed structurally: `MockAdapter` gains `staleTextDuringDispatch` (dispatch first with the pre-change buffer in place, commit after — the live-CC shape), and a new journey pins the fill landing on such a host; mutation-checked to fail against the synchronous code.
+
 ### Fixed — a blank with config but no host implementation now says so instead of doing nothing (`@opencues/runtime` 0.16.0 → 0.16.1)
 
 `~/.cues` is shared across hosts but runtime bundles are per-host, and ANY host's install seeds the shared config — so a BLANK.md can legitimately run ahead of another host's installed bundle. When that happened on a blankInvoke-capable host with a runtime-served (scriptless) blank, the dispatch hit the registry miss and skipped in TOTAL silence: no log, no fill, slot dead. Live case (July 2026): the loading-animation blank's config seeded by an opencode install while the CC fork was still one runtime behind — "it didn't seem to do anything". The same silent shape covers factories that skip registration over a missing prerequisite (e.g. stocks without a Finnhub key).

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/blank-fill.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.test.ts
@@ -1965,3 +1965,49 @@ blankProximity: 10
     expect(adapter.getText()).toContain('[err] newblank');
   });
 });
+
+// ─── Registry-miss [err] on a STALE-TEXT host (the live-CC timing) ────────
+//
+// 2026-07-15: on live CC the #300 [err] fill silently vanished — warn
+// logged, buffer untouched. The miss branch was the only fill running
+// SYNCHRONOUSLY inside the text-change dispatch, and CC's
+// adapter.getText() is one keystroke stale at that instant, so
+// applyAsyncFill's staleness guard dropped it. The default MockAdapter
+// commits text BEFORE dispatch, which hid the class; this journey uses
+// `staleTextDuringDispatch` to model the real host. The fix defers the
+// fill a tick (+ one guarded retry), matching every other fill path's
+// natural post-latency timing.
+describe('BlankFill registry miss on a stale-text-during-dispatch host', () => {
+  const SCRIPTLESS = `---
+type: blank
+name: newblank
+blankKeywords: newblank
+blankProximity: 10
+---
+`;
+
+  it('the [err] fill still lands (deferred past the state catch-up)', async () => {
+    const adapter = new MockAdapter({
+      cwd: '/proj',
+      files: { '/mock/CUES.md': TIPS, '/proj/blanks/newblank/BLANK.md': SCRIPTLESS },
+      capabilities: [
+        'render-override', 'dim-ranges', 'highlight-range',
+        'file-read', 'file-write', 'force-render', 'change-source',
+        'blank-invoke',
+      ],
+      staleTextDuringDispatch: true,
+    });
+    adapter.stubBlankInvoke('someother:get', 'x');
+    const loader = new ConfigLoader(adapter);
+    await loader.load();
+    const bf = new BlankFill(adapter, loader);
+    bf.subscribe();
+    adapter.pushText('newblank _');
+    // Pre-fix, the synchronous fill saw the pre-keystroke buffer and was
+    // dropped here in total silence. Give the deferred fill + retry room.
+    await new Promise(r => setTimeout(r, 80));
+    expect(adapter.getText()).toBe(
+      'newblank [err] newblank: not available on this host — stale bundle or missing prerequisite. Try `opencues install mock`',
+    );
+  });
+});

--- a/packages/opencues-runtime/src/modules/blank-fill.ts
+++ b/packages/opencues-runtime/src/modules/blank-fill.ts
@@ -593,11 +593,27 @@ export class BlankFill {
               `registration prerequisite. Fix: \`opencues install ${this.adapter.hostName}\`.`,
             );
           }
-          this.applyAsyncFill(
-            slot,
-            `[err] ${slot.blankName}: not available on this host — stale bundle or missing prerequisite. Try \`opencues install ${this.adapter.hostName}\``,
-            typedAction,
-          );
+          // DEFER the [err] fill — this branch is the only fill that
+          // would otherwise run SYNCHRONOUSLY inside the text-change
+          // dispatch. On live CC (found 2026-07-15) adapter.getText()
+          // is still one keystroke stale at that instant (the host's
+          // buffer state catches up after the handler returns), so
+          // `words[slot.index]` missed and applyAsyncFill's staleness
+          // guard silently dropped the fill — warn logged, buffer
+          // untouched, and the MockAdapter's synchronous text state
+          // hid it from the unit journeys. Every OTHER fill path is
+          // naturally deferred past the state update by script/LLM
+          // latency; match that timing. One guarded retry covers hosts
+          // whose state settles later than a tick — if the buffer
+          // legitimately moved on instead, the retry is dropped by the
+          // same staleness guard that protects late script callbacks.
+          {
+            const errFill = `[err] ${slot.blankName}: not available on this host — stale bundle or missing prerequisite. Try \`opencues install ${this.adapter.hostName}\``;
+            setTimeout(() => {
+              if (this.tryErrFill(slot, errFill, typedAction)) return;
+              setTimeout(() => { this.tryErrFill(slot, errFill, typedAction); }, 50);
+            }, 0);
+          }
           return;
         }
         // OS-level sandbox config — populated when the blank's
@@ -839,6 +855,21 @@ export class BlankFill {
    * adapter.pushText (calls onChange), since this runs outside any
    * dispatch.
    */
+  /** Attempt an [err] feedback fill; returns true when the slot's `_`
+   *  (or its animation frame char) is present in the CURRENT buffer —
+   *  i.e. the fill had a target and applyAsyncFill ran its course.
+   *  False = the adapter's text state hasn't caught up with the
+   *  keystroke that formed the slot (live-CC timing, 2026-07-15) and
+   *  the caller may retry once. */
+  private tryErrFill(slot: BlankSlot, errFill: string, typedAction?: 'set' | 'step'): boolean {
+    const cleaned = this.adapter.getText().replace(/[\u200B\u200C]/g, '');
+    const target = splitWords(cleaned)[slot.index];
+    const present = !!target
+      && (target.word === '_' || (this._loading?.isOurSlotChar(slot.index, target.word) ?? false));
+    if (present) this.applyAsyncFill(slot, errFill, typedAction);
+    return present;
+  }
+
   private applyAsyncFill(slot: BlankSlot, fillValue: string, typedAction?: 'set' | 'step'): void {
     const currentText = this.adapter.getText();
     const cleaned = currentText.replace(/[\u200B\u200C]/g, '');

--- a/packages/opencues-runtime/testing/mock-adapter.ts
+++ b/packages/opencues-runtime/testing/mock-adapter.ts
@@ -24,6 +24,16 @@ export interface MockAdapterOptions {
   capabilities?: readonly Capability[];
   /** If set, setText fires onTextChange synchronously (before returning). Default true. */
   syncTextChange?: boolean;
+  /**
+   * Model hosts whose adapter TEXT STATE lags the text-change dispatch
+   * by one tick (live CC, 2026-07-15): handlers receive the NEW text in
+   * the event, but adapter.getText() still returns the PRE-change
+   * buffer until the dispatch returns. Any fill that runs
+   * SYNCHRONOUSLY inside the handler sees a stale buffer and gets
+   * dropped by staleness guards — the exact class the default
+   * (state-first) mock cannot reproduce. Default false.
+   */
+  staleTextDuringDispatch?: boolean;
   cwd?: string;
   /** Seed filesystem (path -> content). Writes go here too. */
   files?: Record<string, string>;
@@ -73,6 +83,7 @@ export class MockAdapter implements HostAdapter {
   private _files = new Map<string, string>();
   private _disposed = false;
   private _syncTextChange: boolean;
+  private _staleTextDuringDispatch: boolean;
 
   private _keySubs: KeySub[] = [];
   private _textSubs: TextSub[] = [];
@@ -97,6 +108,7 @@ export class MockAdapter implements HostAdapter {
     this.capabilities = opts.capabilities ?? DEFAULT_CAPS;
     this.cwd = opts.cwd ?? '/mock';
     this._syncTextChange = opts.syncTextChange ?? true;
+    this._staleTextDuringDispatch = opts.staleTextDuringDispatch ?? false;
     for (const [path, content] of Object.entries(opts.files ?? {})) {
       this._files.set(path, content);
     }
@@ -307,6 +319,24 @@ export class MockAdapter implements HostAdapter {
    *  the test specifically wants to simulate paste / programmatic insertion. */
   pushTextNoKeystroke(text: string, cursorOffset?: number): void {
     const prev = this._text;
+    if (this._staleTextDuringDispatch) {
+      // Dispatch FIRST with the pre-change buffer still in place (the
+      // event carries the new text), then commit — mirrors hosts where
+      // getText() catches up only after the handler returns.
+      const offset = cursorOffset !== undefined
+        ? Math.max(0, Math.min(cursorOffset, text.length))
+        : Math.min(this._offset > text.length ? text.length : this._offset, text.length);
+      const event: TextChangeEvent = {
+        text,
+        cursorOffset: offset,
+        previousText: prev,
+        source: this.capabilities.includes('change-source') ? 'user' : 'unknown',
+      };
+      this._dispatchTextChange(event);
+      this._text = text;
+      this._offset = offset;
+      return;
+    }
     this._text = text;
     if (cursorOffset !== undefined) this._offset = Math.max(0, Math.min(cursorOffset, text.length));
     else if (this._offset > text.length) this._offset = text.length;


### PR DESCRIPTION
## Caught live during slot-2 validation of #300

On real CC the registry-miss guard half-worked: the once-per-blank **warn fired**, but the `[err]` fill **never appeared** — `loading animation ▖,▘,▝,▗ _` stayed untouched. Trace: slot formed → invoke → warn → silence, no `substituting` line.

Root cause: the miss branch is the **only** fill that ran *synchronously inside the text-change dispatch*. On CC, `adapter.getText()` is one keystroke stale at that instant (the host's buffer state catches up after the handler returns), so `words[slot.index]` missed and `applyAsyncFill`'s staleness guard silently dropped the fill. Every other fill path is naturally deferred past the state update by script/LLM latency — and the MockAdapter commits text **before** dispatch, so the #300 unit journeys couldn't see the class (they passed honestly against a host model that doesn't exist on CC).

## Fix

Defer the `[err]` fill one tick, with one guarded retry at 50ms: `tryErrFill` probes for the slot's `_` (or its animation frame char) before filling; if the buffer legitimately moved on instead, the retry is dropped by the same staleness guard that protects late script callbacks. No behaviour change for any other fill path.

## The harness gap, closed structurally

`MockAdapter` gains **`staleTextDuringDispatch`** — dispatch handlers with the new text in the *event* while `getText()` still returns the pre-change buffer, committing after dispatch returns (the live-CC shape). A new journey pins the `[err]` landing on such a host, and it's **mutation-checked**: fails against the synchronous code, passes with the defer. Any future fill path that runs synchronously in-dispatch is now testable against this host class.

Full runtime suite green (2 unrelated load-flakes — brightness script smoke + seed-configs SEED — pass in isolation, matching their history). `@opencues/runtime` 0.16.1 → 0.16.2 · CHANGELOG updated.

Live verification on a real CC PTY follows in a comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)