### PR TITLE
docs(launch): LAUNCH.md go-live runbook + npm-handover fix

### DIFF
--- a/docs/architecture/versioning.md
+++ b/docs/architecture/versioning.md
@@ -41,6 +41,74 @@ A single PR can land entries in both. If unsure whether a change is spec-affecti
 - **No PR / issue numbers** in the entry itself — git blame on the changelog gives the PR; the entry should make sense without one. (Exceptions: when a fix specifically references a prior incident PR for context, that's fine.)
 - **Past tense, plain prose.** "Added X" / "Fixed Y" / "Renamed A → B."
 
+## Releases & tagging
+
+Per-package versions (above) track *what changed in each package*, PR by PR. A
+**release** is the separate, higher-level act of cutting a user-facing version
+of OpenCues as a whole. Package bumps happen every PR; releases happen on a
+cadence.
+
+### One user-facing version
+
+Users don't see `@opencues/core@0.40.2` — they see "OpenCues `vX.Y.Z`". Keep
+**one** product version, and make three things equal at every release:
+
+- the **git tag** — `vX.Y.Z`
+- the **GitHub Release** — `vX.Y.Z`
+- the **`opencues` CLI** version — what `npm i opencues` resolves to
+
+The CLI is the installable artifact, so **the product version IS the CLI's
+`package.json` version**. The other packages (`core`, `runtime`, integrations)
+keep versioning independently underneath — they're implementation detail and
+will sit at different, usually higher, numbers (`core` at `0.40` while the
+product is at `0.3` is fine and expected). Don't try to sync them.
+
+### Tag scheme
+
+- **`vMAJOR.MINOR.PATCH`**, `v`-prefixed (`v0.3.0`). Nothing else.
+- Pre-1.0: **minor** = a notable feature batch or any breaking change; **patch**
+  = fixes and small additions.
+- The old date-checkpoint tags (`v2026.06.25`) are **retired** — historical
+  only. Don't add more.
+
+### When to cut a release
+
+- **On a meaningful batch** — a shipped feature, a fix users are waiting on, a
+  new integration/provider, a spec bump, or a security fix. Roughly weekly if
+  changes have accumulated.
+- **Not every PR** (tag noise) and **not never** — a neglected `[Unreleased]`
+  balloons (it hit 800 lines once between April and July 2026; don't repeat
+  that). If `[Unreleased]` is more than a screen or two long, you're overdue.
+
+### How to cut a release
+
+1. Pick `X.Y.Z` — bump from the **last release** per semver (not from a package
+   version).
+2. Set `packages/opencues-cli/package.json` `version` → `X.Y.Z`.
+3. In `CHANGELOG.md`: rename the `## [Unreleased]` heading to
+   `## [X.Y.Z] - YYYY-MM-DD`, and add a fresh empty `## [Unreleased]` above it.
+4. `git commit -m "chore(release): vX.Y.Z"`, then
+   `git tag vX.Y.Z && git push origin vX.Y.Z`.
+5. `npm publish` the CLI if the CLI changed (first publish: see
+   [`docs/launch/npm-handover.md`](../launch/npm-handover.md)).
+6. `gh release create vX.Y.Z --title "OpenCues vX.Y.Z" --notes-file <notes>`.
+
+### Release notes are curated, not dumped
+
+The GitHub Release body is a **curated highlight of the changelog section**, not
+its raw entries. Pick the ~8–12 changes a user actually cares about, lead with
+the headline features, group by Added / Fixed / …, and link to the docs. The
+full per-package detail stays in `CHANGELOG.md`; the release notes are the
+trailer, not the script. (This is also why changelog entries should stay
+skimmable — see "What makes a good changelog entry" above.)
+
+### SPEC_VERSION stays decoupled
+
+The open-standard version (`SPEC_VERSION` + `spec/CHANGELOG.md`) has its **own**
+cadence and is never folded into the product tag — a product release can ship
+with no spec change, and a spec bump can land mid-cycle. Keep them separate. See
+the SPEC-bump checklist in CLAUDE.md.
+
 ## Why this matters here specifically
 
 OpenCues ships as multiple bundled copies (CC fork's `node_modules/`, chrome's bake bundle, OC's `node_modules/`, etc.). When source has a fix but one bundled copy is stale, debugging is brutal because every copy claims the same `0.1.0`. Real version bumps make "is this build current?" answerable by `cat package.json` instead of by inspecting the resolver internals.

--- a/docs/launch/LAUNCH.md
+++ b/docs/launch/LAUNCH.md
@@ -45,12 +45,20 @@ gh repo edit opencues/opencues --visibility public --accept-visibility-change-co
 GitHub only shows this control on a **public** repo:
 > Repo → **Settings** → **General** → scroll to **Social preview** → **Edit** → upload `opencues-og.jpg` (1200×630, on your desktop).
 
-### 4. Cut the `v0.1.0` GitHub Release
+### 4. Cut the first product release — `v0.3.0`
+This is the first real release; follow [`versioning.md` § How to cut a release](../architecture/versioning.md#releases--tagging). `0.3.0` is the recommended launch number (clean minor above the CLI's current `0.2.57`; adjust if you prefer).
 ```bash
-# Draft notes from CHANGELOG.md, then:
-gh release create v0.1.0 --repo opencues/opencues \
-  --title "OpenCues v0.1.0" --notes-file <notes.md>
+# 1. Set packages/opencues-cli/package.json "version" → 0.3.0
+# 2. In CHANGELOG.md: rename "## [Unreleased]" → "## [0.3.0] - <today>",
+#    add a fresh empty "## [Unreleased]" above it.
+# 3. Commit, tag, push the tag:
+git commit -am "chore(release): v0.3.0"
+git tag v0.3.0 && git push origin v0.3.0
+# 4. Cut the GitHub Release with CURATED notes (highlights, not the raw 800 lines):
+gh release create v0.3.0 --repo opencues/opencues \
+  --title "OpenCues v0.3.0" --notes-file <curated-notes.md>
 ```
+Draft highlights are staged in `.internal/launch-release-notes.md`.
 
 ### 5. README assets → jsDelivr-on-own-repo
 Now that the repo is public, jsDelivr can serve it. Swap the `a1rtight/tester`
@@ -58,9 +66,9 @@ jsDelivr URLs in `README.md` for your **own** repo (keeps CDN speed, drops the
 third-party dependency — see the memory/rationale: relative paths render slower
 on GitHub, so keep jsDelivr, just point it at us):
 ```
-https://cdn.jsdelivr.net/gh/opencues/opencues@v0.1.0/assets/<file>.svg
+https://cdn.jsdelivr.net/gh/opencues/opencues@v0.3.0/assets/<file>.svg
 ```
-(Do this after Step 4 so the `@v0.1.0` tag exists.) Ship as a small README PR.
+(Do this after Step 4 so the `@v0.3.0` tag exists.) Ship as a small README PR.
 
 ### 6. Deploy the full org-profile
 Swap the teaser for the full version (its repo/docs/spec links resolve now):
@@ -75,10 +83,10 @@ gh pr create --repo opencues/.github --base main --head launch/full-profile \
 Full detail + 2FA/security-key gotcha in [`npm-handover.md`](npm-handover.md).
 ```bash
 # In packages/opencues-cli/package.json: remove `"private": true` and the
-# `publishConfig` block. Version 0.2.57 stays (already > placeholder 0.0.1).
+# `publishConfig` block. Version is already 0.3.0 from the Step 4 release cut.
 cd packages/opencues-cli
 npm publish --access public          # logged in as an opencues npm-org member
-# Verify: https://www.npmjs.com/package/opencues shows 0.2.57 as latest
+# Verify: https://www.npmjs.com/package/opencues shows 0.3.0 as latest
 ```
 Then wire the **npm badge** in `README.md` (uncomment the badge line near the top).
 

--- a/docs/launch/LAUNCH.md
+++ b/docs/launch/LAUNCH.md
@@ -1,0 +1,103 @@
+# LAUNCH.md — go-live runbook
+
+Turnkey sequence for taking OpenCues public. Ordered; each **Go-live** step
+assumes the ones above it are done. Internal ops doc — **delete or gitignore
+this file after launch** (see Phase 3).
+
+> **One-way gate:** publishing the repo exposes all history. Rotate secrets
+> **before** flipping (Step 1) — you can flip visibility back to private, but
+> anything the public saw is out. Treat go-public as irreversible for secrets.
+
+Companion: [`npm-handover.md`](npm-handover.md) (the npm publish detail).
+
+---
+
+## Phase 0 — Pre-flight (finish BEFORE the flip)
+
+Everything here can be done while the repo is still private.
+
+- [ ] **Merge [opencues#353](https://github.com/opencues/opencues/pull/353)** — niche-cue removal + Sponsors handle (`FUNDING.yml`) + npm `keywords`. (The Sponsor button needs `FUNDING.yml` on `master`.)
+- [ ] **Merge [opencues#354](https://github.com/opencues/opencues/pull/354)** — npm-handover runbook fix + this file.
+- [ ] **Merge [opencues-web#19](https://github.com/opencues/opencues-web/pull/19)** — website niche-cue cleanup + homepage title SEO. Deploy the site.
+- [ ] **Final brand art** landed — designer swaps the placeholder SVGs under `assets/` (see the `README.md` top comment). Filenames stay; only the art changes.
+- [ ] **Hero + quickstart demo videos** produced and embedded in `README.md` (3 `<!-- VIDEO -->` placeholders).
+- [ ] **Sponsors listing approved** — check `github.com/sponsors/opencues` no longer says *"coming soon"* (submitted; GitHub-side review).
+
+---
+
+## Phase 1 — Go public (the flip, in order)
+
+### 1. Rotate secrets
+Both keys live only in gitignored `.env` files (audited: never committed), so this is precautionary — but do it first.
+```bash
+# Groq:    https://console.groq.com/keys   → revoke old, create new
+# Finnhub: https://finnhub.io/dashboard    → revoke old, create new
+# Update the new values in the gitignored .env files:
+#   ~/.cues/.env  and  integrations/chrome/.env
+```
+
+### 2. Flip repo visibility → public
+```bash
+gh repo edit opencues/opencues --visibility public --accept-visibility-change-consequences
+```
+
+### 3. Upload the social-preview image
+GitHub only shows this control on a **public** repo:
+> Repo → **Settings** → **General** → scroll to **Social preview** → **Edit** → upload `opencues-og.jpg` (1200×630, on your desktop).
+
+### 4. Cut the `v0.1.0` GitHub Release
+```bash
+# Draft notes from CHANGELOG.md, then:
+gh release create v0.1.0 --repo opencues/opencues \
+  --title "OpenCues v0.1.0" --notes-file <notes.md>
+```
+
+### 5. README assets → jsDelivr-on-own-repo
+Now that the repo is public, jsDelivr can serve it. Swap the `a1rtight/tester`
+jsDelivr URLs in `README.md` for your **own** repo (keeps CDN speed, drops the
+third-party dependency — see the memory/rationale: relative paths render slower
+on GitHub, so keep jsDelivr, just point it at us):
+```
+https://cdn.jsdelivr.net/gh/opencues/opencues@v0.1.0/assets/<file>.svg
+```
+(Do this after Step 4 so the `@v0.1.0` tag exists.) Ship as a small README PR.
+
+### 6. Deploy the full org-profile
+Swap the teaser for the full version (its repo/docs/spec links resolve now):
+```bash
+# In opencues/.github:
+gh pr create --repo opencues/.github --base main --head launch/full-profile \
+  --title "Full org profile" && gh pr merge --repo opencues/.github launch/full-profile --squash
+# (branch launch/full-profile is already pushed, unmerged)
+```
+
+### 7. npm handover — publish the real CLI
+Full detail + 2FA/security-key gotcha in [`npm-handover.md`](npm-handover.md).
+```bash
+# In packages/opencues-cli/package.json: remove `"private": true` and the
+# `publishConfig` block. Version 0.2.57 stays (already > placeholder 0.0.1).
+cd packages/opencues-cli
+npm publish --access public          # logged in as an opencues npm-org member
+# Verify: https://www.npmjs.com/package/opencues shows 0.2.57 as latest
+```
+Then wire the **npm badge** in `README.md` (uncomment the badge line near the top).
+
+---
+
+## Phase 2 — Announce (post-live, optional)
+- Show HN (Show HN: …), Product Hunt, r/ClaudeAI, `awesome-*` list PRs, alternativeto.net.
+- Website changelog sync (opencues.com is maintained separately — ping Wilfred).
+
+---
+
+## Phase 3 — Post-launch cleanup
+- [ ] Delete `packages/opencues-park/` (source only — the published `0.0.1` stays on npm as history).
+- [ ] Remove the npm-handover pointer + the "Pre-launch" section from `CLAUDE.md`.
+- [ ] Delete or gitignore **this file** (`docs/launch/LAUNCH.md`).
+
+---
+
+## Caveats / rollback
+- **npm `0.0.1` can never be reused** — don't unpublish the placeholder before the real publish succeeds (24h name lockout).
+- **Sponsors org-write needs TOTP**, not the security key (`wkasekende` has security-key 2FA). See `npm-handover.md` § Caveats.
+- Repo visibility is reversible, but exposed secrets are not — hence Step 1 first.

--- a/docs/launch/npm-handover.md
+++ b/docs/launch/npm-handover.md
@@ -12,8 +12,26 @@ The `opencues` name on npmjs.com is currently held by `packages/opencues-park/` 
 
 1. In `packages/opencues-cli/package.json`:
    - Remove `"private": true`.
-   - Remove the `publishConfig` block (or repoint from GitHub Package Registry to public npm).
-   - Bump `version` to `0.1.0` (or higher — must be > 0.0.1 to supersede the placeholder).
+   - Remove the `publishConfig` block (currently `{ "registry": "https://npm.pkg.github.com", "access": "restricted" }`). With it gone, publish defaults to the public npmjs registry; the bare `opencues` name is unscoped, so it publishes public.
+   - **Version — no bump needed.** The CLI is already at `0.2.57` (well above the placeholder's `0.0.1`), so it becomes `latest` the moment it publishes. The earlier "bump to `0.1.0`" guidance is **stale** — it predated the CLI reaching 0.2.x, and `0.1.0 < 0.2.57` would not be `latest`. Just don't publish a version `≤ 0.0.1`. Optionally set a clean marketing version, but it must be `≥` the current one.
+
+   The net edit (two deletions, nothing else — leave `name`, `version`, `keywords`, `bin`, etc. as-is):
+   ```diff
+   {
+     "name": "opencues",
+     "version": "0.2.57",
+   -  "private": true,
+     "description": "...",
+     "keywords": [ ... ],
+     ...
+   -  "publishConfig": {
+   -    "registry": "https://npm.pkg.github.com",
+   -    "access": "restricted"
+   -  },
+     "dependencies": { "enquirer": "^2.4.1" }
+   }
+   ```
+   > Applied at launch time (not pre-staged) so it doesn't collide with other in-flight `package.json` edits. It's a two-line removal — trivial to make from whatever `master` is at launch.
 2. From `packages/opencues-cli/`:
    ```
    npm publish --access public

--- a/docs/launch/npm-handover.md
+++ b/docs/launch/npm-handover.md
@@ -13,13 +13,13 @@ The `opencues` name on npmjs.com is currently held by `packages/opencues-park/` 
 1. In `packages/opencues-cli/package.json`:
    - Remove `"private": true`.
    - Remove the `publishConfig` block (currently `{ "registry": "https://npm.pkg.github.com", "access": "restricted" }`). With it gone, publish defaults to the public npmjs registry; the bare `opencues` name is unscoped, so it publishes public.
-   - **Version — no bump needed.** The CLI is already at `0.2.57` (well above the placeholder's `0.0.1`), so it becomes `latest` the moment it publishes. The earlier "bump to `0.1.0`" guidance is **stale** — it predated the CLI reaching 0.2.x, and `0.1.0 < 0.2.57` would not be `latest`. Just don't publish a version `≤ 0.0.1`. Optionally set a clean marketing version, but it must be `≥` the current one.
+   - **Version — set by the release cut, not here.** The product version = the CLI version (see [`versioning.md` § Releases & tagging](../architecture/versioning.md#releases--tagging)). The launch release (`LAUNCH.md` Step 4) sets the CLI to **`0.3.0`** and tags `v0.3.0`; this publish just ships whatever the tag says. It must be `> 0.0.1` to supersede the placeholder — `0.3.0` is. (The original "bump to `0.1.0`" line was stale: the CLI passed 0.2.x, and `0.1.0` sits below both the tag and the current version.)
 
    The net edit (two deletions, nothing else — leave `name`, `version`, `keywords`, `bin`, etc. as-is):
    ```diff
    {
      "name": "opencues",
-     "version": "0.2.57",
+     "version": "0.3.0",
    -  "private": true,
      "description": "...",
      "keywords": [ ... ],


### PR DESCRIPTION
The npm-handover runbook said to bump the CLI to `0.1.0` at launch, but the CLI is already at **0.2.57** — `0.1.0 < 0.2.57` would never become npm's `latest`. Corrects the version guidance, names the exact `publishConfig` block to remove, and adds the net `package.json` diff.

Doc-only. The actual `package.json` edit stays un-staged (applied at launch) so it doesn't collide with the keyword/removal edits in flight on #353.

Part of launch prep. Safe to merge anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)