### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-29
+
+First public release. Full highlights in the [GitHub Release](https://github.com/opencues/opencues/releases/tag/v0.3.0).
+
 ### Removed — shipped niche word-cues `legal` / `medical` / `financial`
 
 Deleted the three professional-domain word-cue packs from `defaults/cues/`. Low value for a general audience, and because cues compete for the span via priority eviction they crowd out the genuinely useful cues (contradiction, sentence rewrites). The per-word cue **mechanism** (`RoutedWordSourceGroup`) and its docs are unchanged — only the shipped instances go. Docs, templates, and spec/conformance fixtures repointed to the remaining shipped cues (`spelling`, `more-formal`) or neutral examples. No package behaviour change (tests + comments only); the shipped-content change lands in the next release.

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.2.57",
+  "version": "0.3.0",
   "private": true,
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "keywords": [


### PR DESCRIPTION
First public release cut. Bumps CLI → 0.3.0 (the product version), promotes `[Unreleased]` → `[0.3.0]`. Tag + GitHub Release follow the merge (per versioning.md § Releases & tagging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)