### PR TITLE
feat(runtime): refresh scheduler — calendar feeds self-sync on a 15-min TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — refresh scheduler: calendar feeds self-sync every 15 minutes (`@opencues/core` 0.31.0, `@opencues/runtime` 0.25.0, CLI 0.2.53)
+
+The system now owns refresh cadence: a `RefreshScheduler` (runtime) ticks every 30s and asks registered resources "are you due?" — nothing "calls" a sync. Calendar feeds are the first resource: due when the shared snapshot's own `ingestedAt` is older than 15 minutes, so any number of concurrently-running hosts self-deduplicate off the same file clock (plus per-process jitter and a pre-write re-stat in core that discards a fetch another producer superseded). The feeds→snapshot sync itself moved to `@opencues/core` (`syncCalendarFeeds` — atomic tmp+rename write, VCALENDAR sniff, last-good posture on failure) with THREE callers sharing the one implementation: the CLI (`opencues calendar sync`), the runtime scheduler inside `buildCalendarContextIngest`, and chrome-host (5-min due-check on its watch loop; the resulting write trips its existing fs.watch → bundle push). User journey collapses to `opencues calendar add <url>` — feeds are at most ~15 min stale while any host runs, file→runtime stays ≤60s. In-flight guards, contained failures, unref'd timers (never in the keystroke path, never keeping a process alive). 5 scheduler + 8 core-sync + 1 end-to-end ingest tests, all hermetic.
+
 ### Fixed — doctor: chrome-host push-list check false-positived on registry-derived scripts (`opencues` CLI 0.2.52)
 
 `host.cjs` derives its push list from `chromeHostFileList()` at runtime — structurally drift-proof — but doctor verified parity by grepping the script TEXT for literal basenames. Older names passed only because they happen to appear in comments/filter code; NOTES.md and calendar.json (the two newest pushed files) "failed" despite being pushed correctly. Doctor now recognises a registry-derived script (`chromeHostFileList` present) and reports that as the check; the literal grep remains only for pre-derive host scripts that hardcoded the names.

--- a/integrations/chrome/host/host.cjs
+++ b/integrations/chrome/host/host.cjs
@@ -731,3 +731,21 @@ try {
 } catch (e) {
   sendMessage({ type: 'error', message: 'watch failed: ' + (e && e.message || e) });
 }
+
+// ── Calendar feed refresh (resource-on-a-timer model) ─────────────────
+// chrome-only users have no native host running, so the chrome-host
+// process is their producer: every 5 min ask core's due-check whether
+// the shared snapshot is older than the 15-min TTL, and refresh via the
+// SAME core syncCalendarFeeds the CLI + runtime scheduler use (one
+// implementation — a hand-copied sync is the mirrored-guard drift
+// class). Writing calendar.json trips fs.watch above, which pushes the
+// fresh bundle to the extension — no extra plumbing.
+setInterval(() => {
+  try {
+    const core = loadCore();
+    if (!core || typeof core.calendarSyncDue !== 'function') return;
+    if (!core.calendarSyncDue(fs, CUE_ROOT)) return;
+    core.syncCalendarFeeds({ fs, cuesDir: CUE_ROOT, log: () => {} })
+      .catch(() => { /* keep last-good snapshot; retried when next due */ });
+  } catch { /* never take the host down over calendar freshness */ }
+}, 5 * 60_000).unref?.();

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "private": true,
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "bin": {

--- a/packages/opencues-cli/src/commands/calendar.cjs
+++ b/packages/opencues-cli/src/commands/calendar.cjs
@@ -59,7 +59,14 @@ function tryLoadCore() {
     path.resolve(__dirname, '..', '..', '..', '..', 'node_modules', '@opencues', 'core', 'dist'),
   ];
   for (const c of candidates) {
-    try { return require(path.join(c, 'ics.js')); } catch {}
+    try {
+      const ics = require(path.join(c, 'ics.js'));
+      // calendar-sync.js carries the ONE feeds->snapshot implementation
+      // (shared with the runtime refresh scheduler + chrome-host).
+      let sync = {};
+      try { sync = require(path.join(c, 'calendar-sync.js')); } catch {}
+      return Object.assign({}, ics, sync);
+    } catch {}
   }
   return null;
 }
