### PR TITLE
docs: website changelog PR is a required release step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ host and the runtime.
 > the repo restructure. See `docs/architecture/repo-structure.md` for the
 > target layout + stage tracker.
 
-## Website sync - ping Wilfred
+## Website sync — REQUIRED at every release, ping Wilfred for the rest
 
 opencues.com (repo: `~/opencues-website`) is maintained separately and distills
 this repo's CHANGELOG.md, feature docs, and FAQ.md into published pages
@@ -49,6 +49,14 @@ release cuts; anything that alters install steps or the public capability
 story. Unpublished-on-site features (see the website repo's CLAUDE.md content
 rules) still apply there. The website repo tracks its last sync date against
 this repo in its own CLAUDE.md.
+
+**Release cuts are not advisory: cutting `vX.Y.Z` REQUIRES the paired
+website changelog PR in the same pass** — it is step 7 of
+[versioning.md § How to cut a release](docs/architecture/versioning.md#releases--tagging)
+(site `changelog.md` entry with the real date + website CLAUDE.md sync line +
+sitemap script). A release without its site PR is an incomplete release;
+whoever cuts the tag opens the PR. There is no CI gate across the two repos —
+this contract IS the gate, which is why it lives here.
 
 ---
 

--- a/docs/architecture/versioning.md
+++ b/docs/architecture/versioning.md
@@ -92,6 +92,17 @@ product is at `0.3` is fine and expected). Don't try to sync them.
 5. `npm publish` the CLI if the CLI changed (first publish: see
    the internal npm-handover runbook).
 6. `gh release create vX.Y.Z --title "OpenCues vX.Y.Z" --notes-file <notes>`.
+7. **Open the paired website changelog PR** (`~/opencues-website`, repo
+   `opencues/opencues-web`) — a release is not DONE until this PR exists.
+   In `md/population/changelog.md`: add a `# vX.Y.Z` entry at the top with
+   the real release date (`# 30th JULY 2026` format — don't leave the
+   `# current date` placeholder on a shipped release) and marketing-distilled
+   sections (`# TITLE / vN-anchor` headers, benefit-first bullets — match the
+   existing entries' voice, not the raw CHANGELOG). Update the website
+   CLAUDE.md "Last synced" line, run
+   `python3 scripts/update-sitemap-lastmod.py`, and note any owed follow-up
+   passes (features page, comparison grid, open-standard page on spec bumps).
+   Post-deploy: `python3 scripts/indexnow-submit.py`.
 
 ### Release notes are curated, not dumped
 


### PR DESCRIPTION
Per Wilfred: the changelog↔website sync becomes part of the release definition, not an advisory ping.

- **versioning.md § How to cut a release** gains **step 7**: open the paired `opencues-web` changelog PR — real release date (never ship the `# current date` placeholder), marketing-distilled entry in the site's voice, site-CLAUDE.md sync line, sitemap script, and the post-deploy IndexNow submit.
- **CLAUDE.md § Website sync** upgraded: *a release without its site PR is an incomplete release; whoever cuts the tag opens the PR.* No cross-repo CI gate exists, so this contract is the gate.

First application of the rule: opencues-web#21 (v0.3.0 date bake + v0.4.0 entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)