### PR TITLE
feat(install): curl installer + bun-only bootstrap + brew-tap release step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — install channels: `curl | bash` installer, bun-only bootstrap, Homebrew tap (CLI 0.4.0 → 0.4.1)
+
+Three new ways in, matching the site's install bar: **curl** — `install.sh` at the repo root (served as `https://opencues.com/install` via a site redirect): checks Node 22+ and git with actionable errors, runs `npm i -g opencues`, prints next steps; covered by the shell-portability lint (root installers now in its scan). **bun** — `resolvePnpm` gains a `bun x pnpm` rung so `bun add -g opencues` bootstraps on bun-only machines (no node ⇒ no corepack); verified end-to-end in a pristine `oven/bun` container. **brew** — new tap `opencues/homebrew-opencues` (`brew install opencues/opencues/opencues`), formula tracks the npm release tarball; bumping it joins the release steps.
+
+
 ### Fixed — CC: chained transforms broke — the bridge's synthetic `_` was consumed as a note-cycle (`@opencues/runtime` 0.28.20 → 0.28.21)
 
 Six agentic scenarios (stacked bolds, three-stack, multi-blank, both chains) failed only on Claude Code: after a transform substitute, the next injected `… <instruction> _` never fired. Root cause: the event-bridge's `text:` inject frames its synthetic `_` keystroke as the final keypress of the NEW string (0.28.20's fix), but the CC band's inline bridge `dispatchKey` re-sampled adapter state and clobbered that framing — the stale cursor sat exactly at the filled span's end, inside Cycling's inclusive `_`-note gate, so the `_` cycled the def back to its original instead of arming the blank gate (the resolver then saw old-`_`/new-`_` in its diff and stayed silent). Every other band passes the bridge event through untouched; CC's inline construction had drifted — the same band-drift class as the July secret-guard incident. Fix: honour the caller's `text`/`cursorOffset` when supplied, adapter sampling only as fallback. Pinned by the six agentic scenarios (41/43/45/46/100/101).

--- a/docs/architecture/versioning.md
+++ b/docs/architecture/versioning.md
@@ -95,6 +95,11 @@ product is at `0.3` is fine and expected). Don't try to sync them.
    a pristine-container cold install of the published package (fetch pinned
    to the new tag, corepack bootstrap). A publish isn't verified until this
    gate is green.
+   Then **bump the Homebrew tap** (`opencues/homebrew-opencues`,
+   `Formula/opencues.rb`): update `url` to the new registry tarball and
+   `sha256` (`curl -sL <tarball-url> | sha256sum`), commit, push. The brew
+   channel serves whatever the formula pins — skipping this leaves brew
+   users on the previous release.
 6. `gh release create vX.Y.Z --title "OpenCues vX.Y.Z" --notes-file <notes>`.
 7. **Open the paired website changelog PR** (`~/opencues-website`, repo
    `opencues/opencues-web`) — a release is not DONE until this PR exists.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# OpenCues installer — the `curl -fsSL https://opencues.com/install | bash` path.