@@ -121,30 +128,17 @@ const WINDOW_DAYS = 60;
 async function buildSnapshot() {
   const core = tryLoadCore();
   if (!core || typeof core.parseIcs !== 'function') return { ok: false, reason: '@opencues/core not built' };
-  const urls = activeUrls(readLines());
-  if (urls.length === 0) return { ok: false, reason: 'no feeds' };
+  // ONE implementation — core's syncCalendarFeeds (also driven by the
+  // runtime refresh scheduler + chrome-host). Older cores without it
+  // cannot occur here (same repo), but guard anyway.
+  if (typeof core.syncCalendarFeeds !== 'function') return { ok: false, reason: '@opencues/core too old (no syncCalendarFeeds)' };
+  const r = await core.syncCalendarFeeds({ fs, cuesDir: CUES_DIR, windowDays: WINDOW_DAYS, log: (m) => { if (process.env.OPENCUES_DEBUG) console.error(m); } });
+  if (!r.ok) return r;
+  let snap = { events: [] };
+  try { snap = JSON.parse(fs.readFileSync(SNAPSHOT_PATH, 'utf8')); } catch { /* just synced; unlikely */ }
   const now = Date.now();
-  const winStartMs = now - 3600e3, winEndMs = now + WINDOW_DAYS * 24 * 3600e3;
-  const all = []; let okCount = 0;
-  for (const url of urls) {
-    try {
-      const ctl = new AbortController(); const to = setTimeout(() => ctl.abort(), 15000);
-      const res = await fetch(toHttp(url), { headers: { 'User-Agent': 'opencues-cli/1.0' }, redirect: 'follow', signal: ctl.signal });
-      clearTimeout(to);
-      if (!res.ok) { console.log(`  ${red(G.ringOn)} ${dim(`HTTP ${res.status} — ${url.slice(0, 50)}`)}`); continue; }
-      const text = await res.text();
-      if (!/BEGIN:VCALENDAR/i.test(text)) { console.log(`  ${red(G.ringOn)} ${dim(`not iCalendar — ${url.slice(0, 50)}`)}`); continue; }
-      all.push(...core.parseIcs(text, { windowStartMs: winStartMs, windowEndMs: winEndMs, maxEvents: 200 }));
-      okCount++;
-    } catch (e) { console.log(`  ${red(G.ringOn)} ${dim(`${(e && e.message) || e} — ${url.slice(0, 50)}`)}`); }
-  }
-  if (okCount === 0) return { ok: false, reason: 'all feeds failed — snapshot NOT overwritten' };
-  const seen = new Set();
-  const events = all.filter(e => { const k = `${e.start}|${e.title}`; if (seen.has(k)) return false; seen.add(k); return true; })
-    .sort((a, b) => a.start.localeCompare(b.start)).slice(0, 50);
-  fs.mkdirSync(CUES_DIR, { recursive: true });
-  fs.writeFileSync(SNAPSHOT_PATH, JSON.stringify({ source: 'opencues calendar sync', ingestedAt: new Date().toISOString(), events }, null, 2) + '\n');
-  return { ok: true, okCount, feeds: urls.length, events: events.length, next: events.find(e => new Date(e.start).getTime() >= now) };
+  return { ok: true, okCount: r.okCount, feeds: r.feeds, events: r.events,
+           next: (snap.events || []).find(e => new Date(e.start).getTime() >= now) };
 }
 
 async function sync(silent) {

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/calendar-sync.test.ts
+++ b/packages/opencues-core/src/calendar-sync.test.ts
@@ -1,0 +1,126 @@
+/**
+ * calendar-sync — the ONE feeds→snapshot implementation (CLI + runtime
+ * scheduler + chrome-host all call this; see the mirrored-guard drift
+ * lesson for why it must not be copied).
+ *
+ * Hermetic: injected fs paths under a mkdtemp dir, injected fetch.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import * as assert from 'node:assert';
+import * as realFs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  syncCalendarFeeds,
+  calendarSyncDue,
+  readCalendarFeedUrls,
+  CALENDAR_SYNC_TTL_MS,
+} from './calendar-sync';
+
+let dir = '';
+beforeEach(() => { dir = realFs.mkdtempSync(path.join(os.tmpdir(), 'opencues-cal-sync-')); });
+afterEach(() => { realFs.rmSync(dir, { recursive: true, force: true }); });
+
+const fsDep = realFs as unknown as Parameters<typeof calendarSyncDue>[0];
+
+function writeFeeds(lines: string[]): void {
+  realFs.writeFileSync(path.join(dir, 'calendar-feeds.txt'), lines.join('\n') + '\n');
+}
+function writeSnapshot(ingestedAt: string): void {
+  realFs.writeFileSync(path.join(dir, 'calendar.json'), JSON.stringify({ ingestedAt, events: [] }));
+}
+function ics(summary: string, startUtc: string, endUtc: string): string {
+  return `BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART:${startUtc}\nDTEND:${endUtc}\nSUMMARY:${summary}\nEND:VEVENT\nEND:VCALENDAR\n`;
+}
+function inWindowStamp(hoursAhead: number): { s: string; e: string } {
+  const d = new Date(Date.now() + hoursAhead * 3600e3);
+  const f = (x: Date): string => x.toISOString().replace(/[-:]/g, '').slice(0, 15) + 'Z';
+  const end = new Date(d.getTime() + 3600e3);
+  return { s: f(d), e: f(end) };
+}
+
+describe('calendarSyncDue — the scheduler due-check', () => {
+  it('not due without a feeds file', () => {
+    assert.equal(calendarSyncDue(fsDep, dir), false);
+  });
+  it('due when feeds exist and no snapshot', () => {
+    writeFeeds(['https://example.test/a.ics']);
+    assert.equal(calendarSyncDue(fsDep, dir), true);
+  });
+  it('not due when the snapshot is fresh; due once older than the TTL', () => {
+    writeFeeds(['https://example.test/a.ics']);
+    writeSnapshot(new Date().toISOString());
+    assert.equal(calendarSyncDue(fsDep, dir), false);
+    writeSnapshot(new Date(Date.now() - CALENDAR_SYNC_TTL_MS - 1000).toISOString());
+    assert.equal(calendarSyncDue(fsDep, dir), true);
+  });
+  it('comment lines and blanks are not feeds', () => {
+    writeFeeds(['# disabled https://example.test/x.ics', '']);
+    assert.equal(readCalendarFeedUrls(fsDep, dir)?.length, 0);
+    assert.equal(calendarSyncDue(fsDep, dir), false);
+  });
+});
+
+describe('syncCalendarFeeds', () => {
+  it('fetches, parses, dedupes across feeds, writes atomically', async () => {
+    writeFeeds(['https://example.test/a.ics', 'webcal://example.test/b.ics']);
+    const { s, e } = inWindowStamp(24);
+    const seen: string[] = [];
+    const r = await syncCalendarFeeds({
+      fs: fsDep as never, cuesDir: dir,
+      fetchImpl: async (url) => {
+        seen.push(url);
+        // both feeds carry the same event → dedupe to one
+        return { ok: true, status: 200, text: async () => ics('Shared Event', s, e) };
+      },
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.okCount, 2);
+    assert.equal(r.events, 1, 'identical start|title deduped');
+    assert.ok(seen[1].startsWith('https://'), 'webcal:// upgraded to https://');
+    const snap = JSON.parse(realFs.readFileSync(path.join(dir, 'calendar.json'), 'utf8'));
+    assert.equal(snap.events.length, 1);
+    assert.equal(snap.events[0].title, 'Shared Event');
+    assert.ok(snap.ingestedAt);
+    assert.equal(realFs.readdirSync(dir).filter(f => f.includes('.tmp-')).length, 0, 'no tmp leftovers');
+  });
+
+  it('all feeds failing keeps the previous snapshot (last-good posture)', async () => {
+    writeFeeds(['https://example.test/a.ics']);
+    writeSnapshot('2026-07-01T00:00:00Z');
+    const before = realFs.readFileSync(path.join(dir, 'calendar.json'), 'utf8');
+    const r = await syncCalendarFeeds({
+      fs: fsDep as never, cuesDir: dir,
+      fetchImpl: async () => { throw new Error('offline'); },
+    });
+    assert.equal(r.ok, false);
+    assert.equal(realFs.readFileSync(path.join(dir, 'calendar.json'), 'utf8'), before);
+  });
+
+  it('a 200 HTML page is refused (VCALENDAR sniff)', async () => {
+    writeFeeds(['https://example.test/login.html']);
+    const r = await syncCalendarFeeds({
+      fs: fsDep as never, cuesDir: dir,
+      fetchImpl: async () => ({ ok: true, status: 200, text: async () => '<html>sign in</html>' }),
+    });
+    assert.equal(r.ok, false);
+  });
+
+  it('discards its own result when another producer refreshed concurrently', async () => {
+    writeFeeds(['https://example.test/a.ics']);
+    const { s, e } = inWindowStamp(24);
+    const r = await syncCalendarFeeds({
+      fs: fsDep as never, cuesDir: dir,
+      fetchImpl: async () => {
+        // simulate a competing producer winning the race mid-fetch
+        writeSnapshot(new Date(Date.now() + 5000).toISOString());
+        return { ok: true, status: 200, text: async () => ics('Mine', s, e) };
+      },
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, 'superseded');
+    const snap = JSON.parse(realFs.readFileSync(path.join(dir, 'calendar.json'), 'utf8'));
+    assert.equal(snap.events.length, 0, 'the newer snapshot was NOT clobbered');
+  });
+});

--- a/packages/opencues-core/src/calendar-sync.ts
+++ b/packages/opencues-core/src/calendar-sync.ts
@@ -1,0 +1,151 @@
+/**
+ * Calendar feed sync — the ONE implementation of feeds → calendar.json.
+ *
+ * Extracted from the CLI (`opencues calendar sync`) so the runtime's
+ * refresh scheduler, the chrome-host process, and the CLI all share it —
+ * a hand-copied sync would be the July 2026 mirrored-guard drift class
+ * all over again. Callers differ only in how they schedule it:
+ *
+ *   - CLI: on demand (`opencues calendar sync`).
+ *   - Runtime refresh scheduler: due when the snapshot's `ingestedAt`
+ *     is older than the resource TTL (15 min) — the snapshot file's own
+ *     timestamp is the cross-host, cross-restart clock, so any number
+ *     of concurrently-running hosts self-deduplicate.
+ *   - chrome-host: same due check on its existing watch loop.
+ *
+ * Write discipline: atomic (tmp + rename) so a reader never sees a
+ * half-written snapshot; a pre-write re-stat discards our result when
+ * another producer refreshed while we were fetching (last writer would
+ * otherwise clobber a NEWER snapshot with an older fetch).
+ */
+
+import { parseIcs } from './ics';
+
+export interface CalendarSyncDeps {
+  /** fs facade — pass `require('node:fs')` (kept injectable for tests). */
+  readonly fs: {
+    readFileSync(p: string, enc: 'utf8'): string;
+    writeFileSync(p: string, data: string): void;
+    renameSync(a: string, b: string): void;
+    mkdirSync(p: string, opts: { recursive: boolean }): void;
+    statSync(p: string, opts: { throwIfNoEntry: false }): { mtimeMs: number } | undefined;
+    existsSync(p: string): boolean;
+  };
+  /** Directory holding calendar-feeds.txt + calendar.json (~/.cues or $OPENCUES_HOME). */
+  readonly cuesDir: string;
+  /** Fetch — defaults to ambient fetch. */
+  readonly fetchImpl?: (url: string, init?: unknown) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+  readonly log?: (msg: string) => void;
+  /** Event horizon (days ahead). */
+  readonly windowDays?: number;
+  /** Per-feed fetch timeout. */
+  readonly timeoutMs?: number;
+}
+
+export interface CalendarSyncResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+  readonly feeds?: number;
+  readonly okCount?: number;
+  readonly events?: number;
+}
+
+export const CALENDAR_FEEDS_BASENAME = 'calendar-feeds.txt';
+export const CALENDAR_SNAPSHOT_BASENAME = 'calendar.json';
+/** Feed-refresh TTL — the scheduler treats the snapshot as due when its
+ *  `ingestedAt` is older than this. */
+export const CALENDAR_SYNC_TTL_MS = 15 * 60_000;
+
+function joinPath(dir: string, base: string): string {
+  return dir.endsWith('/') || dir.endsWith('\\') ? dir + base : `${dir}/${base}`;
+}
+
+/** Read active (non-comment) feed URLs; null when no feeds file exists. */
+export function readCalendarFeedUrls(fs: CalendarSyncDeps['fs'], cuesDir: string): string[] | null {
+  const p = joinPath(cuesDir, CALENDAR_FEEDS_BASENAME);
+  let raw: string;
+  try { raw = fs.readFileSync(p, 'utf8'); } catch { return null; }
+  return raw.split(/\r?\n/).map(l => l.trim()).filter(l => l && !l.startsWith('#'));
+}
+
+/** Parse the snapshot's ingestedAt (ms epoch); -1 when missing/unreadable. */
+export function calendarSnapshotAgeAnchor(fs: CalendarSyncDeps['fs'], cuesDir: string): number {
+  const p = joinPath(cuesDir, CALENDAR_SNAPSHOT_BASENAME);
+  try {
+    const parsed = JSON.parse(fs.readFileSync(p, 'utf8')) as { ingestedAt?: string };
+    const t = parsed?.ingestedAt ? Date.parse(parsed.ingestedAt) : NaN;
+    return Number.isFinite(t) ? t : -1;
+  } catch { return -1; }
+}
+
+/** The scheduler's due-check: feeds configured AND snapshot missing or
+ *  older than the TTL. Reading the shared file (not process memory) is
+ *  what lets concurrent hosts self-deduplicate. */
+export function calendarSyncDue(fs: CalendarSyncDeps['fs'], cuesDir: string, ttlMs: number = CALENDAR_SYNC_TTL_MS, now: number = Date.now()): boolean {
+  const urls = readCalendarFeedUrls(fs, cuesDir);
+  if (!urls || urls.length === 0) return false;
+  const anchor = calendarSnapshotAgeAnchor(fs, cuesDir);
+  return anchor < 0 || now - anchor >= ttlMs;
+}
+
+/** Fetch every feed → parse → dedupe → atomically write calendar.json.
+ *  Never throws; failures keep the previous snapshot (the documented
+ *  "last good" posture). */
+export async function syncCalendarFeeds(deps: CalendarSyncDeps): Promise<CalendarSyncResult> {
+  const { fs, cuesDir } = deps;
+  const log = deps.log ?? (() => {});
+  const fetchImpl = deps.fetchImpl
+    ?? (typeof fetch !== 'undefined' ? (fetch as unknown as NonNullable<CalendarSyncDeps['fetchImpl']>) : undefined);
+  if (!fetchImpl) return { ok: false, reason: 'no fetch available' };
+
+  const urls = readCalendarFeedUrls(fs, cuesDir);
+  if (!urls || urls.length === 0) return { ok: false, reason: 'no feeds' };
+
+  const startedAt = Date.now();
+  const windowDays = deps.windowDays ?? 60;
+  const winStartMs = startedAt - 3600e3;
+  const winEndMs = startedAt + windowDays * 24 * 3600e3;
+  const timeoutMs = deps.timeoutMs ?? 15_000;
+
+  const all: ReturnType<typeof parseIcs> = [];
+  let okCount = 0;
+  for (const url of urls) {
+    try {
+      const httpUrl = url.replace(/^webcal:\/\//i, 'https://');
+      const ctl = typeof AbortController !== 'undefined' ? new AbortController() : undefined;
+      const to = ctl ? setTimeout(() => ctl.abort(), timeoutMs) : undefined;
+      const res = await fetchImpl(httpUrl, { headers: { 'User-Agent': 'opencues-calendar-sync/1.0' }, redirect: 'follow', signal: ctl?.signal });
+      if (to) clearTimeout(to);
+      if (!res.ok) { log(`calendar-sync: HTTP ${res.status} — ${url.slice(0, 50)}`); continue; }
+      const text = await res.text();
+      if (!/BEGIN:VCALENDAR/i.test(text)) { log(`calendar-sync: not iCalendar — ${url.slice(0, 50)}`); continue; }
+      all.push(...parseIcs(text, { windowStartMs: winStartMs, windowEndMs: winEndMs, maxEvents: 200 }));
+      okCount++;
+    } catch (e) {
+      log(`calendar-sync: ${(e as Error)?.message ?? e} — ${url.slice(0, 50)}`);
+    }
+  }
+  if (okCount === 0) return { ok: false, reason: 'all feeds failed — snapshot NOT overwritten', feeds: urls.length, okCount };
+
+  const seen = new Set<string>();
+  const events = all
+    .filter(e => { const k = `${e.start}|${e.title}`; if (seen.has(k)) return false; seen.add(k); return true; })
+    .sort((a, b) => a.start.localeCompare(b.start))
+    .slice(0, 50);
+
+  // Pre-write re-stat: if another producer refreshed while we fetched,
+  // ours is the OLDER data — discard rather than clobber.
+  const anchorNow = calendarSnapshotAgeAnchor(fs, cuesDir);
+  if (anchorNow >= startedAt) {
+    log('calendar-sync: another producer refreshed concurrently — discarding this fetch');
+    return { ok: true, reason: 'superseded', feeds: urls.length, okCount, events: events.length };
+  }
+
+  const snapshotPath = joinPath(cuesDir, CALENDAR_SNAPSHOT_BASENAME);
+  const tmpPath = `${snapshotPath}.tmp-${startedAt}`;
+  fs.mkdirSync(cuesDir, { recursive: true });
+  fs.writeFileSync(tmpPath, JSON.stringify({ source: 'opencues calendar sync', ingestedAt: new Date().toISOString(), events }, null, 2) + '\n');
+  fs.renameSync(tmpPath, snapshotPath);
+  log(`calendar-sync: ${events.length} event(s) from ${okCount}/${urls.length} feed(s)`);
+  return { ok: true, feeds: urls.length, okCount, events: events.length };
+}

--- a/packages/opencues-core/src/index.ts
+++ b/packages/opencues-core/src/index.ts
@@ -320,6 +320,17 @@ export type {
   CalendarContextEvent,
   CalendarContextSnapshot,
 } from './calendar-context';
+export {
+  syncCalendarFeeds,
+  calendarSyncDue,
+  readCalendarFeedUrls,
+  calendarSnapshotAgeAnchor,
+  CALENDAR_SYNC_TTL_MS,
+  CALENDAR_FEEDS_BASENAME,
+  CALENDAR_SNAPSHOT_BASENAME,
+  type CalendarSyncDeps,
+  type CalendarSyncResult,
+} from './calendar-sync';
 
 // iCalendar (.ics / webcal) parser — the first real calendar-context producer.
 // Pure (no network); the host poller fetches the feed and passes the text.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/boot-common.calendar-ingest.test.ts
+++ b/packages/opencues-runtime/src/boot-common.calendar-ingest.test.ts
@@ -116,4 +116,30 @@ describe('buildCalendarContextIngest', () => {
     expectEq(h.events.length, 2, 're-ingest applied without restart');
     expectEq(h.catalog.get('[EVENT 2]'), 'Two');
   });
+
+  it('feed-sync resource: stale snapshot + feeds file → scheduler refreshes from the feed', async () => {
+    // stale snapshot (older than the 15-min TTL) + a configured feed
+    fs.writeFileSync(path.join(tmpHome, 'calendar.json'),
+      JSON.stringify({ ingestedAt: new Date(Date.now() - 60 * 60_000).toISOString(), events: [] }));
+    fs.writeFileSync(path.join(tmpHome, 'calendar-feeds.txt'), 'https://example.test/feed.ics\n');
+    const d = new Date(Date.now() + 24 * 3600e3);
+    const f = (x: Date): string => x.toISOString().replace(/[-:]/g, '').slice(0, 15) + 'Z';
+    const end = new Date(d.getTime() + 3600e3);
+    const g = globalThis as { fetch?: unknown };
+    const saved = g.fetch;
+    g.fetch = async () => ({
+      ok: true, status: 200,
+      text: async () => `BEGIN:VCALENDAR\nBEGIN:VEVENT\nDTSTART:${f(d)}\nDTEND:${f(end)}\nSUMMARY:Fed Event\nEND:VEVENT\nEND:VCALENDAR\n`,
+    });
+    try {
+      const h = build(50);           // refreshMs set → jitter 0 → deterministic
+      await new Promise(r => setTimeout(r, 400));
+      expectEq(h.events.length, 1, 'holder refreshed from the feed via the scheduler');
+      expectEq(h.events[0].title, 'Fed Event');
+      const snap = JSON.parse(fs.readFileSync(path.join(tmpHome, 'calendar.json'), 'utf8'));
+      expect(Date.now() - Date.parse(snap.ingestedAt)).toBeLessThan(60_000);
+    } finally {
+      g.fetch = saved;
+    }
+  });
 });

