### PR TITLE
docs(blank-loading): document the custom-frame linger limitation (opencode, cosmetic)

### DIFF
--- a/docs/features/blank-loading.md
+++ b/docs/features/blank-loading.md
@@ -143,3 +143,40 @@ parallel colour scalars. Every floor (frame truncation, interval
 clamp, unused colours, one-sided colour lists) is named in the
 confirmation. Grammar + examples: `defaults/blanks/loading-animation/BLANK.md`;
 implementation: `packages/opencues-runtime/src/blanks/loading-animation.ts`.
+
+## Known limitation — custom frames without `_`, on opencode (2026-07-15)
+
+Every SHIPPED mode (`bounce`, `flipper`, `braille-rotate`) has `_` as
+its rest frame (frame[0]), so the animated slot passes through `_`
+each cycle. **Custom frames need not** — e.g. `▖,▘,▝,▗` never shows
+`_`. Combined with an opencode-specific quirk, that surfaces an
+intermittent cosmetic artifact:
+
+- **Symptom:** on **opencode only**, under load, a custom-frame char
+  (`▖`/`▘`/…) can linger in the `_` slot a beat longer than the
+  source took to resolve, instead of restoring to `_` promptly.
+  Self-heals — the buffer *does* return to `_`; it's a timing lag,
+  not a permanent stick.
+- **Root cause:** opencode attributes runtime writes vs user typing
+  via `sourceReclassifier` (see `adapters/oc/*/boot.ts`). A custom
+  animation ticks every `blank-loading-interval-ms` (default 75ms);
+  occasionally a frame `setText` is misclassified as `user`, which
+  re-triggers the resolver (`resolver.ts:onTextChange` gates on
+  `source === 'user'`) and keeps the slot animating. Shipped modes
+  mask this because a lingering frame is often `_`.
+- **Not affected:** Claude Code (its ZWS reclassifier attributes
+  animation writes correctly), and every host when using a shipped
+  mode.
+- **Repro:** set `blank-loading-animation: custom` +
+  `blank-loading-frames: ▖,▘,▝,▗`, run the agentic suite on opencode
+  (or fire `_`-triggering blanks repeatedly under load) — a fraction
+  of assertions catch a frame char at rest.
+
+Deliberately NOT fixed reactively: the proper fix touches the
+`sourceReclassifier`, which is load-bearing trust-gate code (credit
+accounting for the explicit-`_` security gate), so a change there
+carries real regression risk for an intermittent cosmetic artifact on
+a non-CC host. The safe host-agnostic alternative — give custom frame
+lists a `_` rest frame like the shipped modes — is queued as a
+follow-up (it slightly changes the custom animation's look by
+blinking through `_`).


### PR DESCRIPTION
Documents a real-but-minor limitation surfaced during the 2026-07-15 agentic validation sweep, and records the deliberate decision not to fix it reactively.

**Symptom:** custom loading frames without `_` (e.g. `▖,▘,▝,▗`) can intermittently linger a beat in the `_` slot on **opencode** under load, instead of restoring to `_` promptly. Self-healing (buffer does return to `_`), cosmetic, and **opencode-only** — Claude Code's reclassifier attributes animation writes correctly, and every shipped mode (bounce/flipper/braille) is immune because it rests on `_`.

**Root cause:** opencode's `sourceReclassifier` occasionally misclassifies a 75ms-interval frame `setText` as `user`, which re-triggers the resolver (`onTextChange` gates on `source === 'user'`) and keeps the slot animating.

**Why not fixed here:** the proper fix touches the `sourceReclassifier` — load-bearing trust-gate code (explicit-`_` credit accounting) — so changing it carries real regression risk for an intermittent cosmetic artifact on a non-CC host. The safe host-agnostic alternative (give custom frame lists a `_` rest frame like shipped modes) is queued as a follow-up; it slightly changes the custom animation's look.

Doc-only. No code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)