### PR TITLE
fix(doctor): recognise registry-derived chrome-host push list (CLI 0.2.52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — doctor: chrome-host push-list check false-positived on registry-derived scripts (`opencues` CLI 0.2.52)
+
+`host.cjs` derives its push list from `chromeHostFileList()` at runtime — structurally drift-proof — but doctor verified parity by grepping the script TEXT for literal basenames. Older names passed only because they happen to appear in comments/filter code; NOTES.md and calendar.json (the two newest pushed files) "failed" despite being pushed correctly. Doctor now recognises a registry-derived script (`chromeHostFileList` present) and reports that as the check; the literal grep remains only for pre-derive host scripts that hardcoded the names.
+
 ### Fixed — chrome bundle: `node:os` external for the calendar-ingest helper (`@opencues/chrome` 0.2.89)
 
 `buildCalendarContextIngest` (0.24.0) lazy-requires `node:os`; chrome's esbuild external list had only `node:fs`/`node:path`/`node:child_process`, so the chrome build hard-failed at install time. The helper self-disables in the browser (chrome has its own loader), so external-as-is is correct. The PR #49-class gate didn't fire on #322 because the chrome build task cache-hit; `opencues install chrome` caught it.

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "private": true,
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "bin": {

--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -748,8 +748,23 @@ module.exports = async function doctor(argv, ctx) {
       if (hostScript && fs.existsSync(hostScript)) {
         const text = fs.readFileSync(hostScript, 'utf8');
         const required = registry.chromeHostFileList();
-        const missing = required.filter(f => !text.includes(f));
-        s.ok(`host pushes [${required.join(', ')}]`, missing.length === 0);
+        // A host script that derives its push list from the FEATURES
+        // registry (chromeHostFileList) structurally cannot drift — new
+        // pushed-by-host files are picked up with zero host.cjs changes,
+        // so their basenames never appear as literals in the script.
+        // Pre-derive host scripts hardcoded the names; for those (only)
+        // the literal grep below is the right parity check. Grepping a
+        // derived script for literals false-positived on NOTES.md +
+        // calendar.json (July 2026) purely because nobody had mentioned
+        // them in a comment.
+        const derivesFromRegistry = text.includes('chromeHostFileList');
+        const missing = derivesFromRegistry ? [] : required.filter(f => !text.includes(f));
+        s.ok(
+          derivesFromRegistry
+            ? 'host derives push list from FEATURES registry (chromeHostFileList)'
+            : `host pushes [${required.join(', ')}]`,
+          missing.length === 0,
+        );
         if (missing.length > 0) {
           findings.push({
             sev: 'warn',


### PR DESCRIPTION
The last remaining doctor warning was a false positive: `host.cjs` derives its push list from `chromeHostFileList()` (drift-proof), but doctor text-grepped for literal basenames - NOTES.md and calendar.json are pushed correctly at runtime yet never appear as literals. Doctor now detects derivation (`chromeHostFileList` in the script) and passes; literal grep kept for pre-derive scripts. Verified: registry list contains both files; doctor exits clean with zero suggestions; CLI suite 631/633 (the 2 known WSL-host artifacts, pass on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)