### PR TITLE
fix(runtime): guard OPENCUES_HOME reads for browser bundles (greens CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — browser-safe guards on the calendar-ingest OPENCUES_HOME reads (`@opencues/runtime` 0.25.1)
+
+The two ingest closures read `process.env` unguarded — the runtime-browser-safe lint had been red since #322 (masked by a broken CI-watch pipe; five PRs merged over the single failing job). Guards added; semantics unchanged (the ingest already early-returns in browsers).
+
 ### Fixed — `opencues calendar remove` now clears cleanly (no ghost calendar) (CLI 0.2.54)
 
 Removing a feed only edited `calendar-feeds.txt`; the snapshot reconciled on "the next poll" — which, for the LAST feed, never comes (`syncCalendarFeeds` refuses on no-feeds and the scheduler's due-check goes permanently quiet), so the deleted calendar's events ghosted forever: stale PII still firing conflict cues and answering availability. Now `remove` reconciles immediately: with feeds remaining it re-syncs on the spot (removed events drop now, not within the 15-min TTL); removing the last feed writes an EMPTY snapshot — empty beats deleting the file, because chrome's loader falls back to the bake-time bundled snapshot when the file is missing, which would resurrect even older events. External producers that write `calendar.json` without a feeds file are unaffected (the clear only runs on user-initiated remove). Hosts pick up the cleared snapshot within ~60s via the ingest. Two hermetic regression tests.

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/boot-common.ts
+++ b/packages/opencues-runtime/src/boot-common.ts
@@ -718,7 +718,7 @@ export function buildCalendarContextIngest(
   const os = require('node:os') as typeof import('node:os');
 
   const snapshotPath = (): string => {
-    const override = process.env['OPENCUES_HOME'];
+    const override = typeof process !== 'undefined' ? process.env['OPENCUES_HOME'] : undefined;
     if (override && override.trim().length > 0) return path.join(override, 'calendar.json');
     return path.join(os.homedir(), '.cues', 'calendar.json');
   };
@@ -783,7 +783,7 @@ export function buildCalendarContextIngest(
   };
   if (syncCore.calendarSyncDue && syncCore.syncCalendarFeeds) {
     const cuesDirOf = (): string => {
-      const override = process.env['OPENCUES_HOME'];
+      const override = typeof process !== 'undefined' ? process.env['OPENCUES_HOME'] : undefined;
       return override && override.trim().length > 0 ? override : path.join(os.homedir(), '.cues');
     };
     scheduler.register({


### PR DESCRIPTION
CI has been red since #322 on exactly one job - `runtime browser-safe lint` - flagging two unguarded `process.env['OPENCUES_HOME']` reads in the calendar-ingest closures. Five PRs (#322-#326) merged over it because my watch piped `gh run watch` through `tail`, so tail's exit code masked the run's. All other jobs were green in every one of those runs. Guards added (semantics unchanged - the ingest already early-returns in browsers); lint green locally; ingest+scheduler tests 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)