--- a/packages/opencues-runtime/src/boot-common.ts
+++ b/packages/opencues-runtime/src/boot-common.ts
@@ -21,6 +21,7 @@ import type { HostAdapter, LogLevel } from './adapter';
 import type { ResolvedAgentLLM } from './modules/agent-rewrite';
 import { buildBlankWeaver, type BlankWeaver } from './modules/blank-weave';
 import type { HttpAdapterShape } from '@opencues/core';
+import { createRefreshScheduler } from './refresh-scheduler';
 import { StocksBlank } from './blanks/stocks';
 import { WeatherBlank } from './blanks/weather';
 import { CryptoBlank } from './blanks/crypto';
@@ -722,15 +723,13 @@ export function buildCalendarContextIngest(
     return path.join(os.homedir(), '.cues', 'calendar.json');
   };
 
-  let timerHandle: ReturnType<typeof setTimeout> | null = null;
-  let stopped = false;
   let lastMtimeMs = -1;
   let lastPath = '';
   const holder: CalendarContextHolder = {
     events: [],
     catalog: new Map<string, string>(),
     ingestedAt: undefined,
-    stop() { stopped = true; if (timerHandle) { clearTimeout(timerHandle); timerHandle = null; } },
+    stop() { /* replaced below once the scheduler exists */ },
   };
 
   const load = (): void => {
@@ -766,14 +765,42 @@ export function buildCalendarContextIngest(
     }
   };
 
