### PR TITLE
chore(release): v0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7] - 2026-08-19
+
 ### Added — dsh serves company rules too (`@opencues/dsh` 0.2.12 → 0.2.13)
 
 `RULES.md` reached the DeepSeek Harness: the plugin's node half now merges project rules (from the **session's** workspace — never the dsh server's own cwd, the same trap this integration fixed once for the watchlist key) and user rules into the same route the browser polls, using the same core parser and merge the native ingest uses — so the route cannot drift from what native hosts serve. Verified live in the composer: "mirror the customer table to us-east-1" draws `⚠ Customer data must stay in eu-west-1` from a project rules file, the compliant phrasing stays silent, project beats user, cross-file duplicates collapse, and user-scope rules serve even before the first session kick. Chrome stays out deliberately — no filesystem, and the security posture prefers it that way.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -732,16 +732,16 @@ done
 |---|---|---|---|
 | `SPEC.md` (open-standard) | `cues-spec` | 0.11 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
-| `packages/opencues-core/` | `@opencues/core` | 0.52.0 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.34.0 | private |
-| `packages/opencues-cli/` | `opencues` (real CLI) | 0.7.5 | **PUBLISHED on npm** |
+| `packages/opencues-core/` | `@opencues/core` | 0.54.0 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.34.3 | private |
+| `packages/opencues-cli/` | `opencues` (real CLI) | 0.7.7 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.11 | private |
 | `integrations/opencode/` | `@opencues/opencode` | 0.2.15 | private |
-| `integrations/chrome/` | `@opencues/chrome` | 0.2.174 | private |
+| `integrations/chrome/` | `@opencues/chrome` | 0.2.178 | private |
 | `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.2.11 | private |
 | `integrations/shell/` | `@opencues/shell` | 0.2.21 | private |
 | `integrations/windows/` | `@opencues/windows` | 0.2.4 | private |
-| `integrations/dsh/` | `@opencues/dsh` | 0.2.8 | **PUBLISHABLE** — dsh installs plugins from npm |
+| `integrations/dsh/` | `@opencues/dsh` | 0.2.13 | **PUBLISHABLE** — dsh installs plugins from npm |
 
 The bare `opencues` name on npm is the real CLI (`packages/opencues-cli/`, **published** — v0.6.0 superseded the retired parking placeholder's v0.0.1; the old `packages/opencues-park/` source was deleted post-publish, July 2026). The npm org grants access via the `developers` team.
 


### PR DESCRIPTION
Release commit — CHANGELOG cut for the post-0.7.5 wave (animator fix, spelling-mark scope, DeepSeek + Kimi providers, RULES.md on dsh), version map regenerated. Alignment green on every repo-local surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkegdvpTMwUndZR6q2gytr