### PR TITLE
fix(cc): bridge dispatchKey clobbered the synthetic `_` framing — chained transforms broke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — CC: chained transforms broke — the bridge's synthetic `_` was consumed as a note-cycle (`@opencues/runtime` 0.28.20 → 0.28.21)
+
+Six agentic scenarios (stacked bolds, three-stack, multi-blank, both chains) failed only on Claude Code: after a transform substitute, the next injected `… <instruction> _` never fired. Root cause: the event-bridge's `text:` inject frames its synthetic `_` keystroke as the final keypress of the NEW string (0.28.20's fix), but the CC band's inline bridge `dispatchKey` re-sampled adapter state and clobbered that framing — the stale cursor sat exactly at the filled span's end, inside Cycling's inclusive `_`-note gate, so the `_` cycled the def back to its original instead of arming the blank gate (the resolver then saw old-`_`/new-`_` in its diff and stayed silent). Every other band passes the bridge event through untouched; CC's inline construction had drifted — the same band-drift class as the July secret-guard incident. Fix: honour the caller's `text`/`cursorOffset` when supplied, adapter sampling only as fallback. Pinned by the six agentic scenarios (41/43/45/46/100/101).
+
+
 ### Removed — `packages/opencues-park/` (the npm parking placeholder)
 
 `opencues@0.4.0` (the real CLI) is published to public npm and superseded the placeholder's `0.0.1` as `latest`, so the park package's source is no longer needed (the published 0.0.1 stays on npm as history). README npm badge wired; CLAUDE.md version map updated.

--- a/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
+++ b/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
@@ -823,12 +823,21 @@ export function boot(host: HostInfo): BootResult {
         return out.replace(/\x1b\[[0-9;]*m/g, '');
       },
       // Synthetic keys go through the same handler list real keystrokes
-      // use, but sample text/cursor at dispatch time (the cli.js patch
-      // does the same — InputZone closures are stale across React
-      // re-renders, so the dispatch site is the only fresh source).
+      // use. HONOUR the caller's text/cursorOffset framing when supplied:
+      // the event-bridge's `text:` inject frames its synthetic `_` as the
+      // final keystroke of the injected string (new text minus the `_`,
+      // cursor at its position). Re-sampling adapter state here clobbered
+      // that framing with the PRE-inject buffer — after a transform
+      // substitute the stale cursor sat exactly at the filled span's end,
+      // inside Cycling's inclusive `_`-note gate, so the synthetic `_` was
+      // consumed as a cycle (def reverted to the original) instead of
+      // arming the blank gate. Every OTHER band passes the event through
+      // untouched (emitUntilConsumed(e)); this inline construction had
+      // drifted. Adapter sampling remains the fallback for callers that
+      // don't frame (none today — parseKeyArg samples equivalently).
       dispatchKey: (e) => {
-        const text = adapter.getText();
-        const cursor = adapter.getCursorOffset();
+        const text = e.text !== undefined ? e.text : adapter.getText();
+        const cursor = e.cursorOffset !== undefined ? e.cursorOffset : adapter.getCursorOffset();
         const ev: KeyEvent = {
           key: e.key,
           modifiers: { ...e.modifiers },

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.28.20",
+  "version": "0.28.21",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",


### PR DESCRIPTION
Root-causes the 6 cluster-B agentic failures (stacked bolds ×3, multi-blank, both chains — CC-only, deterministic).

## Mechanism
1. Event-bridge `text:` inject synthesizes a `_` keystroke framed as the final keypress of the new string (the 0.28.20 fix).
2. **CC's inline bridge `dispatchKey` discarded that framing** and re-sampled adapter state → stale cursor sat exactly at the filled transform span's end, inside Cycling's inclusive `_`-note gate.
3. The `_` was consumed as a note-cycle → def reverted to its original text (`cycling.cycled` events in the bridge stream were the smoking gun).
4. The inject's text then landed with a previousText that already ended in `_` → the resolver's explicit-`_` freshness gate saw nothing new → silent no-op (`resolver.completed resultCount=0`, no source ever started).

## Why CC only
OC / gemini / shell / windows all pass the bridge event through untouched (`emitUntilConsumed(e)`); CC's hand-built inline construction had drifted — same band-drift class as the July secret-guard incident (CLAUDE.md drift table).

## Fix
Honour the caller's `text`/`cursorOffset` when supplied; adapter sampling stays as the fallback (bare `key:` injects sample equivalently via `parseKeyArg`).

## Verified
- Agentic scenarios **41/43/45/46/100/101: 6/6 green** post-fix (were 0/6, both harness states), full step counts, no timeouts
- Runtime suite 114/114 files, 2194 pass
- typecheck clean · runtime 0.28.20 → 0.28.21 + CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)