+  // ── Refresh scheduling — the SYSTEM owns cadence, resources declare
+  // due-ness (July 2026 inversion). Two resources:
+  //   snapshot-reread: is the file newer than what the holder carries?
+  //     (cheap mtime check inside load()) — every tick.
+  //   feed-sync: are feeds configured AND the snapshot's own ingestedAt
+  //     older than CALENDAR_SYNC_TTL_MS (15 min)? The shared file
+  //     timestamp is the cross-host clock, so N running hosts
+  //     self-deduplicate; jitter staggers the herd; core's pre-write
+  //     re-stat discards a fetch another producer superseded.
   const refreshMs = opts.refreshMs ?? 60_000;
-  const tick = (): void => {
-    if (stopped) return;
-    load();
-    timerHandle = setTimeout(tick, refreshMs);
-    (timerHandle as { unref?: () => void }).unref?.();
+  const scheduler = createRefreshScheduler((m) => log('info', m), { tickMs: refreshMs });
+  scheduler.register({ id: 'calendar-snapshot-reread', due: () => true, refresh: load });
+  const syncCore = core as unknown as {
+    calendarSyncDue?: (fsMod: unknown, dir: string) => boolean;
+    syncCalendarFeeds?: (deps: unknown) => Promise<unknown>;
   };
-  tick();
+  if (syncCore.calendarSyncDue && syncCore.syncCalendarFeeds) {
+    const cuesDirOf = (): string => {
+      const override = process.env['OPENCUES_HOME'];
+      return override && override.trim().length > 0 ? override : path.join(os.homedir(), '.cues');
+    };
+    scheduler.register({
+      id: 'calendar-feed-sync',
+      jitterMs: opts.refreshMs ? 0 : 30_000,
+      due: () => {
+        try { return syncCore.calendarSyncDue!(fs, cuesDirOf()); } catch { return false; }
+      },
+      refresh: async () => {
+        await syncCore.syncCalendarFeeds!({ fs, cuesDir: cuesDirOf(), log: (m: string) => log('info', m) });
+        load();   // fold the fresh snapshot into the holder immediately
+      },
+    });
+  }
+  load();               // boot read
+  scheduler.tickNow();  // boot due-check (a stale snapshot refreshes ~immediately)
+  (holder as { stop: () => void }).stop = () => scheduler.stop();
   return holder;
 }
 

