### PR TITLE
fix(runtime): an inline note's arrow points AT the span, not two cells left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed — an inline note's `↳` points AT the span, not two cells left of it (`@opencues/runtime`)
+### Changed — an inline note's `↳` points AT the span, not two cells left of it (`@opencues/runtime` 0.30.2 → 0.30.3)
 
 The note line's indent aligned the MESSAGE under the flagged span, with the `↳ ` connector hanging in the margin to its left. It aligns the CONNECTOR now: the arrow lands on the value's first character. The reason is that a message's alignment depends on whichever character it begins with — an emoji's mark is drawn narrower than its cell and lands a fraction off, while a word lands on exactly — so the same note sat differently by message and by host. The connector is one glyph the renderer controls, so pointing IT at the span is stable, and it is the rule the artifact kit and opencues.com have used for a while: this closes a divergence rather than opening one. `applyDirectives` pads by `col` instead of `col - prefixCells`, and `inlineNoteBoxColumn` (the column the OpenTUI hosts float their overlay line at) returns the span's own column, so the terminal splice and the overlay hosts still land in the same place.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — an inline note's `↳` points AT the span, not two cells left of it (`@opencues/runtime`)
+
+The note line's indent aligned the MESSAGE under the flagged span, with the `↳ ` connector hanging in the margin to its left. It aligns the CONNECTOR now: the arrow lands on the value's first character. The reason is that a message's alignment depends on whichever character it begins with — an emoji's mark is drawn narrower than its cell and lands a fraction off, while a word lands on exactly — so the same note sat differently by message and by host. The connector is one glyph the renderer controls, so pointing IT at the span is stable, and it is the rule the artifact kit and opencues.com have used for a while: this closes a divergence rather than opening one. `applyDirectives` pads by `col` instead of `col - prefixCells`, and `inlineNoteBoxColumn` (the column the OpenTUI hosts float their overlay line at) returns the span's own column, so the terminal splice and the overlay hosts still land in the same place.
+
+**Claude Code's first-line indent goes to 0 with it**, and the two errors it was cancelling are worth recording. `CC_INPUT_FIRST_LINE_INDENT` existed because the note is injected as a continuation line, which the comment said gets no `❯ ` prompt — so the pad added the prompt width back. CC's input box indents continuation lines too, so that addition and the connector's own two-cell subtraction cancelled: on screen the arrow already sat on the span and the message two cells past it, which is what CC has always shown and why nobody noticed the runtime was nominally message-aligned. With the subtraction gone the addition double-counted and the arrow moved two cells INTO the word. Zero is the honest value and it agrees with the OpenTUI hosts, which never had a compensation. Still overridable live with `OPENCUES_CC_NOTE_INDENT` for a host that really does indent only its first line.
+
+Nine `dim-render.test.ts` expectations and five `render-directives.test.ts` ones pinned the old rule and now pin the new; 2245 runtime tests pass, with opencode (54), gemini-cli (23) and shell (45). Not a spec change — a rendering rule, no scalar.
+
 ## [0.6.0] - 2026-08-09
 
 ### Added — dismiss a cue from its own note (`@opencues/core` 0.42.7 → 0.43.0, `@opencues/runtime` 0.29.11 → 0.30.2, `opencues` 0.5.5 → 0.6.0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -702,7 +702,7 @@ done
 | `SPEC.md` (open-standard) | `cues-spec` | 0.11 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
 | `packages/opencues-core/` | `@opencues/core` | 0.43.0 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.30.2 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.30.3 | private |
 | `packages/opencues-cli/` | `opencues` (real CLI) | 0.6.0 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.11 | private |
 | `integrations/opencode/` | `@opencues/opencode` | 0.2.15 | private |

