### PR TITLE
chore(readme): hide npm badge until announce

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 
 <br><br><br>
 
-[![npm](https://img.shields.io/npm/v/opencues)](https://npmjs.com/package/opencues)
+<!-- npm badge — hidden until announce; uncomment to show:
+[![npm](https://img.shields.io/npm/v/opencues)](https://npmjs.com/package/opencues) -->
 
 **OpenCues enables native AI integration anywhere you type.** Model agnostic and fully open source. Inline agents and prompting.
 


### PR DESCRIPTION
Per Wilfred — package is live but we're not advertising yet; badge returns at announce (one-line uncomment).