--- a/packages/opencues-runtime/src/refresh-scheduler.test.ts
+++ b/packages/opencues-runtime/src/refresh-scheduler.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Refresh scheduler — the system-owns-cadence contract (July 2026).
+ * Resources declare due-ness; the tick refreshes what's due, one
+ * in-flight per resource, failures retried when next due, never in the
+ * keystroke path.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRefreshScheduler } from './refresh-scheduler';
+
+const noop = (): void => {};
+
+describe('createRefreshScheduler', () => {
+  it('refreshes a due resource on tick and skips a not-due one', () => {
+    const s = createRefreshScheduler(noop, { tickMs: 999_999 });
+    let a = 0, b = 0;
+    s.register({ id: 'a', due: () => true, refresh: () => { a++; } });
+    s.register({ id: 'b', due: () => false, refresh: () => { b++; } });
+    s.tickNow();
+    s.tickNow();
+    expect(a).toBe(2);
+    expect(b).toBe(0);
+    s.stop();
+  });
+
+  it('holds ONE in-flight refresh per resource (slow refresh skips ticks, never stacks)', async () => {
+    const s = createRefreshScheduler(noop, { tickMs: 999_999 });
+    let started = 0;
+    let release: () => void = () => {};
+    const gate = new Promise<void>(r => { release = r; });
+    s.register({ id: 'slow', due: () => true, refresh: async () => { started++; await gate; } });
+    s.tickNow();
+    s.tickNow();
+    s.tickNow();
+    expect(started).toBe(1);
+    release();
+    await new Promise(r => setTimeout(r, 10));
+    s.tickNow();
+    expect(started).toBe(2);
+    s.stop();
+  });
+
+  it('a rejecting refresh is contained and retried when next due', async () => {
+    const msgs: string[] = [];
+    const s = createRefreshScheduler(m => msgs.push(m), { tickMs: 999_999 });
+    let calls = 0;
+    s.register({ id: 'flaky', due: () => true, refresh: async () => { calls++; throw new Error('feed down'); } });
+    s.tickNow();
+    await new Promise(r => setTimeout(r, 10));
+    s.tickNow();
+    await new Promise(r => setTimeout(r, 10));
+    expect(calls).toBe(2);
+    expect(msgs.some(m => m.includes('flaky') && m.includes('feed down'))).toBe(true);
+    s.stop();
+  });
+
+  it('a throwing due() is contained (scheduler survives)', () => {
+    const msgs: string[] = [];
+    const s = createRefreshScheduler(m => msgs.push(m), { tickMs: 999_999 });
+    let ok = 0;
+    s.register({ id: 'bad-due', due: () => { throw new Error('boom'); }, refresh: noop });
+    s.register({ id: 'good', due: () => true, refresh: () => { ok++; } });
+    s.tickNow();
+    expect(ok).toBe(1);
+    expect(msgs.some(m => m.includes('bad-due'))).toBe(true);
+    s.stop();
+  });
+
+  it('jitter defers first eligibility; stop() halts everything', () => {
+    let t = 1_000_000;
+    const s = createRefreshScheduler(noop, { tickMs: 999_999, now: () => t });
+    let n = 0;
+    s.register({ id: 'j', due: () => true, refresh: () => { n++; }, jitterMs: 5_000 });
+    s.tickNow();                 // within jitter window → not eligible
+    expect(n).toBe(0);
+    t += 6_000;
+    s.tickNow();
+    expect(n).toBe(1);
+    s.stop();
+    t += 60_000;
+    s.tickNow();                 // stopped → no-op
+    expect(n).toBe(1);
+  });
+});