--- a/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
+++ b/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
@@ -53,18 +53,30 @@ import type {
 } from '../../../src/adapter';
 
 /**
- * Columns Claude Code prepends to the input's FIRST line (the `❯ ` prompt +
- * any box indent) but NOT to continuation lines. An inline cue note is injected
- * as a continuation line, so a first-line span sits this far right of its
- * buffer column on screen; `applyDirectives` adds it back so the note stays
- * under the span. Tunable live via `OPENCUES_CC_NOTE_INDENT` (no rebuild —
- * export it and restart) while we settle on the right value; default is the
- * `❯ ` prompt width.
+ * Columns Claude Code prepends to the input's FIRST line that a continuation
+ * line does NOT get. For Claude Code that is ZERO: the `❯ ` prompt indents the
+ * first line, and CC's input box indents the continuation lines by the same
+ * amount, so an injected note line already starts at the span's own frame.
+ *
+ * IT WAS 2 UNTIL 2026-08-16, and the reason is worth keeping because it was
+ * two errors cancelling. The comment here claimed continuation lines got no
+ * indent, so the pad added the prompt width back — and the old note rule then
+ * subtracted the `↳ ` connector's two cells to put the MESSAGE under the span.
+ * The two cancelled: on screen the ARROW landed on the span's column and the
+ * message sat two cells past it, which is what CC has always shown and why
+ * nobody noticed the runtime was nominally message-aligned. When the runtime
+ * moved to aligning the CONNECTOR (render-directives.ts), the subtraction went
+ * and the addition was left double-counting: the arrow appeared two cells INTO
+ * the word. Zero is the honest value, and it agrees with the OpenTUI hosts,
+ * which never had a compensation.
+ *
+ * Still tunable live via `OPENCUES_CC_NOTE_INDENT` (no rebuild — export it and
+ * restart) for a host whose box does indent only the first line.
  */
 const CC_INPUT_FIRST_LINE_INDENT: number = (() => {
   const raw = typeof process !== 'undefined' ? process.env?.OPENCUES_CC_NOTE_INDENT : undefined;
   const n = raw !== undefined ? Number(raw) : NaN;
-  return Number.isFinite(n) && n >= 0 ? n : 2;
+  return Number.isFinite(n) && n >= 0 ? n : 0;
 })();
 
 /** Minimal host info the patch supplies. boot() builds HostBindings from it. */

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/dim-render.test.ts
+++ b/packages/opencues-runtime/src/modules/dim-render.test.ts
@@ -632,8 +632,8 @@ describe('DimRender inline cue notes (inline-cues-mode)', () => {
     });
     const directives = dimRender.compute({ text: buf, cursor: 5, externalHighlights: [] });
     const visible = applyDirectives(buf, directives).replace(/\x1b\[[0-9;]*m/g, '');
-    expect(visible).toContain('formal\n     ↳ 2 | Improve formality'); // 5 spaces (cells)
-    expect(visible).not.toContain('formal\n  ↳'); // NOT the 2-space code-point pad
+    expect(visible).toContain('formal\n       ↳ 2 | Improve formality'); // 5 spaces (cells)
+    expect(visible).not.toContain('formal\n     ↳'); // NOT the old message-aode-point pad
   });
 
   it('auto-selects a transform span when the caret is inside, and CLEARS when it leaves', () => {
@@ -920,9 +920,9 @@ blankScript: ./vol.sh
     // indented to the span's column (11 = start of "saturday").
     const visible = painted.replace(/\x1b\[[0-9;]*m/g, '');
     expect(visible.startsWith(BUFFER)).toBe(true);
-    // Message aligns under the span (col 11); "↳ " (2 cols) hangs in the margin,
-    // so the line is padded to col-2 = 9 before the connector.
-    expect(visible).toContain('\n' + ' '.repeat(9) + '↳ ⚠  2 | the 19th is a Friday, not Saturday');
+    // THE CONNECTOR aligns under the span (col 11): the line is padded to the
+    // span's own column, so the arrow points at its first character.
+    expect(visible).toContain('\n' + ' '.repeat(11) + '↳ ⚠  2 | the 19th is a Friday, not Saturday');
     expect(painted).toContain('\x1b[2m↳ ⚠  2 | the 19th is a Friday, not Saturday   (underscore to cycle)\x1b[22m');
   });
 
@@ -939,10 +939,10 @@ blankScript: ./vol.sh
       cueTip: '⚠ the 19th is a Friday',
     });
     const directives = dimRender.compute({ text: buf0, cursor: 3, externalHighlights: [] });
