### PR TITLE
chore: version-map table catches up to oc/shell 0.2.17/0.2.23

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,10 +736,10 @@ done
 | `packages/opencues-runtime/` | `@opencues/runtime` | 0.38.0 | private |
 | `packages/opencues-cli/` | `opencues` (real CLI) | 0.7.7 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.11 | private |
-| `integrations/opencode/` | `@opencues/opencode` | 0.2.16 | private |
+| `integrations/opencode/` | `@opencues/opencode` | 0.2.17 | private |
 | `integrations/chrome/` | `@opencues/chrome` | 0.2.200 | private |
 | `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.2.11 | private |
-| `integrations/shell/` | `@opencues/shell` | 0.2.22 | private |
+| `integrations/shell/` | `@opencues/shell` | 0.2.23 | private |
 | `integrations/windows/` | `@opencues/windows` | 0.2.4 | private |
 | `integrations/dsh/` | `@opencues/dsh` | 0.2.17 | **PUBLISHABLE** — dsh installs plugins from npm |
 


### PR DESCRIPTION
Two-line snapshot fix flagged by `check-release-alignment` after #421 merged: the CLAUDE.md version-map table was resolved before the renumber pass split the duplicate oc/shell bump claims into two honest bumps. Alignment: 0 disagreements after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Berhbdh47bWswfYcyEP21S