--- a/packages/opencues-runtime/src/refresh-scheduler.ts
+++ b/packages/opencues-runtime/src/refresh-scheduler.ts
@@ -1,0 +1,109 @@
+/**
+ * Refresh scheduler — ONE system tick that asks every registered
+ * refreshable resource "are you due?" and refreshes the ones that are.
+ *
+ * The inversion this exists for (July 2026, Wilfred's framing): nothing
+ * "calls" a sync — resources DECLARE themselves refreshable with a due
+ * predicate, and the system owns the cadence. Calendar feeds are the
+ * first resource (15-min TTL, due-ness read from the shared snapshot's
+ * own `ingestedAt` so concurrent hosts self-deduplicate); the snapshot
+ * file re-read is the second. The world-data caches (bank holidays /
+ * weather / TfL) and blank-context prewarm are natural future migrations
+ * onto the same tick.
+ *
+ * Guarantees:
+ *   - the tick NEVER runs in the keystroke path (interval timer only,
+ *     unref'd so it never keeps a host process alive);
+ *   - one in-flight refresh per resource (a slow refresh skips ticks
+ *     rather than stacking);
+ *   - per-resource jitter (fixed per process lifetime) staggers
+ *     multi-host herds without any cross-process coordination;
+ *   - a throwing/rejecting refresh is logged and retried on the next
+ *     due tick — it can never take the scheduler down.
+ */
+
+export interface RefreshableResource {
+  /** Stable id for logs. */
+  readonly id: string;
+  /** Is a refresh warranted right now? Cheap — called every tick. */
+  due(now: number): boolean;
+  /** Perform the refresh. May be async; failures are logged + retried. */
+  refresh(): void | Promise<void>;
+  /** Random extra delay budget (ms) applied once per process to this
+   *  resource's due-ness, staggering multi-host herds. Default 0. */
+  readonly jitterMs?: number;
+}
+
+export interface RefreshScheduler {
+  register(resource: RefreshableResource): void;
+  /** Run one tick immediately (boot + tests). */
+  tickNow(): void;
+  stop(): void;
+}
+
+export function createRefreshScheduler(
+  log: (msg: string) => void,
+  opts: { tickMs?: number; now?: () => number } = {},
+): RefreshScheduler {
+  const tickMs = opts.tickMs ?? 30_000;
+  const now = opts.now ?? Date.now;
+  interface Entry { r: RefreshableResource; inFlight: boolean; notBefore: number }
+  const entries: Entry[] = [];
+  let stopped = false;
+  let handle: ReturnType<typeof setTimeout> | null = null;
+
+  const runOne = (e: Entry): void => {
+    e.inFlight = true;
+    let result: void | Promise<void>;
+    try {
+      result = e.r.refresh();
+    } catch (err) {
+      log(`refresh[${e.r.id}]: failed (${(err as Error)?.message ?? err}) — will retry when next due`);
+      e.inFlight = false;
+      return;
+    }
+    // Sync refreshes complete synchronously (deterministic for callers +
+    // tests); only genuine promises hold the in-flight guard open.
+    if (result && typeof (result as Promise<void>).then === 'function') {
+      (result as Promise<void>)
+        .catch(err => log(`refresh[${e.r.id}]: failed (${(err as Error)?.message ?? err}) — will retry when next due`))
+        .finally(() => { e.inFlight = false; });
+    } else {
+      e.inFlight = false;
+    }
+  };
+
+  const tick = (): void => {
+    if (stopped) return;
+    const t = now();
+    for (const e of entries) {
+      if (e.inFlight || t < e.notBefore) continue;
+      try {
+        if (e.r.due(t)) runOne(e);
+      } catch (err) {
+        log(`refresh[${e.r.id}]: due() threw (${(err as Error)?.message ?? err})`);
+      }
+    }
+  };
+
+  const loop = (): void => {
+    if (stopped) return;
+    tick();
+    handle = setTimeout(loop, tickMs);
+    (handle as { unref?: () => void }).unref?.();
+  };
+  handle = setTimeout(loop, tickMs);
+  (handle as { unref?: () => void }).unref?.();
+
+  return {
+    register(resource: RefreshableResource): void {
+      const jitter = resource.jitterMs ? Math.floor(Math.random() * resource.jitterMs) : 0;
+      entries.push({ r: resource, inFlight: false, notBefore: now() + jitter });
+    },
+    tickNow(): void { tick(); },
+    stop(): void {
+      stopped = true;
+      if (handle) { clearTimeout(handle); handle = null; }
+    },
+  };
+}


