### PR TITLE
chore(release): v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-08-18
+
 ### Added — nine default rules ship on the watchlist (`@opencues/core` 0.51.0 → 0.52.0, `@opencues/chrome` 0.2.173 → 0.2.174, `@opencues/dsh` 0.2.7 → 0.2.8)
 
 `opencues seed-configs` now seeds a `~/.cues/RULES.md` with nine always-on rules — the hard-and-fast floor: secrets never in code/config/logs, no real credentials pasted into chats or AI prompts, no committed `.env`, no destructive commands against production, no hand-edited production data, backup before anything irreversible, no skipping failing tests to green CI, no un-anonymized production data in dev, and no blanket unattended-destructive permissions for agents.
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 They flag, they never block, and they're yours: each cue dismisses with `_` like any other, the file is plain markdown you edit freely, and an edited file is never touched by re-seeding — the template says to empty the bullets rather than delete the file, since a deleted file reseeds on the next install. Existing installs receive the file on their next `opencues seed-configs` / `opencues install`; nine defaults leave fifteen watchlist slots for your own rules and session decisions.
 
-**`opencues rules` manages the set without opening an editor** (`opencues` 0.7.4 → 0.8.0): `list` shows the merged view in the runtime's own order — project file first, duplicates the dedupe will ignore marked as such — plus `add` (with the same newline/length refusals the dsh settings route uses: one bullet is one rule, not a smuggling channel), `remove <n|substring>` (surgical: one bullet line goes, prose survives; ambiguous substrings list the candidates instead of guessing), `path`, and `--json`. Parsing and editing are the same core functions the runtime ingest loads, so the command cannot drift from what the watchlist actually reads.
+**`opencues rules` manages the set without opening an editor** (`opencues` 0.7.4 → 0.7.5): `list` shows the merged view in the runtime's own order — project file first, duplicates the dedupe will ignore marked as such — plus `add` (with the same newline/length refusals the dsh settings route uses: one bullet is one rule, not a smuggling channel), `remove <n|substring>` (surgical: one bullet line goes, prose survives; ambiguous substrings list the candidates instead of guessing), `path`, and `--json`. Parsing and editing are the same core functions the runtime ingest loads, so the command cannot drift from what the watchlist actually reads.
 
 And a confession that became a test: the first manual verification of the seeding **wrote into the real `~/.cues`**, because `seed-configs` targets `os.homedir()` and only `OPENCUES.md` honours `$OPENCUES_HOME`. The committed tests are hermetic the way that mistake teaches — HOME and USERPROFILE both overridden — and pin the full contract: nine bullets on first seed, an edited file never touched, removal preserving prose, duplicate refusal, and the registry entry itself (removing `RULES.md` from `CORE_TEMPLATES` would silently unship the defaults, so a test fails if it goes).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -703,16 +703,16 @@ done
 |---|---|---|---|
 | `SPEC.md` (open-standard) | `cues-spec` | 0.11 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
-| `packages/opencues-core/` | `@opencues/core` | 0.46.0 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.31.2 | private |
-| `packages/opencues-cli/` | `opencues` (real CLI) | 0.7.2 | **PUBLISHED on npm** |
+| `packages/opencues-core/` | `@opencues/core` | 0.52.0 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.34.0 | private |
+| `packages/opencues-cli/` | `opencues` (real CLI) | 0.7.5 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.11 | private |
 | `integrations/opencode/` | `@opencues/opencode` | 0.2.15 | private |
-| `integrations/chrome/` | `@opencues/chrome` | 0.2.166 | private |
+| `integrations/chrome/` | `@opencues/chrome` | 0.2.174 | private |
 | `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.2.11 | private |
 | `integrations/shell/` | `@opencues/shell` | 0.2.21 | private |
 | `integrations/windows/` | `@opencues/windows` | 0.2.4 | private |
-| `integrations/dsh/` | `@opencues/dsh` | 0.1.2 | **PUBLISHABLE** — dsh installs plugins from npm |
+| `integrations/dsh/` | `@opencues/dsh` | 0.2.8 | **PUBLISHABLE** — dsh installs plugins from npm |
 
 The bare `opencues` name on npm is the real CLI (`packages/opencues-cli/`, **published** — v0.6.0 superseded the retired parking placeholder's v0.0.1; the old `packages/opencues-park/` source was deleted post-publish, July 2026). The npm org grants access via the `developers` team.
 

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.8.0",
+  "version": "0.7.5",
   "license": "Apache-2.0",
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "keywords": [


### PR DESCRIPTION
Release commit for v0.7.5 — CHANGELOG cut, cli version set (down from an unpublished 0.8.0 per the stay-<0.8 call), CLAUDE.md version map regenerated. `check-release-alignment --offline` green on every repo-local surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkegdvpTMwUndZR6q2gytr