### PR TITLE
fix(runtime): loading animator restores `_` instead of stranding its glyph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — the loading animator no longer strands its glyph in the buffer (`@opencues/runtime` 0.30.3 → 0.30.4)
+
+Type into a `_` slot while its blank is still in flight and the spinner character was left behind for good: `weather ▘!!`. The animator gives up whenever the slot's word stops being one of its frames — the documented behaviour, since the substitution path is expected to take the word — but it gave up *without putting `_` back*, so the blank it was animating could never resolve either. There was no `_` left to splice into. Two ways to reach it, both fixed:
+
+**The user types beside the glyph.** The animator owns exactly one character, the frame it last wrote, so a slot now records it (`lastWritten`) and peels that single occurrence back out on give-up: `▘!!` → `_!!`, keeping the user's edit and the blank. Matching is on the exact character last written, never the frame set, because `bounce` and `flipper` frames are ordinary ASCII (`-`, `|`, `/`) and matching the set would rewrite a `-` the user typed themselves. Applies on the tick path and on `stop()`, which had the same hole.
+
+**An edit before the slot shifts every word index.** The animator then watches the wrong word entirely while its glyph sits elsewhere, so neither the tracked word nor the give-up check ever sees it. A last-resort rescue scans the buffer, on two conditions that together make it unambiguous: the glyph is non-ASCII (the braille and custom marks, so `bounce`/`flipper` are excluded by construction) and it occurs exactly once. Anything less certain is left alone — a stray glyph is a blemish, rewriting a character the user typed is data loss.
+
+Found on DeepSeek Harness, whose asynchronous composer writes widen the window, but the give-up path is host-agnostic and every host could hit it. Eight new `blank-loading.test.ts` cases cover both recoveries plus the three refusals (substitution took the word, ASCII frame, glyph appears twice); 91 pass in that file.
+
 ## [0.6.1] - 2026-08-16
 
 ### Changed — an inline note's `↳` points AT the span, not two cells left of it (`@opencues/runtime` 0.30.2 → 0.30.3)

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/modules/blank-loading.test.ts
+++ b/packages/opencues-runtime/src/modules/blank-loading.test.ts
@@ -865,3 +865,106 @@ describe('getActiveColoredRanges — painted-vs-logical coordinate mapping', () 
     expect(ranges[0]).toMatchObject({ start: 3, end: 5, wordIndex: 1 });
   });
 });