-    // col 0 + promptPad 2 - "↳ "(2) = 0 → arrow sits at the left edge, no indent.
+    // col 0 + promptPad 2 → the arrow sits at the prompt's own column, no indent.
     const visible = applyDirectives(buf0, directives, 2).replace(/\x1b\[[0-9;]*m/g, '');
-    expect(visible).toContain('\n↳ ⚠  2 | the 19th is a Friday');
-    expect(visible).not.toContain('\n ↳'); // no leading space before the arrow
+    expect(visible).toContain('\n  ↳ ⚠  2 | the 19th is a Friday');
+    expect(visible).not.toContain('\n↳'); // the prompt's columns before the arrow
   });
 
   it('adds the host first-line indent when the span is on line 1 (CC prompt)', () => {
@@ -952,7 +952,7 @@ blankScript: ./vol.sh
     // firstLineIndent = 4 → note pad = (col-2) + 4 = 9 + 4 = 13. The span is on
     // line 1 (lineStart 0), so the prompt offset applies.
     const visible = applyDirectives(BUFFER, directives, 4).replace(/\x1b\[[0-9;]*m/g, '');
-    expect(visible).toContain('\n' + ' '.repeat(13) + '↳ ⚠  2 | the 19th is a Friday, not Saturday');
+    expect(visible).toContain('\n' + ' '.repeat(15) + '↳ ⚠  2 | the 19th is a Friday, not Saturday');
   });
 
   it('does NOT add the first-line indent when the span is on a later line', () => {
@@ -970,9 +970,9 @@ blankScript: ./vol.sh
     });
     const directives = dimRender.compute({ text: multiline, cursor: 24, externalHighlights: [] });
     // Even with a large firstLineIndent, a line-2 span gets NO prompt pad:
-    // col = 21 - 16 = 5 → pad = col-2 = 3, unchanged.
+    // col = 21 - 16 = 5 → pad = col = 5, and no prompt indent on a later line.
     const visible = applyDirectives(multiline, directives, 8).replace(/\x1b\[[0-9;]*m/g, '');
-    expect(visible).toContain('saturday now\n   ↳ ⚠  2 | the 19th is a Friday');
+    expect(visible).toContain('saturday now\n     ↳ ⚠  2 | the 19th is a Friday');
   });
 
   it('places the pill under the SPAN\'s line, not below the whole buffer (long buffer)', () => {
@@ -992,8 +992,8 @@ blankScript: ./vol.sh
     });
     const directives = dimRender.compute({ text: multiline, cursor: 8, externalHighlights: [] });
     const visible = applyDirectives(multiline, directives).replace(/\x1b\[[0-9;]*m/g, '');
-    // span at col 5 → message aligns under it, "↳ " hangs left → pad = 3.
-    expect(visible).toContain('saturday\n   ↳ ⚠  2 | the 19th is a Friday   (underscore to cycle)\nmore text');
+    // span at col 5 → the connector sits ON col 5 → pad = 3.
+    expect(visible).toContain('saturday\n     ↳ ⚠  2 | the 19th is a Friday   (underscore to cycle)\nmore text');
     // Not dangling after the last line.
     expect(visible.endsWith('even more')).toBe(true);
   });
