### PR TITLE
fix(routing): inherit is a universal provider fall-through sentinel (fixes cues silently dropped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `inherit` is now a universal provider fall-through sentinel (`@opencues/core` 0.40.1 → 0.40.2, `@opencues/chrome` 0.2.101 → 0.2.102)
+
+`inherit` means "no override at this tier — use the one below" and is a documented value for BOTH the bucket scalars (`cues-llm-provider: inherit`) and the per-feature ones (`word-cues-provider: inherit`, `agent-provider: inherit`, …). But `resolveLLMTuple` only honored it for the bucket scalars (collapsed upstream); a per-feature `inherit` arrived verbatim and was looked up as a LITERAL provider → unknown → `null` → the source was silently dropped with `"no API key for provider 'inherit'"`. Symptom: setting every routing scalar to `inherit` (to make one global provider authoritative) silently disabled all word-cues / sentence-cues — most visible on chrome, where the whole cue set went dark.
+
+Fix: `resolveLLMTuple` now skips any tier whose provider OR model is `inherit` (treats it identically to absent), so it falls through to the global at every tier. `getProvider('inherit')` returns `null` WITHOUT the "unknown provider" warning (it's a sentinel, not a provider), and chrome's CUES.md provider audit no longer flags `inherit` as misconfigured. Pinned by two `resolveLLM` tests (feature-tier `inherit` → global; all-tiers `inherit` → auto-route) plus the full routing suite. No behaviour change for real provider values.
+
 ### Added — satellite provider cycling silently skips an unreachable provider (`@opencues/runtime` 0.28.2 → 0.28.3)
 
 Extends the provider-switch liveness gate to the `Ctrl+Alt` settings-cycle. `Cycling.eligibleValues` already dropped `*-llm-provider` values with no key set (you never land on a keyless provider); it now also drops any menu provider a recent liveness probe found UNREACHABLE — a present-but-invalid key, or a down host — so the cycle steps right over it, exactly like the keyless ones. Consistent with the "silently skip" model you picked: dead providers just aren't offered as a cycle stop; no flicker, no revert.

--- a/integrations/chrome/manifest.json
+++ b/integrations/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OpenCues",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "permissions": [
     "storage",

--- a/integrations/chrome/package.json
+++ b/integrations/chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/chrome",
-  "version": "0.2.101",
+  "version": "0.2.102",
   "private": true,
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "compatibility": {

--- a/integrations/chrome/src/opencues-bootstrap.ts
+++ b/integrations/chrome/src/opencues-bootstrap.ts
@@ -2440,6 +2440,10 @@ async function auditProvidersAgainstKeys(keys: Record<string, string>): Promise<
 
   const problems: string[] = [];
   for (const d of directives) {
+    // `inherit` is the fall-through sentinel (use the next tier down / the
+    // global) — a documented value for the bucket + per-feature provider
+    // scalars, NOT a real provider. Don't flag it as unknown.
+    if (d.provider === 'inherit') continue;
     if (!(d.provider in PROVIDER_ENV_KEY)) {
       problems.push(`  - "${d.feature === 'global' ? 'llm-provider' : d.feature + '-provider'}: ${d.provider}" — unknown provider`);
       continue;

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/llm-provider.test.ts
+++ b/packages/opencues-core/src/llm-provider.test.ts
@@ -659,6 +659,34 @@ describe('resolveLLM — settings-hierarchy precedence', () => {
     assert.strictEqual(r?.apiKey, 'oai_k');
   });
 
+  it('`inherit` at the feature tier falls through to global (not treated as a literal provider)', () => {
+    // Regression: a per-feature scalar of `inherit` (e.g. word-cues-provider:
+    // inherit) used to be looked up as a literal provider → unknown → null →
+    // the source was silently dropped ("no API key for provider 'inherit'").
+    // It must mean "no override here" and fall through to the global.
+    const r = resolveLLM({
+      featureProvider: 'inherit',
+      featureModel: 'inherit',
+      globalProvider: 'cerebras',
+      globalModel: 'gemma-4-31b',
+      apiKeys,
+    });
+    assert.strictEqual(r?.provider.id, 'cerebras', 'feature `inherit` must fall through to the global provider');
+    assert.strictEqual(r?.model, 'gemma-4-31b', 'feature `inherit` model must fall through to the global model');
+    assert.strictEqual(r?.apiKey, 'cere_k');
+  });
+
+  it('`inherit` at every tier auto-routes over available keys (never a literal provider)', () => {
+    // All tiers `inherit` → equivalent to nothing set → auto-pick (cerebras
+    // is first in the auto order and has a key here).
+    const r = resolveLLM({
+      providerOverride: 'inherit', featureProvider: 'inherit', globalProvider: 'inherit',
+      apiKeys,
+    });
+    assert.strictEqual(r?.provider.id, 'cerebras');
+    assert.notStrictEqual(r?.provider.id, undefined);
+  });
+
   it('falls through to cerebras + provider default model when nothing set', () => {
     // Default flipped from groq → cerebras after May 2026 benchmark sweep
     // (see resolveLLM's inline note). Same gpt-oss-120b model, faster

--- a/packages/opencues-core/src/llm-provider.ts
+++ b/packages/opencues-core/src/llm-provider.ts
@@ -1754,6 +1754,11 @@ export function isProviderValueCyclable(
  */
 export function getProvider(id: string | undefined | null): ProviderAdapter | null {
   if (!id) return null;
+  // `inherit` is the fall-through sentinel (use the global provider), a
+  // documented value for the bucket + per-feature `*-provider` scalars — NOT
+  // a real provider. Return null WITHOUT warning; callers resolve the actual
+  // provider via resolveLLM's tier fall-through.
+  if (id.trim().toLowerCase() === 'inherit') return null;
   const canonical = (LEGACY_PROVIDER_ALIASES[id] ?? id) as ProviderId;
   const found = PROVIDERS[canonical];
   if (!found) {
@@ -2446,9 +2451,20 @@ export function resolveLLMTuple(opts: ResolveLLMOptions): ResolvedLLMTuple | nul
     { p: opts.featureProvider, m: opts.featureModel },
     { p: opts.globalProvider, m: opts.globalModel },
   ];
+  // `inherit` is the fall-through sentinel: it means "no override at this
+  // tier — use the next one down". It's a documented value for the bucket
+  // scalars (cues-llm-provider: inherit) and the per-feature ones
+  // (word-cues-provider: inherit, …). The bucket scalars get collapsed to
+  // the global upstream, but per-feature values arrive here verbatim, so we
+  // must skip an `inherit` tier here too — otherwise it was tried as a
+  // LITERAL provider ('inherit' → unknown → null → the source is dropped
+  // with "no API key for provider 'inherit'"). Treat it identically to an
+  // absent value at every tier.
+  const isOverride = (p?: string | null): p is string =>
+    typeof p === 'string' && p.trim() !== '' && p.trim().toLowerCase() !== 'inherit';
   let providerTierIdx = -1;
   for (let i = 0; i < tiers.length; i += 1) {
-    if (tiers[i].p) { providerTierIdx = i; break; }
+    if (isOverride(tiers[i].p)) { providerTierIdx = i; break; }
   }
   // No-tier-set path: AUTO-ROUTE over the user's available API keys.
   // Picks the first provider from PROVIDER_AUTO_ORDER whose env-var key
@@ -2480,7 +2496,7 @@ export function resolveLLMTuple(opts: ResolveLLMOptions): ResolvedLLMTuple | nul
   let model: string | null = null;
   for (let i = 0; i < tiers.length; i += 1) {
     const m = tiers[i].m;
-    if (!m) continue;
+    if (!isOverride(m)) continue;  // absent OR `inherit` → fall through
     // Only carry the model if it's at least as specific as the provider tier
     // (or no provider tier was set, in which case we fell back to groq and
     // any tier's model is fair game).


### PR DESCRIPTION
Investigating your chrome "0 cues" turned up a real routing bug (which I'd made acute by setting every routing scalar to `inherit`).

## Root cause

`inherit` means "no override at this tier — use the one below" and is a documented value for **both** the bucket scalars (`cues-llm-provider: inherit`) **and** the per-feature ones (`word-cues-provider: inherit`, …). But `resolveLLMTuple` only honored it for the bucket scalars (which are collapsed upstream). A **per-feature** `inherit` arrived verbatim and was looked up as a **literal provider** → unknown → `null` → the source was silently dropped with `"no API key for provider 'inherit'"`.

So making one global provider authoritative by setting everything to `inherit` **silently disabled all word-cues / sentence-cues** — most visible on chrome, where the whole cue set went dark and the log filled with `unknown provider "inherit"`.

## Fix

- `resolveLLMTuple` skips any tier whose **provider or model** is `inherit` — treats it identically to absent, falling through to the global at every tier.
- `getProvider('inherit')` returns `null` **without** the "unknown provider" warning (it's a sentinel), silencing the boot warning for every caller.
- Chrome's CUES.md provider audit no longer flags `inherit` as misconfigured.

## Tests

Two `resolveLLM` tests (feature-tier `inherit` → global; all-tiers `inherit` → auto-route) + full core suite green (1312 node:test + 298 vitest, 0 fail — incl. the feature-registry `inherit` tests). No behaviour change for real provider values.

`@opencues/core` 0.40.1 → 0.40.2, `@opencues/chrome` 0.2.101 → 0.2.102.

## Note on the other half of "0 cues"

Two things were conflated in the logs:
- **`0 cue entries`** just counts CUES.md `## Tips` (local tip cues) — chrome's CUES.md has none, which is harmless; folder word-cues load separately.
- **Folder cues not running on Luma** — those are single-line `<input>` fields, and word-/sentence-cues are pruned there by design (they need cycling; a one-line search box can't cycle alternatives). After this fix they resolve and run in **contenteditable** editors (Gmail, rich text). So on Luma's form fields cues stay (correctly) absent; in a rich editor they now work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN1qzJAvL12sbkwnLELNkQ