+
+describe('BlankLoadingAnimator — recovery when the user types into the slot', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  // Regression: the animator gave up silently when the slot word stopped
+  // being a bare frame character, which orphaned its glyph in the buffer —
+  // the substitution path then had no `_` left to fill, so the blank could
+  // never resolve. Found on DeepSeek Harness, whose async write path widens
+  // the window, but the give-up path itself is host-agnostic.
+  it('peels its own glyph back out when the user types beside it (tick path)', () => {
+    const { adapter, setTextCalls, setBufferDirect } = makeAdapter('weather _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1);
+    vi.advanceTimersByTime(100);              // writes 'weather -'
+    expect(setTextCalls).toEqual(['weather -']);
+
+    setBufferDirect('weather -!!');           // user types `!!` right after the slot
+    vi.advanceTimersByTime(100);              // tick sees a non-frame word
+
+    expect(setTextCalls.at(-1)).toBe('weather _!!');
+    expect(a.active).toBe(false);             // still gives up, just cleanly
+  });
+
+  it('peels its own glyph back out on stop() too', () => {
+    const { adapter, setTextCalls, setBufferDirect } = makeAdapter('weather _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1);
+    vi.advanceTimersByTime(100);              // 'weather -'
+    setBufferDirect('weather -x');            // user typed into the slot word
+    a.stop(1);
+    expect(setTextCalls.at(-1)).toBe('weather _x');
+  });
+
+  it('leaves the buffer alone when the substitution path took the word', () => {
+    const { adapter, setTextCalls, setBufferDirect } = makeAdapter('weather _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1);
+    vi.advanceTimersByTime(100);              // 'weather -'
+    const before = setTextCalls.length;
+    setBufferDirect('weather 18°C');          // answer spliced in; no glyph left
+    vi.advanceTimersByTime(100);
+    expect(setTextCalls.length).toBe(before); // nothing written
+  });
+
+  it('never rewrites a character the user typed that merely looks like a frame', () => {
+    // Recovery matches the EXACT char this slot last wrote, not the frame
+    // set — bounce/flipper frames are ordinary ASCII, so a user's own `-`
+    // must survive untouched.
+    const { adapter, setTextCalls, setBufferDirect } = makeAdapter('weather _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1);
+    vi.advanceTimersByTime(100);              // last written: '-'
+    vi.advanceTimersByTime(100);              // last written: '‾'
+    const before = setTextCalls.length;
+    setBufferDirect('weather a-b');           // user text containing '-', but no '‾'
+    vi.advanceTimersByTime(100);
+    expect(setTextCalls.length).toBe(before); // untouched
+  });
+
+  it('rescues its glyph when an edit BEFORE the slot shifted every word index', () => {
+    // braille-rotate writes non-ASCII marks, so a single occurrence in the
+    // buffer is unambiguously ours even once the tracked index is wrong.
+    const { adapter, setTextCalls, setBufferDirect } = makeAdapter('weather _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'braille-rotate', frameIntervalMs: () => 100 });
+    a.start(1);
+    vi.advanceTimersByTime(100);              // 'weather ⠁'
+    setBufferDirect('X weather ⠁');           // user typed a word at the start
+    vi.advanceTimersByTime(100);              // index 1 is now 'weather'
+    expect(setTextCalls.at(-1)).toBe('X weather _');
+  });
+
+  it('refuses the displaced rescue for ASCII frames (user could have typed one)', () => {
+    const { adapter, setTextCalls, setBufferDirect } = makeAdapter('weather _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1);
+    vi.advanceTimersByTime(100);              // 'weather -'
+    const before = setTextCalls.length;
+    setBufferDirect('X weather -');           // shifted, but '-' is ambiguous
+    vi.advanceTimersByTime(100);
+    expect(setTextCalls.length).toBe(before); // left alone
+  });
+
+  it('refuses the displaced rescue when the glyph appears more than once', () => {
+    const { adapter, setTextCalls, setBufferDirect } = makeAdapter('weather _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'braille-rotate', frameIntervalMs: () => 100 });
+    a.start(1);
+    vi.advanceTimersByTime(100);              // 'weather ⠁'
+    const before = setTextCalls.length;
+    setBufferDirect('⠁ weather ⠁');           // user pasted the same mark
+    vi.advanceTimersByTime(100);
+    expect(setTextCalls.length).toBe(before); // ambiguous — untouched
+  });
+
+  it('does nothing when it never wrote a frame yet', () => {
+    const { adapter, setTextCalls, setBufferDirect } = makeAdapter('weather _');
+    const a = new BlankLoadingAnimator({ adapter, mode: () => 'bounce', frameIntervalMs: () => 100 });
+    a.start(1);
+    setBufferDirect('weather xy');            // user typed before the first tick
+    vi.advanceTimersByTime(100);
+    expect(setTextCalls).toEqual([]);
+  });
+});

--- a/packages/opencues-runtime/src/modules/blank-loading.ts
+++ b/packages/opencues-runtime/src/modules/blank-loading.ts
@@ -319,6 +319,10 @@ interface ActiveSlot {
   /** Index into `frames`. Starts at 0, ticks bump it; wraps to
    *  `loopStartIdx` (not 0) at end-of-array. */
   frameIdx: number;
+  /** The exact character this slot last wrote into the buffer, or null
+   *  before the first write. Give-up recovery uses it to undo OUR glyph
+   *  and nothing else — see `_recoverFromOverwrite`. */
+  lastWritten: string | null;
 }
 
 /**
@@ -494,6 +498,7 @@ export class BlankLoadingAnimator {
       frames,
       loopStartIdx: loopStartIdxFor(mode, customFramesPresent),
       frameIdx: 0,
+      lastWritten: null,
     });
     const modeTag = mode === 'custom'
       ? (customFramesPresent ? 'custom' : 'custom→braille-rotate (fallback)')
@@ -522,7 +527,7 @@ export class BlankLoadingAnimator {
     const slot = this._active.get(wordIndex);
     if (!slot) return;
     this._active.delete(wordIndex);
-    this._restoreUnderscore(wordIndex, slot.frames);
+    this._restoreUnderscore(slot);
     this._log(`BlankLoading: stop wordIndex=${wordIndex} owner=${owner}`);
     if (this._active.size === 0 && this._timer !== null) {
       clearInterval(this._timer);
@@ -543,7 +548,7 @@ export class BlankLoadingAnimator {
         const slot = this._active.get(idx);
         if (!slot) continue;
         this._active.delete(idx);
-        this._restoreUnderscore(idx, slot.frames);
+        this._restoreUnderscore(slot);
       }
       if (this._timer !== null) {
         clearInterval(this._timer);
@@ -569,6 +574,12 @@ export class BlankLoadingAnimator {
       // are also recognised (not just the built-in BOUNCE/BRAILLE
       // sets covered by ALL_FRAME_CHARS).
       if (!slot.frames.includes(word) && word !== '_') {
+        // Before giving up, undo OUR glyph if it is still sitting inside
+        // the word the user typed around (`▘` + `!!` → `▘!!`). Without
+        // this the frame character is orphaned in the buffer forever:
+        // the animator stops, and the substitution path can no longer
+        // find a `_` to splice into. See _recoverFromOverwrite.
+        this._recoverFromOverwrite(slot, word);
         this._dropQuiet(slot.wordIndex); continue;
       }
       // Advance frame and write. Wrap to loopStartIdx (not 0) so the
@@ -580,19 +591,84 @@ export class BlankLoadingAnimator {
       const nextChar = slot.frames[slot.frameIdx];
       if (nextChar === word) continue;        // unlikely (same-frame edge); no-op
       this._writeChar(slot.wordIndex, nextChar);
+      slot.lastWritten = nextChar;            // the one character we own
     }
+  }
+
+  /**
+   * Undo this slot's own glyph when the user typed INTO the slot word.
+   *
+   * The animator owns exactly one character: the frame it last wrote. If
+   * the word still contains that character, the rest of the word is the
+   * user's edit, so replacing that one occurrence with `_` restores the
+   * buffer to "what the user typed, with the blank still a blank" — which
+   * keeps the slot resolvable instead of stranding a spinner glyph.
+   *
+   * Deliberately narrow: it matches the EXACT character last written by
+   * THIS slot, not the frame set. Bounce and flipper frames are ordinary
+   * ASCII (`-`, `|`, `/`), so matching the whole set would rewrite a `-`
+   * the user typed themselves.
+   */
+  private _recoverFromOverwrite(slot: ActiveSlot, word: string): void {
+    const glyph = slot.lastWritten;
+    if (glyph === null || glyph === '_') return;   // nothing of ours in the buffer
+    const at = word.indexOf(glyph);
+    if (at !== -1) {
+      const restored = word.slice(0, at) + '_' + word.slice(at + glyph.length);
+      this._writeChar(slot.wordIndex, restored);
+      this._log(`BlankLoading: recovered overwritten slot wordIndex=${slot.wordIndex} ${JSON.stringify(word)} → ${JSON.stringify(restored)}`);
+      return;
+    }
+    // Our glyph is not in the tracked word at all. Either the substitution
+    // path took the word (nothing to do) or an edit BEFORE the slot shifted
+    // every word index, so we have been watching the wrong word while our
+    // glyph sits elsewhere in the buffer. Rescue it — but only on terms
+    // that cannot touch the user's own text.
+    this._rescueDisplacedGlyph(glyph);
+  }
+
+  /**
+   * Last-resort rescue for a glyph left behind when word indices shifted
+   * under the animator (text inserted before the slot).
+   *
+   * Two conditions make this safe, and both are required:
+   *   - the glyph is non-ASCII, so it is one of the braille / custom
+   *     marks, never a `-` or `|` the user could plausibly have typed
+   *     (bounce and flipper frames are deliberately excluded);
+   *   - it occurs EXACTLY ONCE in the buffer, so there is no ambiguity
+   *     about which occurrence is ours.
+   * Anything less certain is left alone: a stray glyph is a blemish, but
+   * rewriting a character the user typed is data loss.
+   */
+  private _rescueDisplacedGlyph(glyph: string): void {
+    const cp = glyph.codePointAt(0);
+    if (cp === undefined || cp < 128) return;      // ambiguous with user text
+    const text = this._adapter.getText();
+    const first = text.indexOf(glyph);
+    if (first === -1) return;
+    if (text.indexOf(glyph, first + glyph.length) !== -1) return;  // more than one
+    const restored = text.slice(0, first) + '_' + text.slice(first + glyph.length);
+    this._adapter.setText(restored);
+    this._adapter.forceRender?.();
+    this._log(`BlankLoading: rescued displaced glyph ${JSON.stringify(glyph)} at ${first}`);
   }
 
   /** Replace the word at wordIndex with `_`. Used on stop().
    *  Takes the slot's frames so custom-character animations restore
    *  correctly — without the per-slot set we'd refuse to restore any
    *  custom char and the loading glyph would stick. */
-  private _restoreUnderscore(wordIndex: number, slotFrames: readonly string[]): void {
-    const word = this._wordAt(wordIndex);
+  private _restoreUnderscore(slot: ActiveSlot): void {
+    const word = this._wordAt(slot.wordIndex);
     if (word === null) return;
-    if (!slotFrames.includes(word) && word !== '_') return;   // user / substitution took over
+    if (!slot.frames.includes(word) && word !== '_') {
+      // The word is no longer a bare frame char. Either the substitution
+      // path replaced it (nothing to do) or the user typed around our
+      // glyph, in which case recovery peels our one character back out.
+      this._recoverFromOverwrite(slot, word);
+      return;
+    }
     if (word === '_') return;                 // already `_`
-    this._writeChar(wordIndex, '_');
+    this._writeChar(slot.wordIndex, '_');
   }
 
   /** Word-aware splice: replace the word at wordIndex with `next`.


### PR DESCRIPTION
Type into a `_` slot while its blank is still in flight and the spinner character was left in the buffer for good:

```
the capital of france is ▘!!
```

The animator gives up whenever the slot's word stops being one of its frames — correct, since the substitution path is expected to take that word — but it gave up **without putting `_` back**. So the blank it was animating could never resolve either: there was no `_` left to splice into, and retyping doesn't help because the glyph is still sitting there.

## Two ways to reach it

**1. The user types beside the glyph.** The animator owns exactly one character — the frame it last wrote — so a slot now records it (`lastWritten`) and peels that single occurrence back out on give-up: `▘!!` → `_!!`, keeping the user's edit *and* the blank. Matching is on the exact character last written, never the frame set, because `bounce` and `flipper` frames are ordinary ASCII (`-`, `|`, `/`) and matching the set would rewrite a `-` the user typed themselves. Applies on the tick path and on `stop()`, which had the same hole.

**2. An edit before the slot shifts every word index.** The animator then watches the wrong word entirely while its glyph sits elsewhere, so neither the tracked word nor the give-up check ever sees it. A last-resort rescue scans the buffer under two conditions that together make it unambiguous: the glyph is non-ASCII (the braille and custom marks, so `bounce`/`flipper` are excluded by construction) and it occurs exactly once. Anything less certain is left alone — a stray glyph is a blemish, rewriting a character the user typed is data loss.

## How it was found

Wiring OpenCues onto DeepSeek Harness, whose composer writes are asynchronous (React), which widens the window enough to hit reliably. **The give-up path itself is host-agnostic** — every host can reach it, the window is just narrower.

A discriminating test separated the two causes rather than guessing:

| edit | before | after |
|---|---|---|
| adjacent to the slot | `the capital of france is ▘!!` | `the capital of france is _!!` |
| far from the slot (index shift) | `X the capital of spain is ▘` | rescued to `_` |
| no edit (control) | resolves to `Rome` | unchanged |

## Tests

Eight new `blank-loading.test.ts` cases: both recoveries, plus the three refusals that keep it safe — substitution took the word, ASCII frame is ambiguous, glyph appears twice. 91 pass in that file; 2252 pass across the runtime suite.

## Gate status

`scripts/pre-pr.sh` reports 2 of 20 gates red, both environmental on this machine:

- **test-hermeticity** — `--wsl outside of WSL exits 1` fails because this is a real WSL box (the test deletes the WSL env vars but detection still fires), plus `brightness-blank.sh` timing out at 5.86s against a 5s limit under parallel load. Both pass in isolation, with and without this change; `packages/opencues-cli` never references `blank-loading`.
- **doctor** — install-state drift only: chrome's `/mnt/c` mirror, `cues-llm-model: inherit` sentinels, and CC/OC/gemini forks at runtime 0.30.2 vs source 0.30.4. That last one is *produced by* this PR's version bump and clears on `opencues install <host>`.

Not run: the chrome E2E (`npm run test:e2e:chrome`), which is manual and worth a pass since `blank-loading` runs in chrome too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
