### PR TITLE
fix(resolver): abort racing lower-priority siblings on a config-command slot-claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — a config-command slot-claim now aborts racing lower-priority siblings (`@opencues/core` 0.40.0 → 0.40.1)
+
+Follow-up to the provider-liveness probe. When `ConfigIntentSource` claims the `_` (returns `consumedBlankSlots`) for a provider/settings command — applied **or refused** — the resolver now **aborts** any strictly-lower-priority sibling (FluidBlank / TransformBlank) still racing on that slot, cancelling its in-flight LLM call. Previously the claim only *filtered* the sibling's result after the fact, so on a refused provider switch FluidBlank still ran a full wasted round-trip (and it was that late result that used to overwrite the tailored message before the `consumedBlankSlots` filter landed). This generalises the existing abort — which fired only on a whole-buffer claim or an undo/redo ACTION — to any explicit slot-claim, so it works even for the refusal's `_`-only (or empty-results) shape that carries no spanning result. Scoped by construction: `ConfigIntentSource` is the only source that returns source-level `consumedBlankSlots`. Pinned by two resolver tests (claim → in-flight sibling aborted; no claim → sibling runs to completion).
+
 ### Added — provider switches ping the target before committing; stay put + inline error on failure (`@opencues/core` 0.39.0 → 0.40.0)
 
 A fluid-config provider switch (`"switch to ollama _"`, `"use anthropic for cues _"`) now **pings the provider it's about to change to** before writing the scalar. If the target can't answer — Ollama isn't running, a required key is missing, the provider rejects the model — OpenCues writes **nothing** (the current provider stays) and surfaces the reason **inline**, via the same `[err]`-style substitute every other blank LLM failure uses. Previously a switch to an unreachable provider applied blindly and then every subsequent call silently failed.

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.99",
+  "version": "0.2.100",
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.99",
+  "version": "0.2.100",
   "private": true,
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "compatibility": {

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/resolver.test.ts
+++ b/packages/opencues-core/src/resolver.test.ts
@@ -451,3 +451,62 @@ describe('CueResolver: same-word sentence-cues are NOT merged (spaceless CJK)', 
     assert.strictEqual(atOne.length, 1, 'non-sentence-cue duplicates still merge into one');
   });
 });
+
+describe('CueResolver: parallel mode — an explicit slot-claim aborts lower-priority siblings', () => {
+  it('a higher-priority source returning consumedBlankSlots cancels a still-in-flight lower-priority sibling', async () => {
+    // Mirrors the ConfigIntent provider-switch case: the classifier claims
+    // the `_` (consumedBlankSlots) — even with NO spanned result (a refusal
+    // only replaces `_`) — and a slower FluidBlank-style sibling on the same
+    // slot must have its in-flight LLM call aborted, not run to completion
+    // just to be filtered.
+    let lowAborted = false;
+    let lowRanToCompletion = false;
+
+    const high: CueSource = {
+      id: 'high', priority: 100, isCycleable: false, supports: () => true,
+      // Empty-results refusal shape — no spanned result, just the claim.
+      async getCues() { return { results: [], consumedBlankSlots: [3] }; },
+    };
+    const low: CueSource = {
+      id: 'low', priority: 50, isCycleable: false, supports: () => true,
+      async getCues(ctx) {
+        return await new Promise<CueSourceResult>((resolve) => {
+          const done = (aborted: boolean) => {
+            if (aborted) lowAborted = true; else lowRanToCompletion = true;
+            resolve({ results: [] });
+          };
+          if (ctx.signal?.aborted) { done(true); return; }
+          ctx.signal?.addEventListener('abort', () => done(true));
+          // Fallback so the test can't hang if the abort never fires.
+          setTimeout(() => done(false), 800);
+        });
+      },
+    };
+
+    const resolver = new CueResolver([high, low], { parallel: true });
+    await resolver.resolve(makeContext('switch to ollama _'));
+    assert.strictEqual(lowAborted, true, 'lower-priority sibling should be aborted by the slot-claim');
+    assert.strictEqual(lowRanToCompletion, false, 'lower-priority sibling must NOT run to completion');
+  });
+
+  it('no claim → lower-priority sibling runs to completion (abort is scoped to claims)', async () => {
+    let lowRanToCompletion = false;
+    const high: CueSource = {
+      id: 'high', priority: 100, isCycleable: false, supports: () => true,
+      async getCues() { return { results: [] }; }, // no consumedBlankSlots
+    };
+    const low: CueSource = {
+      id: 'low', priority: 50, isCycleable: false, supports: () => true,
+      async getCues(ctx) {
+        return await new Promise<CueSourceResult>((resolve) => {
+          if (ctx.signal?.aborted) { resolve({ results: [] }); return; }
+          ctx.signal?.addEventListener('abort', () => resolve({ results: [] }));
+          setTimeout(() => { lowRanToCompletion = true; resolve({ results: [] }); }, 50);
+        });
+      },
+    };
+    const resolver = new CueResolver([high, low], { parallel: true });
+    await resolver.resolve(makeContext('the sky today looks _'));
+    assert.strictEqual(lowRanToCompletion, true, 'without a claim, the sibling must finish normally');
+  });
+});

