### PR TITLE
Fix README SVGs in light mode

### DIFF
--- a/assets/Hero-2.svg
+++ b/assets/Hero-2.svg
@@ -11,7 +11,13 @@
       }
 
       .cls-3 {
-        fill: #fff;
+        fill: #24292f;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-3 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>

--- a/assets/Hero-3.svg
+++ b/assets/Hero-3.svg
@@ -11,7 +11,13 @@
       }
 
       .cls-3 {
-        fill: #fff;
+        fill: #24292f;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-3 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>

--- a/assets/Hero.svg
+++ b/assets/Hero.svg
@@ -7,7 +7,13 @@
       }
 
       .cls-2 {
-        fill: #fff;
+        fill: #24292f;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-2 {
+          fill: #fff;
+        }
       }
 
       .cls-3 {

--- a/assets/OpenCues_logo.svg
+++ b/assets/OpenCues_logo.svg
@@ -3,7 +3,13 @@
   <defs>
     <style>
       .cls-1 {
-        fill: #fff;
+        fill: #24292f;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-1 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>


### PR DESCRIPTION
## Summary

The SVG assets for the README don't work in light mode—it's white text on white background.  This PR makes the images theme-aware so they show dark gray/black in light mode and the current white in dark mode.

## Type of change

- [ ] Config change (CUES.md, BLANKS.md, controls)
- [ ] opencues-core change (TypeScript library)
- [ ] Integration change (patches, editor-specific code)
- [x] Documentation
- [ ] New feature
- [ ] Bug fix

## Testing

<!-- How did you verify this works? -->

- [ ] Ran `setup.sh` and restarted Claude Code
- [x] Tested manually (the README looks good :white_check_mark: )
- [ ] Ran `npm test` in `packages/opencues-core` (if opencues-core change)

## Notes

I'm going to have to open a second PR (after this one is merged) to correct the commit hash in the README so that it points to the current commit hash.
