### PR TITLE
feat(cues): auto-imply calendar-conflict cue; scope more-formal off the CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — calendar-conflict cue is now auto-implied by `calendar-context-mode` (core 0.41.0 → 0.41.1, runtime 0.28.21 → 0.28.22)
+
+The shipped calendar-conflict cue (`defaults/cues/calendar/CUE.md`, `scope: sentence`, `uses-calendar-context: true`) flags a sentence that proposes a day/time you're already booked ("let's meet October 1st" when Oct 1 is busy → appends a terse `— heads up: <event> …`). It was gated behind `sentence-cues-mode`, a *separately named* toggle from the `calendar-context-mode` a user actually turns on to get calendar reasoning — so enabling calendar context did nothing until you also discovered the second switch. It didn't fire even for the author. Now a `uses-calendar-context` sentence cue is **auto-implied by `calendar-context-mode: on`**: `buildSourcesFromConfig` gains an `enableCalendarContext` option (wired from the resolver, same polarity as the resolve-time calendar snapshot), and a calendar-aware sentence cue bypasses the `sentence-cues-mode` gate. The source still self-inerts when there's no calendar feed, so this is a no-op until you add one (`opencues calendar add`). Every *other* sentence-scope cue stays behind `sentence-cues-mode`. Verified against a real feed on `cerebras/gpt-oss-120b` and `cerebras/gemma-4-31b` (flags all conflicting events, hydrates real titles locally, cedes on free days + non-scheduling prose). Pinned by 4 new gating cases in `build-sources.test.ts`.
+
+### Changed — `more-formal` sentence cue scoped off the coding/agent CLIs
+
+The shipped `more-formal` cue (`scope: sentence` — background "make this more formal" rewrites) now declares `not-on-host: claude-code, gemini-cli, opencode`. Those hosts are for terse instructions to a model, not prose you'd want formalized, so a background formality rewrite there is noise. The cue keeps running on the prose-first surfaces (chrome text fields, the shell editor). Discover-time host filter (`inferHostCompat`) drops it on the three CLI hosts; the calendar-conflict cue is unaffected.
+
 ## [0.4.2] - 2026-08-02
 
 Patch release: launch-readiness for the published `opencues` CLI — a user-facing npm README, Apache-2.0 reconciled across every package, and a time-bomb test fix. Highlights in the [GitHub Release](https://github.com/opencues/opencues/releases/tag/v0.4.2).

--- a/defaults/cues/more-formal/CUE.md
+++ b/defaults/cues/more-formal/CUE.md
@@ -8,6 +8,12 @@ description: Sentence-scope cue — rewrites each sentence to be more formal
 # "make it more formal" is nonsensical. Runs everywhere else (multi-line
 # editors, comment boxes) unchanged. See on-field / not-on-field in the spec.
 not-on-field: single-line
+# Host scoping — the coding/agent CLIs (Claude Code, Gemini CLI, OpenCode) are
+# for terse instructions to a model, not prose you'd want formalized; a
+# background "make this more formal" rewrite is noise there. Keep this cue on
+# the prose-first surfaces (chrome text fields, the shell editor) and off the
+# CLI hosts. The calendar-conflict cue (a different CUE.md) is unaffected.
+not-on-host: claude-code, gemini-cli, opencode
 ---
 
 Rewrite each sentence in the buffer to be MORE FORMAL. Preserve

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/build-sources.test.ts
+++ b/packages/opencues-core/src/sources/build-sources.test.ts
@@ -553,3 +553,64 @@ describe('buildSourcesFromConfig — contradiction-cues engine selection (TDZ or
     assert.equal(cx(sources), undefined);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sentence-cue gating: general sentence-cues-mode vs calendar auto-imply
+// ---------------------------------------------------------------------------
+
+describe('buildSourcesFromConfig — sentence-cue gating + calendar auto-imply', () => {
+  const sentenceCue = (sources: ReturnType<typeof buildSourcesFromConfig>) =>
+    sources.filter((s) => s.id.startsWith('sentence-cue:'));
+
+  // A calendar-aware sentence cue (uses-calendar-context) and a plain prose
+  // sentence cue, both in one CUES.md. The calendar one should be auto-implied
+  // by enableCalendarContext; the plain one stays behind enableSentenceCues.
+  const cuesConfig: CuesMdConfig = mkConfig({
+    sources: {
+      calendar: {
+        name: 'calendar', scope: 'sentence', priority: 90,
+        usesCalendarContext: true, promptText: 'calendar-conflict checker',
+      },
+      formalize: {
+        name: 'formalize', scope: 'sentence', priority: 85,
+        promptText: 'make it more formal',
+      },
+    },
+  });
+
+  it('both off → no sentence cues build', () => {
+    const sources = buildSourcesFromConfig(cuesConfig, undefined, {
+      ...defaultOptions, supportsCycling: true,
+      enableSentenceCues: false, enableCalendarContext: false,
+    });
+    assert.deepEqual(sentenceCue(sources).map((s) => s.id), []);
+  });
+
+  it('calendar-context on + sentence-cues off → ONLY the calendar cue is auto-implied', () => {
+    const sources = buildSourcesFromConfig(cuesConfig, undefined, {
+      ...defaultOptions, supportsCycling: true,
+      enableSentenceCues: false, enableCalendarContext: true,
+    });
+    // The uses-calendar-context cue builds; the plain prose sentence cue does NOT.
+    assert.deepEqual(sentenceCue(sources).map((s) => s.id), ['sentence-cue:calendar']);
+  });
+
+  it('sentence-cues on → every sentence cue builds regardless of calendar-context', () => {
+    const sources = buildSourcesFromConfig(cuesConfig, undefined, {
+      ...defaultOptions, supportsCycling: true,
+      enableSentenceCues: true, enableCalendarContext: false,
+    });
+    assert.deepEqual(
+      sentenceCue(sources).map((s) => s.id).sort(),
+      ['sentence-cue:calendar', 'sentence-cue:formalize'],
+    );
+  });
+
+  it('a host with no cycling surface prunes even the auto-implied calendar cue', () => {
+    const sources = buildSourcesFromConfig(cuesConfig, undefined, {
+      ...defaultOptions, supportsCycling: false,
+      enableSentenceCues: false, enableCalendarContext: true,
+    });
+    assert.deepEqual(sentenceCue(sources).map((s) => s.id), []);
+  });
+});

--- a/packages/opencues-core/src/sources/build-sources.ts
+++ b/packages/opencues-core/src/sources/build-sources.ts
@@ -202,6 +202,17 @@ export interface BuildSourcesOptions {
    * shape — global kill-switch on top of per-cue declaration.
    */
   enableSentenceCues?: boolean;
+  /**
+   * Enable the calendar-context catalog (`calendar-context-mode: on`). Set
+   * independently of `enableSentenceCues` so the shipped calendar-conflict cue
+   * (`uses-calendar-context: true`, `scope: sentence`) is AUTO-IMPLIED by
+   * turning calendar context on — a user who enables calendar reasoning
+   * shouldn't also have to discover the separately-named `sentence-cues-mode`
+   * toggle to get conflict warnings. The source still self-inerts when no
+   * calendar feed is present, so this only surfaces cues when there's data.
+   * Other (non-calendar) sentence cues stay behind `enableSentenceCues`.
+   */
+  enableCalendarContext?: boolean;
   /** Enable the deterministic contradiction-cue layer (Tier 0: weekday-date
    *  mismatch, split-the-bill math — buffer + clock only, no LLM/network).
    *  Defaults to false; flip on via OPENCUES.md `contradiction-cues-mode: on`. */
@@ -586,7 +597,16 @@ export function buildSourcesFromConfig(
       // word-cues so an overlapping word-cue gets suppressed in the
       // resolver (design decision: sentence wins outright).
       if (scope === 'sentence') {
-        if (!options.enableSentenceCues) continue;
+        // The calendar-conflict cue (uses-calendar-context) is auto-implied by
+        // calendar-context-mode — it fires even when the general
+        // sentence-cues-mode toggle is off, because a user who turned on
+        // calendar reasoning expects conflict warnings without hunting for a
+        // second, differently-named toggle. It self-inerts with no feed
+        // (supports() returns false when calendarContext is empty), so no LLM
+        // call fires unless there's real calendar data. Every OTHER
+        // sentence-scope cue stays gated behind sentence-cues-mode.
+        const calendarImplied = srcCfg.usesCalendarContext && options.enableCalendarContext;
+        if (!options.enableSentenceCues && !calendarImplied) continue;
         if (!supportsCycling) {
           options.log?.(`buildSources: skipping sentence-cue '${srcCfg.name}' — host has no cycling surface`);
           continue;

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.28.21",
+  "version": "0.28.22",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/resolver.ts
+++ b/packages/opencues-runtime/src/modules/resolver.ts
@@ -833,6 +833,12 @@ export class Resolver {
       // installs whose OPENCUES.md pre-dates the scalar (no line at all).
       enableUndoActions: settings.get('undo-mode') !== 'off',
       enableSentenceCues: settings.get('sentence-cues-mode') === 'on',
+      // Auto-imply the calendar-conflict sentence-cue from calendar-context-mode
+      // (same polarity as the resolve-time calendarContext gate below): turning
+      // on calendar reasoning surfaces conflict warnings without also flipping
+      // the separately-named sentence-cues-mode. The cue self-inerts with no
+      // feed, so this is a no-op until the user adds a calendar.
+      enableCalendarContext: this.configLoader.opencuesState.calendarContextMode !== 'off',
       enableContradictionCues: settings.get('contradiction-cues-mode') === 'on',
       worldDataFetch: this.options.worldDataFetch,
       weatherLocation: settings.get('weather-location'),


### PR DESCRIPTION
Two shipped-cue fixes surfaced while testing calendar conflicts.

## 1. Calendar-conflict cue is now auto-implied by `calendar-context-mode`

The shipped calendar-conflict cue (`defaults/cues/calendar/CUE.md` — `scope: sentence`, `uses-calendar-context: true`) flags a sentence that proposes a day/time you're already booked:

> `let's meet October 1st` → `let's meet October 1st — heads up: The Founding: Castle Growathon Thu Oct 1, all day; Cafe Compute Meetup: London Thu Oct 1, 7:00–9:00pm`

**The bug:** it was gated behind `sentence-cues-mode` — a *separately named* toggle from the `calendar-context-mode` a user actually turns on to get calendar reasoning. Enabling calendar context did nothing until you also discovered the second switch. It didn't fire even for the author.

**The fix:** `buildSourcesFromConfig` gains an `enableCalendarContext` option (wired from the resolver, same polarity as the resolve-time calendar snapshot). A `uses-calendar-context` sentence cue is **auto-implied** by `calendar-context-mode: on` and bypasses the `sentence-cues-mode` gate. It still self-inerts when there's no calendar feed, so it's a no-op until `opencues calendar add`. Every *other* sentence-scope cue stays behind `sentence-cues-mode`.

## 2. `more-formal` scoped off the coding/agent CLIs

`defaults/cues/more-formal/CUE.md` now declares `not-on-host: claude-code, gemini-cli, opencode`. Those hosts are for terse instructions to a model, not prose you'd want formalized — a background "make this more formal" rewrite there is noise. The cue keeps running on the prose-first surfaces (chrome text fields, shell editor). Discover-time host filter (`inferHostCompat`) drops it; the calendar cue is unaffected.

## Validation
- 4 new gating cases in `build-sources.test.ts` (both-off → none; calendar-on+sentence-off → **only** the calendar cue; sentence-on → all; no-cycling host → none). 44/44 in the file.
- End-to-end against a real feed on `cerebras/gpt-oss-120b` **and** `cerebras/gemma-4-31b`: flags every conflicting event, hydrates real titles locally, cedes on free days + non-scheduling prose.
- Host scoping verified through the real discover path: `more-formal` dropped on the 3 CLIs, present on chrome/shell.

core 0.41.0 → 0.41.1, runtime 0.28.21 → 0.28.22. Not a `SPEC_VERSION` change (`not-on-host` is existing spec; auto-imply is a runtime knob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)