### PR TITLE
fix(chrome): node:os external for calendar-ingest (0.2.89 lockstep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — chrome bundle: `node:os` external for the calendar-ingest helper (`@opencues/chrome` 0.2.89)
+
+`buildCalendarContextIngest` (0.24.0) lazy-requires `node:os`; chrome's esbuild external list had only `node:fs`/`node:path`/`node:child_process`, so the chrome build hard-failed at install time. The helper self-disables in the browser (chrome has its own loader), so external-as-is is correct. The PR #49-class gate didn't fire on #322 because the chrome build task cache-hit; `opencues install chrome` caught it.
+
 ### Fixed — Tier 5c journey geocode was silently inert on native hosts (`@opencues/core` 0.30.1)
 
 `geocodePlace` bailed when `fetchImpl` was undefined — but native hosts (CC/OC/gemini/shell) omit `worldDataFetch` (only chrome supplies one, routed through its service worker), so the whole journey-underestimate tier never fired outside chrome. Unit tests never saw it (they inject stub fetches); the agentic suite caught it on a live OpenCode host. Now defaults to the ambient `fetch`, mirroring BankHolidayProvider/WeatherProvider/TflProvider. Regression pinned with an ambient-fetch unit test.

--- a/integrations/chrome/esbuild.config.mjs
+++ b/integrations/chrome/esbuild.config.mjs
@@ -112,7 +112,7 @@ const common = {
   // (~/.cues/.env read + the zero-key subscription-CLI probe). Both are
   // typeof-process-guarded so the require is unreachable in a content
   // script — external for the same emit-as-is reason.
-  external: ['node:fs', 'node:path', 'node:child_process'],
+  external: ['node:fs', 'node:path', 'node:os', 'node:child_process'],
 };
 
 // The three bundles. content + popup are IIFEs (injected into page

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "private": true,
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "compatibility": {


### PR DESCRIPTION
PR #49-class fix: runtime 0.24.0's calendar-ingest helper lazy-requires `node:os`, missing from chrome's esbuild externals - install-time build failure. Helper self-disables in browser. manifest+package lockstep 0.2.89. check-chrome-bundle green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)