### PR TITLE
fix(assets): theme-aware README SVGs — black in light mode + jsDelivr pin bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
      URLs to that new commit. -->
 
 <div align="right">
-  <a href="#"><img width="180" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/OpenCues_logo.svg"></a>
+  <a href="#"><img width="180" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/opencues/opencues@62dc0d205460b8610dd4825be196e01ef281dc7a/assets/OpenCues_logo.svg"></a>
 </div>
 
 <br><br>
 
 <div align="center">
-  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/Hero.svg"></a>
+  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/opencues/opencues@62dc0d205460b8610dd4825be196e01ef281dc7a/assets/Hero.svg"></a>
 </div>
 
 <br><br>
@@ -97,7 +97,7 @@ fork to pin and no OpenCues CLI step — see
 
 #
 
-<p align="left"><a href="#integrations"><img width="91" alt="Supports:" src="assets/supports.svg"></a><a href="integrations/opencode/README.md"><img width="129" alt="OpenCode" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/Supports-09.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/spacer.svg"><a href="integrations/claude-code/README.md"><img width="144" alt="Claude Code" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/Supports-10.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/spacer.svg"><a href="integrations/gemini-cli/README.md"><img width="126" alt="Gemini CLI" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/Supports-11.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/spacer.svg"><a href="integrations/chrome/README.md"><img width="130" alt="Chrome" src="assets/chrome.svg"></a><a href="integrations/shell/README.md"><img width="82" alt="Shell" src="assets/shell.svg"></a></p>
+<p align="left"><a href="#integrations"><img width="91" alt="Supports:" src="assets/supports.svg"></a><a href="integrations/opencode/README.md"><img width="129" alt="OpenCode" src="https://cdn.jsdelivr.net/gh/opencues/opencues@62dc0d205460b8610dd4825be196e01ef281dc7a/assets/Supports-09.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/spacer.svg"><a href="integrations/claude-code/README.md"><img width="144" alt="Claude Code" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/Supports-10.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/spacer.svg"><a href="integrations/gemini-cli/README.md"><img width="126" alt="Gemini CLI" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/Supports-11.svg"></a><img width="24" alt="" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/spacer.svg"><a href="integrations/chrome/README.md"><img width="130" alt="Chrome" src="assets/chrome.svg"></a><a href="integrations/shell/README.md"><img width="82" alt="Shell" src="assets/shell.svg"></a></p>
 
 <br><br><br><br>
 
@@ -128,7 +128,7 @@ hosts have made, across features, so the total isn't a guess.
 # Configuration & LLM providers
 
 <div align="center">
-  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/Hero-2.svg"></a>
+  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/opencues/opencues@62dc0d205460b8610dd4825be196e01ef281dc7a/assets/Hero-2.svg"></a>
 </div>
 
 <br>
@@ -169,7 +169,7 @@ Full threat model: [`docs/architecture/security-audit.md`](docs/architecture/sec
 # Contributing
 
 <div align="center">
-  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/opencues/opencues@43ac7ab68de968a183aa0340593aac926f26587a/assets/Hero-3.svg"></a>
+  <a href="#"><img width="600" alt="OpenCues" src="https://cdn.jsdelivr.net/gh/opencues/opencues@62dc0d205460b8610dd4825be196e01ef281dc7a/assets/Hero-3.svg"></a>
 </div>
 
 <br>

--- a/assets/Hero-2.svg
+++ b/assets/Hero-2.svg
@@ -11,7 +11,13 @@
       }
 
       .cls-3 {
-        fill: #fff;
+        fill: #000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-3 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>

--- a/assets/Hero-3.svg
+++ b/assets/Hero-3.svg
@@ -11,7 +11,13 @@
       }
 
       .cls-3 {
-        fill: #fff;
+        fill: #000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-3 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>

--- a/assets/Hero.svg
+++ b/assets/Hero.svg
@@ -7,7 +7,13 @@
       }
 
       .cls-2 {
-        fill: #fff;
+        fill: #000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-2 {
+          fill: #fff;
+        }
       }
 
       .cls-3 {

--- a/assets/OpenCues_logo.svg
+++ b/assets/OpenCues_logo.svg
@@ -3,7 +3,13 @@
   <defs>
     <style>
       .cls-1 {
-        fill: #fff;
+        fill: #000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-1 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>

--- a/assets/Supports-09.svg
+++ b/assets/Supports-09.svg
@@ -7,7 +7,13 @@
       }
 
       .cls-2 {
-        fill: #fff;
+        fill: #000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-2 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>

--- a/assets/ollama.svg
+++ b/assets/ollama.svg
@@ -7,7 +7,13 @@
       }
 
       .cls-2 {
-        fill: #fff;
+        fill: #000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-2 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>

--- a/assets/openai.svg
+++ b/assets/openai.svg
@@ -7,7 +7,13 @@
       }
 
       .cls-2 {
-        fill: #fff;
+        fill: #000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-2 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>

--- a/assets/opencode.svg
+++ b/assets/opencode.svg
@@ -7,7 +7,13 @@
       }
 
       .cls-2 {
-        fill: #fff;
+        fill: #000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-2 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>

--- a/assets/opencues-cli.svg
+++ b/assets/opencues-cli.svg
@@ -7,7 +7,13 @@
       }
 
       .cls-2 {
-        fill: #fff;
+        fill: #000;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .cls-2 {
+          fill: #fff;
+        }
       }
     </style>
   </defs>


### PR DESCRIPTION
## Summary

The README's SVG assets were white text / white badge dots on a transparent background, invisible on GitHub's light theme. This makes every affected fill theme-aware: **`#000` in light mode**, `#fff` in dark mode via an embedded `prefers-color-scheme: dark` media query (evaluated by the browser even when the SVG loads through `<img>`/camo).

Supersedes #411, with two differences:
- True black instead of `#24292f`, per maintainer preference.
- Includes the **jsDelivr pin bump in the same PR** — the first commit changes the SVGs, the second repoints the five CDN-served URLs (`OpenCues_logo`, `Hero`, `Hero-2`, `Hero-3`, `Supports-09`) from `43ac7ab` to that first commit's SHA (`62dc0d20`). Commit-pinned jsDelivr URLs are immutable, so without the bump the fix would never render. Unchanged assets keep their existing pins.

Also fixes the same white-fill bug class in the badge SVGs (`opencues-cli`, `opencode`, `openai`, `ollama`, `Supports-09`) — their white circle dot vanished in light mode. `openai.svg` and `opencues-cli.svg` are referenced by relative path so they need no pin bump; `opencode.svg` / `ollama.svg` aren't referenced by the root README but carried the same bug.

## Type of change

- [x] Documentation

## Testing

- [x] Verified each file's only remaining `fill: #fff` sits inside the dark-mode media query
- [x] Verified exactly the five changed CDN assets moved to the new pin (`grep -oE 'opencues@[0-9a-f]+/assets/.*\.svg'`)
- Preview before merge: `https://cdn.jsdelivr.net/gh/opencues/opencues@62dc0d205460b8610dd4825be196e01ef281dc7a/assets/Hero.svg` and toggle the OS light/dark setting

## Notes

- ⚠️ **Merge with a merge commit, not squash** — the README pins commit `62dc0d20` by SHA; squashing would orphan it and eventually break the CDN URLs (same standing rule that protects `43ac7ab`).
- These media queries follow the **OS/browser color scheme**, not GitHub's appearance setting — same limitation as GitHub's official `<picture>` approach. Test by toggling the OS theme, not the GitHub theme toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGsNaNbPsW28iY1LshmmLN