### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-17
+
 ### Fixed — a marketplace install of the dsh plugin shipped no browser half (`@opencues/dsh` 0.1.1 → 0.1.2)
 
 **The dsh plugin marketplaces do not install from npm.** They clone the repository and run `npm install --omit=dev --ignore-scripts` — with scripts disabled *by default*, for safety — then copy the result into the profile. Read out of `DSH-Plugins-Marketplace`'s `lib/index.js` rather than inferred from its prose; its own fallback message states the expectation outright: *"using the build artifacts committed in the repo"*.

--- a/integrations/dsh/CLAUDE.md
+++ b/integrations/dsh/CLAUDE.md
@@ -499,14 +499,15 @@ one dsh's own README endorses.
 | [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) (7.5k★) | [#1508](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/1508) | **The authoritative catalog.** One YAML at `data/plugins/opencues__opencues--integrations-dsh.yml`, then `npm ci && node scripts/generate-readme.mjs`. [dsh-market](https://github.com/dsh-market/dsh-market) reads its `plugins.json` daily, so this entry is what puts OpenCues in the in-dsh market — do not submit to dsh-market directly, it says so itself |
 | [0xsline/awesome-deepseek-harness](https://github.com/0xsline/awesome-deepseek-harness) (687★) | [#374](https://github.com/0xsline/awesome-deepseek-harness/pull/374) | Hand-edited README; **both `README.md` and `README.zh-CN.md` must be updated together**. Category: `Input & Editing` |
 | [Anil-matcha/awesome-dsh-plugin](https://github.com/Anil-matcha/awesome-dsh-plugin) (927★) | [#26](https://github.com/Anil-matcha/awesome-dsh-plugin/pull/26) | Single README, alphabetical within section, `—` separator. No input category; `UI Enhancements` is where composer plugins live |
+| [Dominic789654/awesome-deepseek-harness](https://github.com/Dominic789654/awesome-deepseek-harness) (123★) | [#122](https://github.com/Dominic789654/awesome-deepseek-harness/pull/122) | Requires a **`dsh`** topic rather than `dsh-plugin`. Both READMEs, different separators per language (` — ` en, ` —— ` zh). Category: `UI / Clients` |
 
-**Deliberately not submitted:**
-[Dominic789654/awesome-deepseek-harness](https://github.com/Dominic789654/awesome-deepseek-harness)
-requires a **`dsh`** topic, not `dsh-plugin`. GitHub caps a repo at 20 topics
-and `opencues/opencues` is at exactly 20 — `dsh-plugin` already cost us
-`gpt-oss`. Spending a second slot for one 123★ list is a judgement call, not
-an obvious win, so it is Wilfred's to make rather than something to do
-quietly.
+**The 20-topic cap is the thing to know here.** GitHub allows a repository
+twenty topics and `opencues/opencues` sits at exactly twenty, so every dsh
+topic was a swap, not an addition: `dsh-plugin` cost `gpt-oss`, and `dsh`
+(needed only by the list above) cost `chatgpt`. Adding a third would mean
+dropping something that earns its place, and `dsh-plugin` is the one that
+matters — it is what dsh's own README endorses and what every auto-collector
+scrapes. For scale: ~6,700 repos carry `dsh-plugin`, ~3,300 carry `dsh`.
 
 ### Why `client.js` is committed (the marketplaces do not use npm)
 


### PR DESCRIPTION
Cuts **v0.7.0** from the `[Unreleased]` wave, and fixes one stale note that shipped in #396.

## The release

`CHANGELOG.md`'s `[Unreleased]` becomes `## [0.7.0] - 2026-08-17` with a fresh empty `[Unreleased]` above it. `packages/opencues-cli/package.json` was already at `0.7.0` from the per-PR bumps, so nothing moves there — per the checklist, release THAT rather than editing it downward to tidy the sequence.

Six entries ship in it:

- **`harness` provider** — run OpenCues on the host's own model, with no OpenCues key
- **DeepSeek Harness integration** — the first integration that is a first-class plugin of its host rather than a patch or fork
- **`BuiltinBlankContext.fetchFn`** — a host can supply the transport its network blanks fetch through
- **`process.env.HOME`** — was killing every script-backed blank on a browser host
- **Page ownership** — two OpenCues hosts in one page were fighting over the buffer
- **The dsh clone-install fix** — a marketplace install shipped no browser half

## The stale note

`integrations/dsh/CLAUDE.md` recorded Dominic789654's list as *"deliberately not submitted"*, on the reasoning that a second topic slot was not worth spending. That decision was then reversed, `chatgpt` was swapped for `dsh`, and [their #122](https://github.com/Dominic789654/awesome-deepseek-harness/pull/122) is filed — so the doc contradicted what shipped. It now sits in the submitted table, keeping the part that is still true and still non-obvious: the 20-topic cap makes every dsh topic a **swap**, and `dsh-plugin` is the one that matters (~6,700 repos against ~3,300, and it is what the auto-collectors scrape).

## Checklist state

- `check-release-alignment --offline`: **CLI version matches the newest CHANGELOG release — 0.7.0**. The tag, npm, GitHub release and Homebrew lines are the ones this PR unblocks; they are steps 3-7 and happen after this merges.
- `npm whoami` → `wkasekende`, Docker up, so step 6's cold-install verification can actually run.
- Remaining `pre-pr.sh` failures are the known WSL-detection pair, which cannot pass on a WSL developer machine and do pass on CI.

**Merge with a merge commit**, then the tag goes on `master` after the merge — never before, or the tagged tree still says `[Unreleased]` and that is what every `npm i -g opencues` user clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)