### PR TITLE
fix(cli): consume --no-cleanup — it leaked into the spawned host's argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `opencues run <host> --no-cleanup` leaked the flag into the host's own CLI (CLI 0.2.56)
+
+`--no-cleanup` gated the predecessor-kill correctly but was never consumed in the argv loop (unlike `--skip-banner` / `--no-rebuild-check`), so it rode `passthrough` into the spawned host's command line. opencode prints its help and EXITS on an unknown flag — which silently killed every agentic-harness pool shard ("0/N shards live"; without the flag, concurrent shard launches SIGTERM each other via the predecessor-kill instead, so parallel harness runs were broken both ways). The flag is now consumed opencues-side; the predecessor-kill gate still reads it from the original argv.
+
 ### Security — ground the contradiction-cue geocoder inputs + cap calendar feed size (`@opencues/core` 0.33.0)
 
 Static security review of the July 2026 external-HTTP feature cluster (calendar ingest + Tier-0…5c contradiction cues). Two hardenings; both features are `contradiction-cues-mode` / calendar-feed opt-in, so neither is a live default-on exposure.

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.55",
+  "version": "0.2.56",
   "private": true,
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "bin": {

--- a/packages/opencues-cli/src/commands/run.cjs
+++ b/packages/opencues-cli/src/commands/run.cjs
@@ -231,6 +231,15 @@ module.exports = async function run(argv, ctx) {
       skipRebuildCheck = true;
       continue;
     }
+    if (a === '--no-cleanup') {
+      // opencues-owned flag — consumed here, NOT forwarded to the
+      // spawned host. The predecessor-kill gate reads it from the
+      // ORIGINAL argv (runOC's fullArgv), so consuming it here only
+      // stops it leaking into the host's own CLI — opencode prints
+      // its help and EXITS on an unknown flag, which killed every
+      // agentic-harness pool shard silently ("0/N shards live").
+      continue;
+    }
     if (!a.startsWith('-') && !target) target = a;
     else passthrough.push(a);
   }


### PR DESCRIPTION
`opencues run <host> --no-cleanup` gated the predecessor-kill correctly but never consumed the flag in the argv loop (unlike `--skip-banner` / `--no-rebuild-check`), so it rode `passthrough` onto the host's own command line. opencode prints its help and **exits** on an unknown flag — which silently killed every agentic-harness pool shard (`oc-daemon start N` → "0/N shards live"). Without the flag, concurrent shard launches SIGTERM each other via the predecessor-kill instead, so parallel harness runs were broken in both directions.

One consume branch in the argv loop; the predecessor-kill gate is unchanged (it reads the original argv). Verified live: pool went 0/4 → 4/4 with this fix, full suite now running on it.

Note: CLI takes 0.2.56; #334 will renumber its claimed 0.2.56 → 0.2.57 at its next master merge (same coordination as core 0.33.0/0.34.0 with #332).

🤖 Generated with [Claude Code](https://claude.com/claude-code)