### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-16
+
 ### Changed — an inline note's `↳` points AT the span, not two cells left of it (`@opencues/runtime` 0.30.2 → 0.30.3)
 
 The note line's indent aligned the MESSAGE under the flagged span, with the `↳ ` connector hanging in the margin to its left. It aligns the CONNECTOR now: the arrow lands on the value's first character. The reason is that a message's alignment depends on whichever character it begins with — an emoji's mark is drawn narrower than its cell and lands a fraction off, while a word lands on exactly — so the same note sat differently by message and by host. The connector is one glyph the renderer controls, so pointing IT at the span is stable, and it is the rule the artifact kit and opencues.com have used for a while: this closes a divergence rather than opening one. `applyDirectives` pads by `col` instead of `col - prefixCells`, and `inlineNoteBoxColumn` (the column the OpenTUI hosts float their overlay line at) returns the span's own column, so the terminal splice and the overlay hosts still land in the same place.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -703,7 +703,7 @@ done
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
 | `packages/opencues-core/` | `@opencues/core` | 0.43.0 | private |
 | `packages/opencues-runtime/` | `@opencues/runtime` | 0.30.3 | private |
-| `packages/opencues-cli/` | `opencues` (real CLI) | 0.6.0 | **PUBLISHED on npm** |
+| `packages/opencues-cli/` | `opencues` (real CLI) | 0.6.1 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.11 | private |
 | `integrations/opencode/` | `@opencues/opencode` | 0.2.15 | private |
 | `integrations/chrome/` | `@opencues/chrome` | 0.2.165 | private |

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "Apache-2.0",
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "keywords": [


### PR DESCRIPTION
Release commit for **v0.6.1** — the inline note's `↳` points at the span rather than two cells left of it (#390).

- `packages/opencues-cli/package.json` → `0.6.1`
- `CHANGELOG.md` → `## [Unreleased]` renamed to `## [0.6.1] - 2026-08-16`, fresh empty `[Unreleased]` above it
- `CLAUDE.md` version map row for the CLI → `0.6.1`

`node scripts/check-release-alignment.cjs --offline` is green: every surface agrees, including the site's changelog, which already carries **v0.6.1 · 16th AUG 2026**.

After this merges: tag `v0.6.1` on master, `npm publish` from `packages/opencues-cli`, `gh release create`, Homebrew formula's three lines, then `check-npm-fresh-install.sh` and the website PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WoZ5Lg6ss5a9SnRJjSfwiF