### PR TITLE
chore(release): v0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8] - 2026-08-29
+
 ### Removed — glimmer's real-write machinery deleted (`@opencues/runtime` 0.37.0 → 0.38.0, `@opencues/chrome` 0.2.199 → 0.2.200, `@opencues/dsh` 0.2.16 → 0.2.17 — inline bundle regenerated)
 
 With the OpenTUI overlay mode live-verified on both hosts (entry below), the write-mode code is gone rather than dormant: `GlimmerRenderOptions.realWrite`, `_writeFrame`, the restore-on-cancel branch, `ActiveGlimmer.bufferedText`, `BuildSharedRuntimeOptions.glimmerRealWrite`, and the 9 write-mode tests. `locate()` simplifies to anchoring on `finalText` (the buffer is never written, so the landed text is always the anchor). `HostAdapter.markRuntimeWrite` stays — it's the general host contract for out-of-band buffer writers (blank-loading still uses the host-side reclassifier path), only its glimmer consumer died. `glimmer-realwrite-extension-plan.md` carries a superseded banner as the design record. Chrome band's dead `glimmerRealWrite: undefined` line removed (bundle bytes change → lockstep bump).

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "license": "Apache-2.0",
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "keywords": [


### PR DESCRIPTION
Release commit for v0.7.8: CLI 0.7.7 → 0.7.8, CHANGELOG `[Unreleased]` promoted to `## [0.7.8] - 2026-08-29` with a fresh empty `[Unreleased]` above it.

The wave: glimmer transition rework (host-owned Highlight-API engine on chrome, display-only overlay on OpenCode + shell, 900ms default, real-write machinery deleted), replace-parse separator handling (#424), chrome popup defer race + chrome-host diagnostics (#423).

`check-release-alignment.cjs` pre-check: only the four surfaces this release pass ships (site changelog, npm, GitHub release, Homebrew) disagree; spec 0.11 + module maps green. Tag → publish → release → brew → site follow after merge per versioning.md § How to cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Berhbdh47bWswfYcyEP21S