### PR TITLE
docs(spec): a spec bump has to update the website's open-standard page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -760,6 +760,16 @@ The open-standard version (`packages/opencues-core/src/spec-version.ts`'s `SPEC_
 7. **Conformance fixtures (`spec/conformance/`)** — per `spec/conformance/README.md`, the suite forks when a new spec version cuts. Adding fixtures for the new surface (e.g. `spec/conformance/valid/identity/`) goes here. If the new surface ships without fixtures, add a TODO row to `spec/conformance/README.md` explicitly calling out the coverage gap.
 8. **JSON schemas (`spec/schemas/`)** — update any schema affected by the new frontmatter keys or scalars. JSON-schema-driven validators are the first thing a third-party tooling integrator will reach for; stale schemas silently flag valid frontmatter as unknown.
 9. Update package versions per the usual per-package rules (`@opencues/core` always bumps when SPEC_VERSION bumps; downstream packages bump per `docs/architecture/versioning.md`).
+10. **The website's open-standard page** (`~/opencues-website`,
+    `md/population/open-standard.md`) — the ONE public description of the
+    standard. Change the version strings **and document the new surface**;
+    a version string on its own is what makes the page look current while it
+    describes an older standard. This drifted twice: the page sat at `0.10`
+    through the `0.11` cut, and the `0.10` pass before it moved only the string,
+    so `on-site:` / `on-field:` (the entire content of that bump) went
+    undocumented for two versions. It is also a box in
+    [versioning.md § How to cut a release](docs/architecture/versioning.md#how-to-cut-a-release),
+    because a spec bump usually rides out on one.
 
 The `version-bump-gate` lint enforces `package.json` version bumps when `src/` changes; it does NOT enforce SPEC_VERSION bumps when only `spec/` changes. Reviewers MUST eyeball spec-only PRs for the bump checklist above — there's no current static gate. (Candidate for a future `lint-spec-bump.sh`.)
 

--- a/docs/architecture/versioning.md
+++ b/docs/architecture/versioning.md
@@ -176,6 +176,12 @@ written: the site often carries a PROVISIONAL entry for the unreleased wave.
 - [ ] New capability → a features-page block and usually an FAQ page (that has
       its own checklist in the website CLAUDE.md: hub fold, FAQPage +
       BreadcrumbList JSON-LD, meta description, canonical, sitemap entry).
+- [ ] **`SPEC_VERSION` moved since the last release?** Then
+      `md/population/open-standard.md` needs BOTH its version strings and the
+      **new surface described**. A version bump with no prose is how that page
+      spent two spec versions claiming to be current while documenting a
+      one-axis scoping model. Check it against `spec/CHANGELOG.md`, not against
+      the number.
 - [ ] `python3 scripts/update-sitemap-lastmod.py`.
 - [ ] Update the website CLAUDE.md "Last synced" line, naming what is still owed.
 - [ ] Branch + PR + merge. **Merging is what deploys the site.**


### PR DESCRIPTION
The site's open-standard page is the only public description of the standard, and nothing in either checklist pointed at it. It drifted twice:

- it sat at `0.10` while `SPEC_VERSION` was `0.11` (since 30 July)
- the pass that claimed to bring it to 0.10 moved only the **version string**, so `on-site:` and `on-field:` — the entire content of that bump — were never documented

So the page has been describing a one-axis scoping model for two spec versions while looking current.

## Changes

- **CLAUDE.md § The bump checklist** gains step 10: the website's open-standard page, with the reason a string-only edit is worse than no edit
- **versioning.md § How to cut a release** gains a box in the website step, since a spec bump usually rides out on a release

Both say the same thing: change the strings **and** describe the new surface, and check it against `spec/CHANGELOG.md` rather than against the number.

Paired site fix: opencues-web#27, which brings the page to 0.11 and adds the two missing bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1xJUCEr5brdgQtmc75kAM