@@ -1023,8 +1023,8 @@ blankScript: ./vol.sh
     const visible = applyDirectives(MIDLINE, directives).replace(/\x1b\[[0-9;]*m/g, '');
     // Right-side text preserved on the line; note below, message under col 8.
     expect(visible.startsWith('meet on saturday at 6pm')).toBe(true);
-    // col 8 → pad = 8 - 2 = 6; "↳ " then message → ⚠ lands at col 8 (under 's').
-    expect(visible).toContain('at 6pm\n      ↳ ⚠  2 | the 19th is a Friday');
+    // col 8 → pad = 8; the connector lands ON col 8 (under 's').
+    expect(visible).toContain('at 6pm\n        ↳ ⚠  2 | the 19th is a Friday');
   });
 
   it('MID-LINE span with a following line — note inserts between, right-side text preserved', () => {
@@ -1034,17 +1034,17 @@ blankScript: ./vol.sh
     const directives = dimRender.compute({ text: buf, cursor: 12, externalHighlights: [] });
     const visible = applyDirectives(buf, directives).replace(/\x1b\[[0-9;]*m/g, '');
     // Note lands between the span's line and the next; "at 6pm" stays on line 1,
-    // "see you there" stays on its own line, message aligned under col 8.
-    expect(visible).toContain('at 6pm\n      ↳ ⚠  2 | the 19th is a Friday   (underscore to cycle)\nsee you there');
+    // "see you there" stays on its own line, connector aligned under col 8.
+    expect(visible).toContain('at 6pm\n        ↳ ⚠  2 | the 19th is a Friday   (underscore to cycle)\nsee you there');
   });
 
   it('MID-LINE span on the prompted first line — prompt indent + column both apply', () => {
     const { dynDefs, dimRender } = setup(MIDLINE);
     seedMidlineDef(dynDefs);
     const directives = dimRender.compute({ text: MIDLINE, cursor: 12, externalHighlights: [] });
-    // firstLineIndent 2 (CC prompt) → pad = col 8 + 2 - "↳ "(2) = 8, so the
-    // message sits under the span's on-screen column (prompt 2 + col 8 = 10).
+    // firstLineIndent 2 (CC prompt) → pad = col 8 + 2 = 10, so the CONNECTOR
+    // sits under the span's on-screen column (prompt 2 + col 8 = 10).
     const visible = applyDirectives(MIDLINE, directives, 2).replace(/\x1b\[[0-9;]*m/g, '');
-    expect(visible).toContain('at 6pm\n        ↳ ⚠  2 | the 19th is a Friday');
+    expect(visible).toContain('at 6pm\n          ↳ ⚠  2 | the 19th is a Friday');
   });
 });