### PR DESCRIPTION
Implements the resource-refresh model: **nothing "calls" a sync - the system checks whether registered refreshable resources are due, on a set timer.**

## Architecture
- `RefreshScheduler` (runtime): one 30s tick, resources declare `due(now)` + `refresh()`; one in-flight per resource, contained failures (retry when next due), per-process jitter, unref'd - never in the keystroke path, never keeps a process alive.
- **Calendar feeds = first resource, 15-min TTL**: due-ness reads the shared snapshot's own `ingestedAt`, so concurrent hosts self-deduplicate off the file clock; core's pre-write re-stat discards a fetch a competing producer superseded.
- Sync logic extracted to `@opencues/core` (`syncCalendarFeeds`: atomic tmp+rename, VCALENDAR sniff, webcal→https, cross-feed dedupe, last-good on failure). **Three callers, one implementation** (CLI / runtime scheduler / chrome-host 5-min due-check) - per the mirrored-guard drift lesson.
- chrome-host's write trips its existing `fs.watch` → bundle push; chrome-only users get freshness with zero new plumbing.

## User journey
`opencues calendar add <url>` is now the entire setup. Feeds ≤ ~15 min stale while any host runs; file→runtime ≤ 60s as before.

## Verification
- scheduler 5/5, core sync 8/8 (incl. concurrent-producer discard + HTML-page refusal), ingest end-to-end feed refresh (stubbed ICS feed → holder updated via scheduler)
- core suite 1282/0 with all keys unset; CLI 631/633 (2 known WSL-host artifacts, green on CI)
- chrome build + `check-chrome-bundle` + `check-cc-bundle-integrity` green
- Live: `opencues calendar sync` delegating through core - 4 events, 2/2 real feeds

Extension point noted in the module docs: world-data caches (bank holidays/weather/TfL) and blank-context prewarm are natural future migrations onto the same tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)