+#
+# Thin by design: verify the two prerequisites the standalone CLI needs
+# (Node 22+, git), install the published CLI from npm, print next steps.
+# The CLI itself does the heavy lifting on first use (fetches its runtime
+# repo pinned to its own version tag; workspace deps via pnpm/corepack).
+#
+# Portability: bash 3.2 / BSD-safe per CLAUDE.md § Cross-platform shell
+# scripts (no bash-4isms, no GNU-only flags). Linted by
+# scripts/lint-shell-portability.sh.
+set -euo pipefail
+
+say()  { printf '%s\n' "$*"; }
+fail() { printf 'opencues install: %s\n' "$*" >&2; exit 1; }
+
+# ── OS gate ──────────────────────────────────────────────────────────
+case "$(uname -s)" in
+  Darwin|Linux) : ;;
+  *) fail "unsupported OS '$(uname -s)' — native Windows isn't supported; run inside WSL2 (see https://opencues.com/faqs)." ;;
+esac
+
+# ── Prerequisite: Node 22+ ───────────────────────────────────────────
+if ! command -v node >/dev/null 2>&1; then
+  fail "Node.js 22+ is required and wasn't found.
+  macOS:  brew install node
+  Linux:  curl -fsSL https://fnm.vercel.app/install | bash   (then: fnm install --lts)
+Then re-run this installer."
+fi
+NODE_MAJOR=$(node -e 'process.stdout.write(String(process.versions.node.split(".")[0]))' 2>/dev/null || echo 0)
+if [ "$NODE_MAJOR" -lt 22 ]; then
+  fail "Node.js 22+ is required (found $(node --version)). Upgrade node, then re-run."
+fi
+
+# ── Prerequisite: git ────────────────────────────────────────────────
+if ! command -v git >/dev/null 2>&1; then
+  fail "git is required (the CLI fetches its runtime with it) and wasn't found.
+  macOS:  xcode-select --install   (or: brew install git)
+  Linux:  use your package manager (e.g. apt install git)
+Then re-run this installer."
+fi
+
+# ── Install the CLI ──────────────────────────────────────────────────
+say "▸ installing opencues from npm (npm install -g opencues)"
+if npm install -g opencues; then
+  :
+else
+  fail "npm install -g failed. If that was a permissions (EACCES) error, either:
+  - use a version manager (fnm / nvm) so globals land in your home dir, or
+  - set a user prefix:  npm config set prefix ~/.npm-global   (add ~/.npm-global/bin to PATH)
+Then re-run this installer."
+fi
+
+command -v opencues >/dev/null 2>&1 || fail "installed, but 'opencues' isn't on PATH — open a new shell (or add npm's global bin dir to PATH) and run 'opencues' to continue."
+
+say ""
+say "● opencues $(opencues --version 2>/dev/null | head -1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' || echo installed) ready. Next:"
+say ""
+say "    opencues set-key cerebras csk-...    # cerebras.ai — free tier, lowest latency"
+say "    opencues install claude-code         # or: opencode | gemini-cli | chrome | shell"
+say ""
+say "  Docs: https://opencues.com · problems: opencues doctor"

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "keywords": [
     "ai",

--- a/packages/opencues-cli/src/lib/repo-root.cjs
+++ b/packages/opencues-cli/src/lib/repo-root.cjs
@@ -120,12 +120,17 @@ function fetchRepo(version, { log = console.log } = {}) {
 }
 
 // Resolve the pnpm invocation for a machine that may not have pnpm
-// installed: prefer a real `pnpm`, else fall back to corepack (bundled
-// with Node ≥22 — our engines floor). corepack reads the repo's
-// `packageManager` pin, so the version always matches the workspace.
+// installed: prefer a real `pnpm`, else corepack (bundled with Node ≥22 —
+// our engines floor), else `bun x pnpm` (bun-only machines installing via
+// `bun add -g opencues` have bun but neither node's corepack nor pnpm).
+// corepack reads the repo's `packageManager` pin so the version always
+// matches the workspace; bun x resolves pnpm@latest, close enough for a
+// bootstrap install.
 function resolvePnpm({ run = spawnSync } = {}) {
   if (run('pnpm', ['--version'], { stdio: 'ignore' }).status === 0) return ['pnpm'];
   if (run('corepack', ['--version'], { stdio: 'ignore' }).status === 0) return ['corepack', 'pnpm'];
+  // pnpm@9 pinned: pnpm 10 needs node:sqlite, which bun doesn't implement.
+  if (run('bun', ['--version'], { stdio: 'ignore' }).status === 0) return ['bun', 'x', 'pnpm@9'];
   return null;
 }
 
@@ -142,17 +147,24 @@ function bootstrapRepo(root, { log = console.log, run = spawnSync } = {}) {
   const pnpm = resolvePnpm({ run });
   if (!pnpm) {
     throw new Error(
-      'opencues needs pnpm (or corepack, bundled with Node 22+) to set up its\n'
-      + 'runtime repo, and neither was found. Fix with ONE of:\n'
+      'opencues needs pnpm (or corepack, bundled with Node 22+, or bun) to\n'
+      + 'set up its runtime repo, and none was found. Fix with ONE of:\n'
       + '  corepack enable pnpm      # ships with Node — no install needed\n'
-      + '  npm install -g pnpm',
+      + '  npm install -g pnpm\n'
+      + '  bun --version             # bun works too (bun x pnpm)',
     );
   }
   const env = { ...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: '0' };
 
   if (needDeps) {
     log('  ▸ installing workspace dependencies (one-time, ~1 min)');
-    const r = run(pnpm[0], [...pnpm.slice(1), 'install'], { cwd: root, stdio: 'inherit', env });
+    // Bun rung: pnpm@9 lacks pnpm 10's default build-script deny, so it
+    // would run isolated-vm's node-gyp (doomed under bun — no toolchain,
+    // and the binding can't load in bun anyway; the runtime lazy-requires
+    // it and degrades gracefully, INFOSEC F1). --ignore-scripts restores
+    // pnpm-10-equivalent behaviour on this rung.
+    const installArgs = [...pnpm.slice(1), 'install', ...(pnpm[0] === 'bun' ? ['--ignore-scripts'] : [])];
+    const r = run(pnpm[0], installArgs, { cwd: root, stdio: 'inherit', env });
     if (r.status !== 0) throw new Error('workspace dependency install failed — see output above.');
   }
   if (needCore) {

--- a/packages/opencues-cli/src/lib/repo-root.test.cjs
+++ b/packages/opencues-cli/src/lib/repo-root.test.cjs
@@ -212,6 +212,17 @@ describe('bootstrapRepo (stubbed runner — decision logic only)', () => {
     assert.ok(calls.some(c => c.join(' ') === 'corepack pnpm install'));
   });
 
+  it('falls back to `bun x pnpm` when pnpm AND corepack are absent (bun-only machine)', () => {
+    const calls = [];
+    const run = (cmd, args) => {
+      calls.push([cmd, ...args]);
+      return { status: cmd === 'bun' ? 0 : 1 };   // only bun exists
+    };
+    repoRoot.bootstrapRepo(repoWith({ deps: false, dist: false }), { log: () => {}, run });
+    assert.ok(calls.some(c => c.join(' ') === 'bun x pnpm@9 install --ignore-scripts'));
+    assert.ok(calls.some(c => c.join(' ') === 'bun x pnpm@9 run build'));
+  });
+
   it('throws a user-ready message when neither pnpm nor corepack exists', () => {
     const run = () => ({ status: 1 });
     assert.throws(

--- a/scripts/lint-shell-portability.sh
+++ b/scripts/lint-shell-portability.sh
@@ -28,6 +28,13 @@ SCRIPTS=$(find defaults integrations -name '*.sh' \
   -not -path '*/tweakcc/*' \
   -not -path '*/dist/*' \
   | sort)
+# Root-level user-facing installers (curl | bash targets) are the MOST
+# portability-critical scripts in the repo — they run on machines we know
+# nothing about. Explicit list (find at depth 1 would sweep worktrees).
+for root_sh in install.sh; do
+  [ -f "$root_sh" ] && SCRIPTS="$SCRIPTS
+$root_sh"
+done
 
 for f in $SCRIPTS; do
   COUNT=$((COUNT + 1))


### PR DESCRIPTION
Makes every tab of the site's install bar real (paired website PR follows; tap already live at [opencues/homebrew-opencues](https://github.com/opencues/homebrew-opencues)).

| Channel | What this PR adds | Verified |
|---|---|---|
| **curl** | `install.sh` at repo root — the `curl -fsSL https://opencues.com/install \| bash` target (site redirects to raw master). Node 22+/git preflight with actionable errors → `npm i -g opencues` → next steps. Now covered by the shell-portability lint. | pristine `node:22`, piped via stdin exactly like curl\|bash — full run green |
| **bun** | `resolvePnpm` bun rung: `bun x pnpm@9 --ignore-scripts`. Two bun realities: pnpm 10 requires `node:sqlite` (bun lacks it) → pin pnpm@9; pnpm 9 lacks pnpm 10's default build-script deny → `--ignore-scripts` skips isolated-vm's doomed gyp (the binding can't load under bun regardless; runtime lazy-requires + degrades per INFOSEC F1). | pristine `oven/bun` (no node/pnpm/corepack): install → fetch → bootstrap → `validate` |
| **brew** | Release-runbook step: bump the tap formula (url + sha256) after each `npm publish`. Formula pins the npm registry tarball. | tap live; final `brew install opencues/opencues/opencues` validation on macOS (Wilfred) |
| npm | (already live — 0.4.0) | fresh-machine gate |

CLI 0.4.0 → **0.4.1** (unpublished until the next release cut — the guard's tag contract enforces order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)