--- a/packages/opencues-runtime/src/render-directives.test.ts
+++ b/packages/opencues-runtime/src/render-directives.test.ts
@@ -179,31 +179,35 @@ describe('applyDirectives — markdown ranges (Phase 1: terminals)', () => {
 
 // The OpenTUI hosts (OpenCode / shell) can't splice a note line into the
 // textarea's own render, so they float an absolute overlay line at this
-// column. It must match the terminal splice's alignment: the MESSAGE lands
-// under the span column, the `↳ ` connector (2 cells) hanging to its left.
+// column. It must match the terminal splice's alignment: the `↳ ` CONNECTOR
+// lands ON the span's column, pointing at the value's first character.
+// Aligning the MESSAGE instead (what this did until 2026-08-16) makes the
+// alignment depend on whichever character the message begins with — an emoji's
+// mark is drawn narrower than its cell and lands a fraction off, a word lands
+// on exactly — so the same note wobbled by message.
 describe('inlineNoteBoxColumn', () => {
-  it('span at column 0 → flush left (connector clamps, no negative pad)', () => {
+  it('span at column 0 → flush left', () => {
     expect(inlineNoteBoxColumn('attorney filed today', 0)).toBe(0);
   });
 
-  it('mid-line ASCII span → span column minus the 2-cell connector', () => {
-    // "the " = 4 cells before the span; 4 - 2 (connector) = 2.
-    expect(inlineNoteBoxColumn('the attorney filed', 4)).toBe(2);
+  it('mid-line ASCII span → the span\'s own column', () => {
+    // "the " = 4 cells before the span, so the connector starts at 4.
+    expect(inlineNoteBoxColumn('the attorney filed', 4)).toBe(4);
   });
 
   it('CJK prefix counted in visual cells, not code units', () => {
-    // "日本語" = 3 code units but 6 cells; 6 - 2 = 4 (not 3 - 2 = 1).
-    expect(inlineNoteBoxColumn('日本語x', 3)).toBe(4);
+    // "日本語" = 3 code units but 6 cells → 6, not 3.
+    expect(inlineNoteBoxColumn('日本語x', 3)).toBe(6);
   });
 
   it('only the span line prefix counts (prior lines ignored)', () => {
     // "line1\n" then "the cat"; span at 'cat' (offset 10). Line prefix
-    // "the " = 4 cells → 4 - 2 = 2, independent of line1's length.
-    expect(inlineNoteBoxColumn('line1\nthe cat', 10)).toBe(2);
+    // "the " = 4 cells → 4, independent of line1's length.
+    expect(inlineNoteBoxColumn('line1\nthe cat', 10)).toBe(4);
   });
 
   it('out-of-range spanStart is clamped to the buffer length', () => {
-    expect(inlineNoteBoxColumn('hi', 999)).toBe(0);
+    expect(inlineNoteBoxColumn('hi', 999)).toBe(2);
   });
 });
 

--- a/packages/opencues-runtime/src/render-directives.ts
+++ b/packages/opencues-runtime/src/render-directives.ts
@@ -108,12 +108,18 @@ export function inlineNoteDisplayText(cueTip: string): string {
 
 /**
  * Screen COLUMN (in terminal cells) where an inline note's `↳ ` connector
- * should start so the MESSAGE lands under the span's column — the same
- * alignment `applyDirectives` computes for the terminal splice, factored out
- * so the OpenTUI hosts (OpenCode / shell), which can't splice into the
- * textarea's own render and instead float an absolute-positioned overlay
- * line, land the note in the SAME place. The connector hangs to the left of
- * the span column; clamped at 0 so a span at/near column 0 sits flush left.
+ * should start: ON the span's own column, so the arrow points at the value's
+ * first character. The same alignment `applyDirectives` computes for the
+ * terminal splice, factored out so the OpenTUI hosts (OpenCode / shell), which
+ * can't splice into the textarea's own render and instead float an
+ * absolute-positioned overlay line, land the note in the SAME place.
+ *
+ * THE CONNECTOR ALIGNS, NOT THE MESSAGE (changed 2026-08-16, bringing the
+ * runtime onto the artifact kit's rule). Aligning the message makes the
+ * alignment depend on whichever character it begins with: an emoji's mark is
+ * drawn narrower than its cell and lands a fraction off, while a word lands on
+ * exactly — so the same note wobbled by host and by message. The connector is
+ * one glyph the renderer controls, so pointing IT at the span is stable.
  *
  * `text` is the painted plain-text buffer; `spanStart` is the note span's
  * start offset in that same space. Wrap-unaware by design (matches the
@@ -124,10 +130,7 @@ export function inlineNoteBoxColumn(text: string, spanStart: number): number {
   const s = Math.min(Math.max(0, spanStart), text.length);
   const lineStart = text.lastIndexOf('\n', Math.max(0, s - 1)) + 1;
   const lineText = text.slice(lineStart, s);
-  const col = codeUnitsToCells(lineText, lineText.length);
-  const prefix = INLINE_NOTE_CONNECTOR + ' ';
-  const prefixCells = codeUnitsToCells(prefix, prefix.length);
-  return Math.max(0, col - prefixCells);
+  return Math.max(0, codeUnitsToCells(lineText, lineText.length));
 }
 
 /**
@@ -232,18 +235,16 @@ export function applyDirectives(
     // Japanese" bug). Measure in terminal cells so the note tracks the span.
     const lineText = visible.slice(lineStart, spanStart);
     const col = codeUnitsToCells(lineText, lineText.length);
-    // The `↳ ` connector points up at the span; the MESSAGE aligns under the
-    // span's column, with the arrow hanging in the margin to its left.
+    // THE CONNECTOR ALIGNS, NOT THE MESSAGE: the `↳ ` sits ON the span's own
+    // column, pointing at the value's first character. Aligning the message
+    // instead made the alignment depend on whichever character it began with -
+    // an emoji's mark is drawn narrower than its cell and lands a fraction off,
+    // a word lands on exactly - so the same note wobbled by message.
     const prefix = INLINE_NOTE_CONNECTOR + ' ';
-    const prefixCells = codeUnitsToCells(prefix, prefix.length);
     // First-line span → add back the host prompt indent the note line (a
     // continuation line) doesn't inherit. lineStart === 0 ⟺ span on line 1.
     const promptPad = lineStart === 0 ? Math.max(0, firstLineIndent) : 0;
-    // Message target column = col + promptPad; the connector hangs prefixCells
-    // to its left. Fold both into ONE clamp so a span at (or near) column 0
-    // yields no leading indent — the arrow just sits at the left edge — instead
-    // of being pushed right by the prompt pad.
-    const pad = ' '.repeat(Math.max(0, col + promptPad - prefixCells));
+    const pad = ' '.repeat(Math.max(0, col + promptPad));
     // Trailing `(underscore to cycle)` affordance — present until the user's
     // first cycle this session (dim-render drops the hint via hasCycledEver()).
     const noteBody = padTerminalWideEmoji(formatInlineNoteText(note.text)) + (note.hint ? `   ${note.hint}` : '');


### PR DESCRIPTION
The note line's indent aligned the **message** under the flagged span, with the `↳ ` connector hanging in the margin to its left. It aligns the **connector** now: the arrow lands on the value's first character.

```
before   meet on saturday          after    meet on saturday
               ↳ ⚠  2 | …                          ↳ ⚠  2 | …
```

**Why the connector.** A message's alignment depends on whichever character it begins with — an emoji's mark is drawn narrower than its cell and lands a fraction off, while a word lands on exactly — so the same note sat differently by message and by host. The connector is one glyph the renderer controls. It is also the rule the artifact kit and opencues.com have used for a while, so this closes a divergence rather than opening one.

`applyDirectives` pads by `col` instead of `col - prefixCells`, and `inlineNoteBoxColumn` — the column the OpenTUI hosts float their overlay line at — returns the span's own column, so the terminal splice and the overlay hosts still land in the same place.

**Claude Code's first-line indent goes to 0 with it**, and the two errors it was cancelling are worth recording. `CC_INPUT_FIRST_LINE_INDENT` existed because the note is injected as a continuation line, which the comment said gets no `❯ ` prompt — so the pad added the prompt width back. CC's input box indents continuation lines too, so that addition and the connector's own two-cell subtraction cancelled: on screen the arrow already sat on the span and the message two cells past it. That is what CC has always shown, and why nobody noticed the runtime was nominally message-aligned. With the subtraction gone the addition double-counted and the arrow moved two cells **into** the word — caught by eye on a rebuilt host, not by a test. Zero is the honest value and it agrees with the OpenTUI hosts, which never had a compensation. Still overridable live with `OPENCUES_CC_NOTE_INDENT`.

**Tests.** Nine `dim-render.test.ts` expectations and five `render-directives.test.ts` ones pinned the old rule and now pin the new. 2245 runtime tests pass, with opencode 54, gemini-cli 23 and shell 45. Verified on the installed hosts after `opencues install claude-code --rebuild` and `opencues install opencode`.

Not a spec change — a rendering rule, no scalar. CHANGELOG entry under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoZ5Lg6ss5a9SnRJjSfwiF