### PR TITLE
docs(cli): launch-ready user-facing npm README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — user-facing npm README (`opencues` 0.4.1 → 0.4.2)
+
+Replaced the CLI package's internal contributor README (the one npmjs.com/package/opencues renders) with a launch-ready, user-facing one: the "you type / you get" hook table, a real quickstart (`npm i -g opencues` → `set-key` → `install` → `run`), the 5 integrations, the feature + provider summary, a security one-liner, and links. Fixes the stale "Coming (Tier 2/3)" tables that listed dozens of already-shipped commands (`run`, `doctor`, `import`, `init`, `validate`, …) as unbuilt, and drops the internal "Stage 8 / thin dispatcher / architecture tree" language. All doc links are absolute GitHub URLs (npm resolves relative links against `repository.directory`, which is the CLI subpath, so relative links would 404). Requires a republish to take effect on npm.
+
 ## [0.4.1] - 2026-07-30
 
 Patch release: chained-transform fix + the install channels (curl / bun / brew). Highlights in the [GitHub Release](https://github.com/opencues/opencues/releases/tag/v0.4.1).

--- a/packages/opencues-cli/README.md
+++ b/packages/opencues-cli/README.md
@@ -1,53 +1,92 @@
-# opencues — front-door CLI
+# OpenCues
 
-Single command for installing, configuring, and inspecting OpenCues across all editor integrations. Today: a thin dispatcher over each `integrations/<host>/bin/install.cjs` plus the cross-cutting bits (`seed-configs`, `which`, `version`).
+**Native AI integration anywhere you type.** Model-agnostic, fully open source, inline agents and prompting.
 
-## Today (from a clone)
+Rather than switching to a chat window, write your query in plain text and end it with `_`. An LLM discovers it and answers **inline, right where you wrote it** — across your terminal AI CLIs, your shell, and the browser.
 
-```bash
-node packages/opencues-cli/bin/cli.cjs <command>
-# or, after pnpm install at the workspace root:
-pnpm exec opencues <command>
-```
+`opencues` is the front-door CLI: one command to install, configure, and run OpenCues across every editor integration.
 
-## Post-publish (Stage 8)
+## What it does
 
-```bash
-npx opencues <command>          # one-off
-npm i -g opencues               # global install
-```
-
-## Commands (Tier 1, shipped)
-
-| Command | What |
+| You type | You get |
 |---|---|
-| `opencues install <host>` | Install. `<host>` = `cc`, `oc`, `chrome`, or `--all`. All flags pass through to the per-host installer. |
-| `opencues uninstall <host>` | Roll back. Same shape as install. |
-| `opencues seed-configs` | Copy `<repo>/.cues/` defaults into `~/.cues/`. `--project` writes to `<cwd>/.cues/` instead. |
-| `opencues which` | Show every relevant path (configs, installs, runtime IPC) with ✓/- markers for what exists. |
-| `opencues version` | CLI version + per-integration version + declared host compatibility ranges. |
-| `opencues help [<command>]` | Discoverable help. |
+| `hey can u send me that report when u get a sec make this formal _` | Could you please send me that report at your earliest convenience? |
+| `4 + 4 = _` | `4 + 4 = 8` |
+| `hello world translate to japanese _` | こんにちは世界 |
+| `draft an email to my landlord asking for a rent reduction _` | *(the email, written)* |
+| `ffmpeg command to convert a video to web-ready mp4 _` | `ffmpeg -i input.mov -c:v libx264 -preset slow -crf 23 -c:a aac -b:a 128k -movflags +faststart output.mp4` |
 
-## Coming (Tier 2)
+## Quickstart
 
-`import` (download cue packs from URL/gist/github), `init` (scaffold `<cwd>/.cues/`), `new <kind> <name>` (scaffold a single cue/blank), `validate` (lint configs), `run <host>` (orchestrate launch).
+Requires **Node 22+** and **git**.
 
-## Coming (Tier 3+)
-
-`doctor`, `edit`, `logs`, `list`, `show`, `set-key`, `update`, `debug`, `search`, `publish`, `benchmark`, `completion`, `self-update`.
-
-## Architecture
-
-```
-packages/opencues-cli/
-├── bin/cli.cjs               dispatcher; lazy-loads command modules
-└── src/commands/
-    ├── install.cjs           shells out to integrations/<host>/bin/install.cjs
-    ├── uninstall.cjs         same; uninstall action
-    ├── seed-configs.cjs      cross-cutting; reads <repo>/.cues/, writes ~/.cues/
-    ├── which.cjs             pure inspection
-    ├── version.cjs           pure inspection
-    └── help.cjs              top-level + per-command
+```bash
+npm install -g opencues
+opencues set-key cerebras csk-...     # cerebras.ai — free tier, lowest latency
+opencues install claude-code          # or: opencode | gemini-cli | chrome | shell
+opencues run claude-code              # launch — your native install is untouched
 ```
 
-Per-integration installers stay valid as direct entry points (`pnpm --filter @opencues/claude-code dev-install ...`). The CLI is the discoverable umbrella; both layers are first-class.
+`opencues doctor` diagnoses anything that looks off. Full walkthrough and prerequisites: **[install guide](https://github.com/opencues/opencues/blob/master/docs/install.md)**.
+
+> **Windows** is not supported natively — run inside WSL2.
+
+## Integrations
+
+| Host | Status | Install |
+|---|---|---|
+| Claude Code | Available | `opencues install claude-code` |
+| OpenCode | Available | `opencues install opencode` |
+| Gemini CLI | Beta | `opencues install gemini-cli` |
+| Chrome | Beta | `opencues install chrome` |
+| Shell | Beta | `opencues install shell` |
+
+Each integration pins its own upstream fork and never touches your native host install.
+
+## What you get
+
+| Feature | What it does |
+|---|---|
+| **Blanks** | Type `_` for free-form generation, translation, formatting, full rewrites, or keyword actions (`volume _`, `weather _`). |
+| **Sentence rewrites** | Cycle a whole sentence to a different register (formal, concise, …) — no `_` needed. |
+| **Word cues** | Navigate to a word and cycle a smaller LLM-suggested alternative. |
+| **Personal + ambient context** *(opt-in)* | `my email _` substitutes your real address; fluid lookups can read the page you're on. |
+| **Hot-reload** | Every `.md` config picks up edits in ~2s — no restart. |
+
+Full feature catalogue: **[docs/features](https://github.com/opencues/opencues/blob/master/docs/features/README.md)**.
+
+## Providers
+
+Seven providers supported — **Cerebras, Groq, Gemini, Anthropic, OpenAI**, and more. Set an environment key or run `opencues set-key <provider> <key>` and you're done. Switch provider and model per feature; auto-failover is built in. See **[LLM providers](https://github.com/opencues/opencues/blob/master/docs/guides/llm-providers.md)**.
+
+## CLI commands
+
+```
+opencues install <host>       install an integration (claude-code, opencode, gemini-cli, chrome, shell)
+opencues uninstall <host>     roll it back
+opencues run <host>           launch a patched host
+opencues set-key <p> <key>    store a provider key
+opencues seed-configs         copy default cues into ~/.cues/
+opencues doctor               diagnose install / config issues
+opencues which                show every relevant path
+opencues review <pack>        vet an untrusted cue/blank pack before trusting it
+opencues version              versions + host compatibility
+opencues help [command]       discoverable help
+```
+
+Also shipped: `models`, `identity`, `calendar`, `sync`, `import`, `init`, `new`, `validate`, `list`, `show`, `edit`, `logs`, `update`, `config`, `completion`.
+
+## Security
+
+OpenCues has **no tool handlers and no exec layer** for LLM output — no MCP-tool execution, no agentic actions, no side-effect channel. Worst case, a response lands as user-visible text in the buffer you review before submitting. Third-party blank JS runs in a real V8 isolate (`isolated-vm`) with capability gates and resource quotas, and output is sanitized before it reaches your buffer. Vet a pack before trusting it with `opencues review ./pack/`. Full threat model: **[security audit](https://github.com/opencues/opencues/blob/master/docs/architecture/security-audit.md)**.
+
+## Links
+
+- **GitHub** — https://github.com/opencues/opencues
+- **Open standard (the spec)** — https://github.com/opencues/opencues/blob/master/spec/README.md
+- **Docs** — https://github.com/opencues/opencues/tree/master/docs
+- **Community** — [r/OpenCues](https://www.reddit.com/r/OpenCues/) · [@openCues_](https://x.com/openCues_)
+
+## License
+
+[Apache-2.0](https://github.com/opencues/opencues/blob/master/LICENSE)

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## What

Replaces the CLI package's README (the one rendered on **npmjs.com/package/opencues**) with a launch-ready, user-facing version.

The published page currently shows the **internal contributor doc** — "front-door CLI / thin dispatcher / Stage 8", an architecture file tree, and **"Coming (Tier 2/3)"** tables that list dozens of *already-shipped* commands (`run`, `doctor`, `import`, `init`, `validate`, `edit`, `logs`, `list`, `show`, `set-key`, `update`, …) as unbuilt. It makes a mature tool look like a stub right on the launch page.

## The new README has

- The **you type / you get** hook table
- A real **quickstart** (`npm i -g opencues` → `set-key` → `install` → `run`)
- The **5 integrations** (Claude Code, OpenCode, Gemini CLI, Chrome, Shell)
- Feature + provider summaries, a security one-liner, and links
- **Absolute** GitHub doc URLs — npm resolves relative links against `repository.directory` (the CLI subpath), so relative links would 404

## Publish

Bumps `opencues` 0.4.1 → 0.4.2. The README ships in the tarball and npm renders it from the **latest published version**, so this only takes effect on **`npm publish`** (not done here — that's yours to run).

## ⚠️ Out of scope but still a launch blocker

The shipped `packages/opencues-cli/LICENSE` is the old **proprietary "All Rights Reserved"** file and `package.json` has **no `license` field** — contradicting the Apache-2.0 repo root + the "fully open source" description/keywords. That license reconciliation is a **separate follow-up**, deliberately not bundled into this README PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)