### PR TITLE
feat(release): check-release-alignment.cjs — surface drift, found deterministically

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,13 @@ this repo in its own CLAUDE.md.
 
 ### A release ships FIVE surfaces, not one
 
+**`node scripts/check-release-alignment.cjs` answers "is anything out of step?"
+deterministically** — it diffs every pair of files that must agree across the
+five surfaces and names the fix for each disagreement. Run it before a release
+to see what the last one left behind, and again at the end as the exit gate.
+The judgement calls (is the prose any good, does the page describe the new
+surface) stay human; everything else is a comparison, so it is a script.
+
 Work the checklist in
 [versioning.md § How to cut a release](docs/architecture/versioning.md#how-to-cut-a-release)
 top to bottom. It is a real checklist with boxes, and every box exists because
@@ -691,17 +698,17 @@ done
 |---|---|---|---|
 | `SPEC.md` (open-standard) | `cues-spec` | 0.11 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
-| `packages/opencues-core/` | `@opencues/core` | 0.41.0 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.28.20 | private |
-| `packages/opencues-cli/` | `opencues` (real CLI) | 0.4.0 | **PUBLISHED on npm** |
-| `integrations/claude-code/` | `@opencues/claude-code` | 0.2.10 | private |
-| `integrations/opencode/` | `@opencues/opencode` | 0.2.14 | private |
-| `integrations/chrome/` | `@opencues/chrome` | 0.2.152 | private |
-| `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.2.10 | private |
+| `packages/opencues-core/` | `@opencues/core` | 0.43.0 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.30.2 | private |
+| `packages/opencues-cli/` | `opencues` (real CLI) | 0.6.0 | **PUBLISHED on npm** |
+| `integrations/claude-code/` | `@opencues/claude-code` | 0.2.11 | private |
+| `integrations/opencode/` | `@opencues/opencode` | 0.2.15 | private |
+| `integrations/chrome/` | `@opencues/chrome` | 0.2.165 | private |
+| `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.2.11 | private |
 | `integrations/shell/` | `@opencues/shell` | 0.2.21 | private |
 | `integrations/windows/` | `@opencues/windows` | 0.2.4 | private |
 
-The bare `opencues` name on npm is the real CLI (`packages/opencues-cli/`, **published** — v0.4.0 superseded the retired parking placeholder's v0.0.1; the old `packages/opencues-park/` source was deleted post-publish, July 2026). The npm org grants access via the `developers` team.
+The bare `opencues` name on npm is the real CLI (`packages/opencues-cli/`, **published** — v0.6.0 superseded the retired parking placeholder's v0.0.1; the old `packages/opencues-park/` source was deleted post-publish, July 2026). The npm org grants access via the `developers` team.
 
 The `@opencues/*` library packages remain `private: true`. Flipping one to publishable requires removing `"private": true` AND repointing (or removing) its `publishConfig` block (most currently target `npm.pkg.github.com`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,11 @@ this repo in its own CLAUDE.md.
 ### A release ships FIVE surfaces, not one
 
 **`node scripts/check-release-alignment.cjs` answers "is anything out of step?"
-deterministically** — it diffs every pair of files that must agree across the
-five surfaces and names the fix for each disagreement. Run it before a release
+deterministically** — it diffs every pair of files that must agree and names
+the fix for each disagreement: the five release surfaces, plus the open
+standard (every spec doc's banner against `SPEC_VERSION` and
+`spec/CHANGELOG.md`) and the module numbers (chrome's `manifest.json` against
+its `package.json`, and the version map below against every `package.json`). Run it before a release
 to see what the last one left behind, and again at the end as the exit gate.
 The judgement calls (is the prose any good, does the page describe the new
 surface) stay human; everything else is a comparison, so it is a script.

--- a/docs/architecture/versioning.md
+++ b/docs/architecture/versioning.md
@@ -91,6 +91,14 @@ had been stale since the release before. Work the checklist top to bottom.
 
 **Before you start**
 
+- [ ] `node scripts/check-release-alignment.cjs` — the deterministic half of
+      this checklist. It compares every pair of files that must agree (CLI
+      version ↔ CHANGELOG ↔ tag ↔ npm ↔ GitHub release ↔ Homebrew ↔ the site's
+      changelog, open-standard page and `llms.txt`) and names the fix for each
+      disagreement. Run it before you start to see what the LAST release left
+      behind, and again at the end as the exit gate. `--offline` skips the
+      network checks; `--deep` also verifies the Homebrew sha256 against the
+      published tarball.
 - [ ] `npm whoami` returns your user. A 401 here is the publish failing later
       for a reason that has nothing to do with the release.
 - [ ] `docker ps` works, or accept that step 6's verification gate will be
@@ -197,6 +205,9 @@ written: the site often carries a PROVISIONAL entry for the unreleased wave.
 
 **10. Close the loop**
 
+- [ ] `node scripts/check-release-alignment.cjs` again — every line green. This
+      is the exit gate: if a surface still disagrees, the release is not done,
+      whatever the checklist says.
 - [ ] `opencues install <host>` on your own machines, or they keep running the
       pre-release bundle. `opencues doctor` names every stale one.
 

--- a/scripts/check-release-alignment.cjs
+++ b/scripts/check-release-alignment.cjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// check-release-alignment.cjs — is every surface telling the same story?
+//
+// WHY THIS EXISTS
+//
+// A release ships five surfaces: npm, the git tag, the GitHub release, the
+// Homebrew tap and opencues.com. They are five separate repos, registries and
+// deploys, and nothing but a human reading a checklist kept them in step. The
+// v0.6.0 cut (Aug 2026) lost one to each gap:
+//
+//   - the tag went on BEFORE the release commit merged, so the tagged tree
+//     still said `## [Unreleased]` — and that tree is what every user's
+//     `~/.opencues/repo` clones, since the published CLI pins its checkout to
+//     its own version tag
+//   - the Homebrew formula was two releases behind, and its `assert_match`
+//     had been stale even longer, so the formula test was passing against a
+//     version the formula never shipped
+//   - the site was announcing four unreleased features under a provisional
+//     heading whose `# current date` renders as today
+//   - the open-standard page sat at spec 0.10 through the 0.11 cut, and the
+//     pass before it had moved only the version STRING, leaving the actual
+//     0.10 surface (`on-site:` / `on-field:`) undocumented for two versions
+//   - `llms.txt` was a 0-byte file at a live URL while the checklist called it
+//     the curated index
+//
+// Every one of those is a comparison between two files. None needed judgement.
+// So they belong in a script, not in a checklist someone reads at 2am.
+//
+// WHAT IT IS NOT
+//
+// It does not judge whether the site's PROSE is a good description of the
+// release — that stays human. It only asserts that two places which must agree
+// on a fact do agree on it.
+//
+// USAGE
+//
+//   node scripts/check-release-alignment.cjs            # local files + network
+//   node scripts/check-release-alignment.cjs --offline  # skip npm / gh / brew
+//   node scripts/check-release-alignment.cjs --deep     # also verify the brew sha256
+//   OPENCUES_WEBSITE=/path/to/opencues-website node scripts/check-release-alignment.cjs
+//
+// Exit 0 = aligned. Exit 1 = at least one surface disagrees.
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const REPO = path.resolve(__dirname, '..');
+const SITE = process.env.OPENCUES_WEBSITE || path.join(os.homedir(), 'opencues-website');
+const OFFLINE = process.argv.includes('--offline');
+const DEEP = process.argv.includes('--deep');
+
+const C = process.stdout.isTTY && !process.env.NO_COLOR;
+const green = (s) => (C ? `\x1b[32m${s}\x1b[0m` : s);
+const red = (s) => (C ? `\x1b[31m${s}\x1b[0m` : s);
+const dim = (s) => (C ? `\x1b[2m${s}\x1b[0m` : s);
+
+let failures = 0;
+let skipped = 0;
+const ok = (what, detail) => console.log(`  ${green('●')} ${what}${detail ? dim(` — ${detail}`) : ''}`);
+const bad = (what, detail, fix) => {
+  failures += 1;
+  console.log(`  ${red('●')} ${what}`);
+  if (detail) console.log(`      ${detail}`);
+  if (fix) console.log(`      ${dim(fix)}`);
+};
+const skip = (what, why) => { skipped += 1; console.log(`  ${dim('●')} ${dim(`${what} — skipped (${why})`)}`); };
+const section = (t) => console.log(`\n${t}`);
+
+const read = (p) => fs.readFileSync(p, 'utf8');
+const exists = (p) => fs.existsSync(p);
+/** Run a command for its stdout; null on any failure (missing tool, network, non-zero). */
+function run(cmd, args, opts = {}) {
+  try {
+    return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 60_000, ...opts }).trim();
+  } catch { return null; }
+}
+
+// ── What the product repo believes ──────────────────────────────────────────
+
+const cliVersion = JSON.parse(read(path.join(REPO, 'packages/opencues-cli/package.json'))).version;
+const specVersion = (read(path.join(REPO, 'packages/opencues-core/src/spec-version.ts'))
+  .match(/SPEC_VERSION\s*=\s*'([^']+)'/) || [])[1];
+
+const changelog = read(path.join(REPO, 'CHANGELOG.md'));
+// The newest RELEASED heading — `## [X.Y.Z] - YYYY-MM-DD`. `[Unreleased]` is
+// deliberately not matched: a wave in progress is not a claim about a release.
+const relMatch = changelog.match(/^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})/m);
+const released = relMatch ? { version: relMatch[1], date: relMatch[2] } : null;
+
+console.log(`\nrelease alignment ${dim(`— CLI ${cliVersion}, spec ${specVersion}, newest release ${released ? released.version : '(none)'}`)}`);
+
+// ── 1. Inside the product repo ──────────────────────────────────────────────
+
+section('Product repo');
+
+if (!released) {
+  bad('CHANGELOG has no released section', 'expected a `## [X.Y.Z] - YYYY-MM-DD` heading',
+      'cut the release section before tagging (versioning.md § How to cut a release, step 2)');
+} else if (released.version !== cliVersion) {
+  bad('CLI version does not match the newest CHANGELOG release',
+      `packages/opencues-cli = ${cliVersion}, CHANGELOG newest = ${released.version}`,
+      'these must be identical: version = tag = npm = the tree users clone');
+} else {
+  ok('CLI version matches the newest CHANGELOG release', released.version);
+}
+
+const tag = `v${cliVersion}`;
+const tagCommit = run('git', ['-C', REPO, 'rev-parse', '-q', '--verify', `${tag}^{commit}`]);
+if (!tagCommit) {
+  skip(`tag ${tag}`, 'not created yet');
+} else {
+  // ⚠ The v0.6.0 bug, mechanised: a tag pushed before the release commit
+  // merged points at a tree whose CHANGELOG still says [Unreleased].
+  const taggedChangelog = run('git', ['-C', REPO, 'show', `${tag}:CHANGELOG.md`]) || '';
+  if (!taggedChangelog.includes(`## [${cliVersion}]`)) {
+    bad(`tag ${tag} points at a tree with no release heading`,
+        `${tag} → ${tagCommit.slice(0, 8)}, whose CHANGELOG has no \`## [${cliVersion}]\``,
+        `the tag went on before the release PR merged. Fix: git checkout master && git pull && git tag -f ${tag} && git push -f origin ${tag}`);
+  } else {
+    ok(`tag ${tag} points at the release commit`, tagCommit.slice(0, 8));
+  }
+}
+
+// ── 1b. The open standard ───────────────────────────────────────────────────
+//
+// SPEC_VERSION is stamped in eight places, and a bump that misses one leaves a
+// spec doc claiming an older contract while the runtime enforces a newer one.
+// The CLAUDE.md bump checklist lists them; this checks them.
+
+section('Open standard');
+
+if (!specVersion) {
+  bad('could not read SPEC_VERSION', 'packages/opencues-core/src/spec-version.ts');
+} else {
+  const specStamps = [
+    ['SPEC.md', 'SPEC.md', /\*\*Current version: `([^`]+)`/],
+    ['spec/README.md', 'spec/README.md', /\*\*Status:\*\* `([^`]+)`/],
+  ];
+  // README + CHANGELOG carry their own shapes; SECURITY.md scopes the
+  // standard's security claims and deliberately carries no version banner.
+  for (const f of fs.readdirSync(path.join(REPO, 'spec')).filter((f) => f.endsWith('.md') && !['README.md', 'CHANGELOG.md', 'SECURITY.md'].includes(f))) {
+    specStamps.push([`spec/${f}`, `spec/${f}`, /\*\*Status:\*\* `([^`]+)`/]);
+  }
+  const wrong = [];
+  for (const [label, rel, re] of specStamps) {
+    const abs = path.join(REPO, rel);
+    if (!exists(abs)) continue;
+    const found = (read(abs).match(re) || [])[1];
+    // Banners carry `0.11-alpha`, SPEC.md carries `0.11` — compare the number.
+    if (!found || found.split('-')[0] !== specVersion) wrong.push(`${label} says ${found || '(none)'}`);
+  }
+  if (wrong.length) {
+    bad(`${wrong.length} spec file(s) stamp a version that is not SPEC_VERSION`,
+        wrong.slice(0, 4).join('; ') + (wrong.length > 4 ? ` (+${wrong.length - 4} more)` : ''),
+        `expected ${specVersion} — see CLAUDE.md § The bump checklist`);
+  } else {
+    ok(`every spec doc stamps SPEC_VERSION`, `${specStamps.length} files at ${specVersion}`);
+  }
+
+  const specLog = path.join(REPO, 'spec/CHANGELOG.md');
+  const newestSpec = exists(specLog) ? (read(specLog).match(/^## \[(\d+\.\d+)(?:\.\d+)?-alpha\]/m) || [])[1] : null;
+  if (!newestSpec) skip('spec/CHANGELOG.md', 'no released spec version found');
+  else if (newestSpec !== specVersion) {
+    bad('spec/CHANGELOG.md newest release is not SPEC_VERSION',
+        `changelog = ${newestSpec}, spec-version.ts = ${specVersion}`,
+        'release the [Unreleased] block under the new version header');
+  } else ok('spec/CHANGELOG.md newest release matches SPEC_VERSION', newestSpec);
+}
+
+// ── 1c. Module versions ─────────────────────────────────────────────────────
+
+section('Modules');
+
+// Chrome carries its version TWICE: manifest.json is what chrome://extensions
+// shows, package.json is what the monorepo tracks. They have drifted across
+// five PRs before, leaving users unable to tell a reload apart from a no-op.
+const chromeManifest = path.join(REPO, 'integrations/chrome/manifest.json');
+const chromePkg = path.join(REPO, 'integrations/chrome/package.json');
+if (exists(chromeManifest) && exists(chromePkg)) {
+  const mv = JSON.parse(read(chromeManifest)).version;
+  const pv = JSON.parse(read(chromePkg)).version;
+  if (mv !== pv) {
+    bad('chrome manifest.json and package.json disagree',
+        `manifest = ${mv}, package = ${pv}`,
+        'bump BOTH in the same commit — the manifest is the only version a user can see');
+  } else ok('chrome manifest.json matches package.json', mv);
+}
+
+// The version map in CLAUDE.md is a snapshot people read to answer "what is
+// shipped?". A stale row is a wrong answer with a confident format.
+const claude = read(path.join(REPO, 'CLAUDE.md'));
+const rows = [...claude.matchAll(/^\| `([^`]+\/)` \| `?([^`|]+?)`? \| (\d+\.\d+\.\d+) \|/gm)];
+const drifted = [];
+for (const [, dir, , stated] of rows) {
+  const pkg = path.join(REPO, dir, 'package.json');
+  if (!exists(pkg)) continue;
+  const actual = JSON.parse(read(pkg)).version;
+  if (actual !== stated) drifted.push(`${dir} table says ${stated}, package.json says ${actual}`);
+}
+if (!rows.length) skip('CLAUDE.md version map', 'table not found');
+else if (drifted.length) {
+  bad(`${drifted.length} row(s) of CLAUDE.md's version map are stale`,
+      drifted.slice(0, 4).join('; ') + (drifted.length > 4 ? ` (+${drifted.length - 4} more)` : ''),
+      'regenerate with the loop in CLAUDE.md § Package version map');
+} else ok("CLAUDE.md's version map matches every package.json", `${rows.length} rows`);
+
+// ── 2. The website ──────────────────────────────────────────────────────────
+
+section(`Website ${dim(SITE)}`);
+
+if (!exists(SITE)) {
+  skip('every website check', `${SITE} not found — set OPENCUES_WEBSITE`);
+} else {
+  // 2a. The open-standard page is the one public description of the standard.
+  // Checked for the VERSION STRINGS only; whether the prose describes the new
+  // surface is a human call, and the checklist says so.
+  const osPath = path.join(SITE, 'md/population/open-standard.md');
+  if (!exists(osPath)) {
+    skip('open-standard page', 'file not found');
+  } else {
+    const os_ = read(osPath);
+    const stale = [...os_.matchAll(/(?:opencues\/|currently `|As of `)(\d+\.\d+)/g)]
+      .map((m) => m[1]).filter((v) => v !== specVersion);
+    if (stale.length) {
+      bad('open-standard page cites a spec version that is not SPEC_VERSION',
+          `page says ${[...new Set(stale)].join(', ')}, spec-version.ts says ${specVersion}`,
+          'update the strings AND describe the new surface (check spec/CHANGELOG.md, not just the number)');
+    } else if (!os_.includes(`\`${specVersion}\``)) {
+      bad('open-standard page never mentions the current spec version', `expected \`${specVersion}\` somewhere in the page`);
+    } else {
+      ok('open-standard page cites the current spec version', specVersion);
+    }
+  }
+
+  // 2b. The site's changelog must name the same newest release, with a real
+  // date. `# current date` renders as TODAY at view time — fine for a
+  // provisional entry, a lie on a shipped one.
+  const siteLogPath = path.join(SITE, 'md/population/changelog.md');
+  if (!exists(siteLogPath) || !released) {
+    skip('site changelog', exists(siteLogPath) ? 'no released section to compare' : 'file not found');
+  } else {
+    const siteLog = read(siteLogPath);
+    const entry = siteLog.match(/^# v(\d+\.\d+\.\d+)\s*\n# (.+)$/m);
+    if (!entry) {
+      bad('site changelog has no `# vX.Y.Z` entry', 'expected a version heading followed by a date line');
+    } else if (entry[1] !== released.version) {
+      bad('site changelog names a different newest release',
+          `site says v${entry[1]}, product released ${released.version}`,
+          'the paired website PR is part of the release (versioning.md step 8)');
+    } else if (/current date/i.test(entry[2])) {
+      bad(`site changelog still carries the placeholder date on v${entry[1]}`,
+          '`# current date` renders as today at view time, so a shipped release appears to ship again every day',
+          `replace it with the real date (e.g. # ${new Date(released.date).getUTCDate()}th ${new Date(released.date).toLocaleString('en', { month: 'short' }).toUpperCase()} ${new Date(released.date).getUTCFullYear()})`);
+    } else {
+      ok('site changelog names the same release, with a real date', `v${entry[1]} · ${entry[2]}`);
+    }
+  }
+
+  // 2c. llms.txt is a published index. Empty is worse than absent: the URL
+  // still serves 200 with nothing in it.
+  const llmsPath = path.join(SITE, 'llms.txt');
+  const sitemapPath = path.join(SITE, 'sitemap.xml');
+  if (!exists(llmsPath) || !exists(sitemapPath)) {
+    skip('llms.txt', 'file not found');
+  } else {
+    const llms = read(llmsPath);
+    const indexed = new Set([...llms.matchAll(/\((https:\/\/opencues\.com[^)]*)\)/g)].map((m) => m[1].replace(/\/$/, '')));
+    const published = new Set([...read(sitemapPath).matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1].replace(/\/$/, '')));
+    const missing = [...published].filter((u) => !indexed.has(u));
+    if (llms.trim().length === 0) {
+      bad('llms.txt is empty', 'a 0-byte file served at a live URL', 'regenerate it from the sitemap');
+    } else if (missing.length) {
+      bad(`llms.txt is missing ${missing.length} published page(s)`,
+          missing.slice(0, 3).join(', ') + (missing.length > 3 ? ` (+${missing.length - 3} more)` : ''),
+          'regenerate it whenever the page set changes');
+    } else {
+      ok('llms.txt indexes every published page', `${indexed.size} entries`);
+    }
+  }
+}
+
+// ── 3. Published surfaces ───────────────────────────────────────────────────
+
+section('Published');
+
+if (OFFLINE) {
+  skip('npm / GitHub release / Homebrew', '--offline');
+} else {
+  // 3a. npm
+  const npmVersion = run('npm', ['view', 'opencues', 'version']);
+  if (!npmVersion) {
+    skip('npm', 'registry unreachable');
+  } else if (npmVersion !== cliVersion) {
+    bad('npm latest is not the CLI version',
+        `npm = ${npmVersion}, packages/opencues-cli = ${cliVersion}`,
+        'cd packages/opencues-cli && npm publish   (NOT `npm publish -w` — pnpm workspace)');
+  } else {
+    ok('npm latest matches the CLI version', npmVersion);
+  }
+
+  // 3b. GitHub release
+  const relView = run('gh', ['release', 'view', tag, '--repo', 'opencues/opencues', '--json', 'tagName', '-q', '.tagName']);
+  if (relView === null) {
+    bad(`no GitHub release for ${tag}`, 'the repo front page still advertises the previous version',
+        `gh release create ${tag} --title "OpenCues ${tag}" --notes-file <notes>`);
+  } else {
+    ok('GitHub release exists', relView);
+  }
+
+  // 3c. Homebrew. THREE things drift: url, sha256, and the version asserted by
+  // the formula's own test — that last one was stale for two releases.
+  const formula = run('gh', ['api', 'repos/opencues/homebrew-opencues/contents/Formula/opencues.rb', '-q', '.content']);
+  if (!formula) {
+    skip('Homebrew formula', 'tap unreachable');
+  } else {
+    const rb = Buffer.from(formula, 'base64').toString('utf8');
+    const urlV = (rb.match(/opencues-(\d+\.\d+\.\d+)\.tgz/) || [])[1];
+    const testV = (rb.match(/assert_match "(\d+\.\d+\.\d+)"/) || [])[1];
+    if (urlV !== cliVersion) {
+      bad('Homebrew formula url is a different version',
+          `formula = ${urlV}, released = ${cliVersion}`,
+          'brew users stay on the old release with no signal they are behind');
+    } else if (testV !== cliVersion) {
+      bad('Homebrew formula test asserts a different version',
+          `assert_match "${testV}" while the formula ships ${cliVersion}`,
+          'the formula test passes against a version it does not install');
+    } else {
+      ok('Homebrew formula url + test assert the released version', cliVersion);
+    }
+    if (DEEP && urlV === cliVersion) {
+      const tarball = run('npm', ['view', `opencues@${cliVersion}`, 'dist.tarball']);
+      const want = (rb.match(/sha256 "([a-f0-9]{64})"/) || [])[1];
+      const got = tarball ? run('bash', ['-c', `curl -sL "${tarball}" | sha256sum | awk '{print $1}'`]) : null;
+      if (!got) skip('Homebrew sha256', 'could not fetch the tarball');
+      else if (got !== want) bad('Homebrew sha256 does not match the published tarball', `formula ${want.slice(0, 12)}…, registry ${got.slice(0, 12)}…`);
+      else ok('Homebrew sha256 matches the published tarball', want.slice(0, 12) + '…');
+    }
+  }
+}
+
+// ── Verdict ─────────────────────────────────────────────────────────────────
+
+console.log('');
+if (failures) {
+  console.log(`${red('●')} ${failures} surface(s) disagree${skipped ? dim(` · ${skipped} skipped`) : ''}.`);
+  console.log(dim('  Each line above is two files that must agree and do not. See'));
+  console.log(dim('  docs/architecture/versioning.md § How to cut a release.\n'));
+  process.exit(1);
+}
+console.log(`${green('●')} every surface agrees${skipped ? dim(` · ${skipped} skipped`) : ''}.\n`);