--- a/packages/opencues-core/src/resolver.ts
+++ b/packages/opencues-core/src/resolver.ts
@@ -182,7 +182,19 @@ export class CueResolver {
         const actionClaim = filteredResults.some(
           r => (r.metadata as { undoAction?: unknown } | undefined)?.undoAction !== undefined,
         );
-        if (wholeBufferClaim || actionClaim) {
+        // EXPLICIT slot claim → abort racers. A source that returns
+        // `consumedBlankSlots` is declaring "the `_` is MY command, not a
+        // blank to fill" — same intent as the whole-buffer / undo claims
+        // above, but it needn't span the whole buffer (a ConfigIntent
+        // provider-switch REFUSAL only replaces `_`, and its empty-results
+        // shape carries no spanned result at all). Without this, a
+        // strictly-lower-priority sibling (FluidBlank) keeps its in-flight
+        // LLM call running to completion only to be filtered — pure waste,
+        // and on the refusal path it's the call that used to overwrite the
+        // tailored message. Only ConfigIntentSource returns source-level
+        // consumedBlankSlots today, so this is scoped to config commands.
+        const explicitSlotClaim = (result.consumedBlankSlots?.length ?? 0) > 0;
+        if (wholeBufferClaim || actionClaim || explicitSlotClaim) {
           const claimingPriority = source.priority;
           for (let j = i + 1; j < applicableSources.length; j++) {
             if (applicableSources[j].priority < claimingPriority) {


### PR DESCRIPTION
Follow-up to #349 (provider-liveness probe + `consumedBlankSlots` claim). You asked for **abort-on-refusal** on top of the slot-claim.

## Problem

On a **refused** provider switch, the `consumedBlankSlots` claim only *filtered* FluidBlank's result after the fact — FluidBlank still ran a **full wasted LLM round-trip** in parallel (and before the filter landed, its late result was what overwrote the tailored "kept current provider" message).

## Fix

Generalise the resolver's existing sibling-abort — which fired only on a **whole-buffer claim** or an **undo/redo ACTION** — to **any explicit slot-claim** (`result.consumedBlankSlots` non-empty). When `ConfigIntentSource` claims the `_` for a provider/settings command (applied **or refused**), the resolver aborts strictly-lower-priority siblings still racing on that slot, cancelling their in-flight calls.

This works for the refusal's `_`-only and **empty-results** shapes, which carry no spanning result to trip the whole-buffer path. **Scoped by construction:** `ConfigIntentSource` is the only source that returns source-level `consumedBlankSlots` today, so nothing else changes behaviour.

## Tests

Two resolver tests: claim → in-flight sibling **aborted** (does not run to completion); no claim → sibling **finishes normally** (abort is scoped to claims). Existing whole-buffer + ACTION abort tests still green (17/17 resolver suite).

`@opencues/core` 0.40.0 → 0.40.1, `@opencues/chrome` 0.2.99 → 0.2.100 (bundle lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN1qzJAvL12sbkwnLELNkQ