### PR DESCRIPTION
Your point, mechanised: if the surfaces drift we should know it without anyone remembering to look.

Every failure v0.6.0 hit was a comparison between two files. None needed judgement, so none of them belonged in a checklist read at 2am.

## What it compares

| Group | Checks |
|---|---|
| **Product** | CLI version ↔ newest CHANGELOG release; the tag ↔ the tree it points at |
| **Open standard** | every spec doc's Status banner ↔ `SPEC_VERSION` ↔ `spec/CHANGELOG.md` |
| **Modules** | chrome `manifest.json` ↔ `package.json`; CLAUDE.md's version map ↔ every `package.json` |
| **Website** | open-standard page's spec version; changelog's newest entry + whether it still carries `# current date`; `llms.txt` ↔ sitemap |
| **Published** | npm `latest`; the GitHub release; Homebrew `url` **and** `assert_match` |

Each failure prints the two values and the command that fixes it.

## Verified against the failures, not just today's state

Passing on a repo I just fixed by hand proves nothing, so I reproduced each historical failure and confirmed it fails:

- site at spec 0.10 against `SPEC_VERSION` 0.11 → caught
- site changelog naming a different release → caught
- right version, **placeholder date** (the one that hid best) → caught
- `llms.txt` empty → caught
- tag moved back before the release commit, on a scratch clone → caught, with the `git tag -f` fix printed

## It found two live drifts on first run

`CLAUDE.md`'s version map was stale in six rows — it claimed core 0.41.0 against a real 0.43.0, and runtime 0.28.20 against 0.30.2. Fixed in this PR. That table is what someone reads to answer "what is shipped?", so a stale row is a wrong answer in a confident format.

## Flags

`--offline` skips npm/gh/brew, `--deep` also verifies the Homebrew sha256 against the published tarball, `OPENCUES_WEBSITE=` points at the site repo.

Wired into both ends of the release checklist: once at the start to see what the last release left behind, once at the end as the exit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1xJUCEr5brdgQtmc75kAM