### PR TITLE
fix(cc): viewport scroll unpainted tall spans; doctor sweeps dead statusLine scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — CC viewport scroll silently unpainted every span taller than the input zone (`@opencues/runtime` 0.38.1 → 0.38.2)
+
+`draft email _` produced a correct multi-line rewrite whose span never went grey and looked unselectable. Root cause (reproduced identically on CC 2.1.206 and 2.1.236 — a runtime bug, not a host-version one): CC renders tall buffers through a **scrolled viewport**, and the S3 seam hands `applyRender` only the visible lines, while DynDef spans, highlight state and cue spans are all in full-buffer coordinates. The render ctx was built from the slice, so every scrolled span failed DimRender's stale-def guard (`defSpanLive` — the guard that stops dim leaking onto new text) and dropped its dim, inline note, and highlight. Short buffers fit the viewport, which is why every harness scenario and everyday transform looked fine.
+
+Fix in the CC band (`adapters/cc/v2.1/viewport.ts` + `boot.ts:applyRender`): locate the rendered slice inside the full buffer (handles CC's one-space cursor-cell pad; ambiguity resolves toward the occurrence containing the caret), hand handlers the FULL text so spans validate, then translate every directive family (dim/markdown/colored ranges, highlight, inlineNote, the glimmer whole-buffer `textOverride`) back into slice coordinates, clipping off-screen ranges. No contiguous match (soft-wrap inserts, mid-render mutation) → pre-fix behaviour byte-for-byte. Pinned by `viewport.test.ts` + boot-level scenario tests (scrolled slice paints dim; pad-space handled; fully off-screen span paints nothing; fallback never throws); verified live on an isolated fork against the original `draft an email _` repro.
+
+### Added — `opencues doctor` sweeps every CC project for dead statusLine scripts (`opencues` CLI 0.7.9 → 0.7.10)
+
+A project-level `.claude/settings.json` statusLine SHADOWS the user-level one for CC sessions launched from that directory — and a stale entry (e.g. the retired `~/claude-code-cues` layout from before the compact-footprint move) means "no statusline, only in this one project", invisible to a cwd-scoped doctor run (Sep 2026: `~/testing` carried exactly this for three months). `cc-statusline.cjs` gains `commandScriptExists` (tri-state over shell command strings — absolute-path tokens stat'd, bare `$PATH` commands never judged) and `auditProjectStatuslines` (walks CC's own `~/.claude.json` project registry); doctor surfaces each dead entry as a warn row naming the directory, with the rewrite-vs-edit fix per whether the dead path is ours.
+
 ### Added — Cerebras `qwen-3.8-27b` first-class; `gemma-4-31b` deprecated by Cerebras (`@opencues/core` 0.56.1 → 0.57.0, `@opencues/runtime` 0.38.0 → 0.38.1, `opencues` CLI 0.7.8 → 0.7.9)
 
 Cerebras shipped `qwen-3.8-27b` (probed live 2026-09-03 on `/v1/models`) and moved `gemma-4-31b` to Public preview (deprecated — still served, kept here for back-compat, no longer advised). qwen is now in cerebras's `knownModels`, selectable via the config menu, `blanks-llm-model: qwen-3.8-27b`, or natural language (`use qwen for blanks _` — new fluid-config alias at parity with `gemma`/`haiku`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -733,8 +733,8 @@ done
 | `SPEC.md` (open-standard) | `cues-spec` | 0.11 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
 | `packages/opencues-core/` | `@opencues/core` | 0.57.0 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.38.1 | private |
-| `packages/opencues-cli/` | `opencues` (real CLI) | 0.7.9 | **PUBLISHED on npm** |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.38.2 | private |
+| `packages/opencues-cli/` | `opencues` (real CLI) | 0.7.10 | **PUBLISHED on npm** |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.11 | private |
 | `integrations/opencode/` | `@opencues/opencode` | 0.2.17 | private |
 | `integrations/chrome/` | `@opencues/chrome` | 0.2.200 | private |

--- a/packages/opencues-cli/package.json
+++ b/packages/opencues-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencues",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "license": "Apache-2.0",
   "description": "OpenCues enables native AI integration anywhere you type. Model agnostic and fully open source. Inline agents and prompting.",
   "keywords": [

--- a/packages/opencues-cli/src/commands/doctor.cjs
+++ b/packages/opencues-cli/src/commands/doctor.cjs
@@ -570,6 +570,29 @@ module.exports = async function doctor(argv, ctx) {
           s.bad(`statusLine (project) — settings.json unreadable`, false);
         }
       }
+
+      // ── Dead statusLine scripts, machine-wide ─────────────────────
+      // A project-level statusLine SHADOWS the user-level one for any CC
+      // session launched from that directory — and doctor only inspects
+      // the cwd, so a stale entry elsewhere is invisible until the user
+      // wonders why "there is no statusline" in exactly one project
+      // (Sep 2026: ~/testing/.claude/settings.json still pointed at the
+      // retired ~/claude-code-cues layout, months after the compact-
+      // footprint move). Sweep every project CC has registered in
+      // ~/.claude.json and flag commands whose script no longer exists.
+      // Existence-only check: custom (non-opencues) commands that exist
+      // are respected and never flagged.
+      const dead = ccsl.auditProjectStatuslines();
+      for (const row of dead) {
+        s.bad(`statusLine (${row.dir}) — script missing`, false);
+        findings.push({
+          sev: 'warn',
+          msg: `statusLine.command in ${row.file} points at a script that no longer exists (${row.cmd})${row.opencues ? ' — a retired opencues install path' : ''}. CC sessions launched from ${row.dir} render NO statusline.`,
+          fix: row.opencues
+            ? `cd ${row.dir} && opencues statusline enable --project --force   # rewrite to the current install`
+            : `edit ${row.file} — fix or remove the statusLine block`,
+        });
+      }
     } catch { /* cc-statusline lib unavailable — non-fatal */ }
     // (No statusline-dependency warning for session-contradiction / ask-cues:
     // the CC boot band now kicks the producer itself via a transcript poller —

--- a/packages/opencues-cli/src/lib/cc-statusline.cjs
+++ b/packages/opencues-cli/src/lib/cc-statusline.cjs
@@ -196,6 +196,59 @@ function disable(scope, opts = {}) {
   return { ok: true, action: 'cleared', message: `Cleared statusLine from ${info.file} (was: ${info.currentCmd}; backup at ${info.file}.bak.cues-statusline)` };
 }
 
+// Does the script a statusLine.command points at actually exist?
+// The command is a shell string ("bash /path/x.sh", "/path/x.sh --flag"),
+// so we stat every absolute-path token. Tri-state:
+//   'exists'  — at least one absolute-path token resolves
+//   'missing' — absolute-path token(s) present, none resolve (the
+//               dead-script class: a retired fork layout like
+//               ~/claude-code-cues left settings pointing at nothing,
+//               and CC silently paints NO statusline — Sep 2026)
+//   'unknown' — no absolute-path token (bare command on $PATH); not ours
+//               to judge, never flag.
+function commandScriptExists(cmd) {
+  if (typeof cmd !== 'string' || !cmd.trim()) return 'unknown';
+  const home = os.homedir();
+  const tokens = cmd.split(/\s+/).map((t) => t.replace(/^["']|["']$/g, ''));
+  const pathTokens = tokens
+    .map((t) => (t.startsWith('~/') ? path.join(home, t.slice(2)) : t))
+    .filter((t) => path.isAbsolute(t));
+  if (pathTokens.length === 0) return 'unknown';
+  return pathTokens.some((t) => fs.existsSync(t)) ? 'exists' : 'missing';
+}
+
+// Machine-wide sweep for dead statusLine commands. CC registers every
+// project dir it has run in under ~/.claude.json `projects`; each may
+// carry its own .claude/settings.json whose statusLine SHADOWS the
+// user-level one for sessions launched there. A stale entry (e.g. the
+// retired ~/claude-code-cues layout) means "no statusline, only in this
+// one directory" — invisible to a cwd-scoped doctor run. Returns only
+// the broken rows: { dir, file, cmd, opencues } with cmd's script missing.
+function auditProjectStatuslines() {
+  const out = [];
+  let reg;
+  try {
+    reg = JSON.parse(fs.readFileSync(path.join(os.homedir(), '.claude.json'), 'utf8'));
+  } catch {
+    return out; // no registry / unreadable — nothing to sweep
+  }
+  for (const dir of Object.keys(reg?.projects ?? {})) {
+    const file = path.join(dir, '.claude', 'settings.json');
+    let data;
+    try {
+      data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    } catch {
+      continue; // no project settings / unreadable — the cwd-scoped row covers parse errors
+    }
+    const cmd = data?.statusLine?.command;
+    if (typeof cmd !== 'string' || !cmd) continue;
+    if (commandScriptExists(cmd) === 'missing') {
+      out.push({ dir, file, cmd, opencues: isOpenCuesPath(cmd) });
+    }
+  }
+  return out;
+}
+
 module.exports = {
   resolveStatuslineScript,
   isOpenCuesPath,
@@ -203,4 +256,6 @@ module.exports = {
   inspect,
   enable,
   disable,
+  commandScriptExists,
+  auditProjectStatuslines,
 };

--- a/packages/opencues-cli/src/lib/cc-statusline.test.cjs
+++ b/packages/opencues-cli/src/lib/cc-statusline.test.cjs
@@ -267,3 +267,72 @@ test('enable: refuses to touch broken JSON file', () => {
     assert.strictEqual(fs.readFileSync(settings, 'utf8'), 'not json {{{');
   });
 });
+
+// ── commandScriptExists + auditProjectStatuslines (Sep 2026) ─────────
+// The dead-script class: a project-level statusLine pointing at a script
+// from a retired install layout renders NO statusline for CC sessions in
+// exactly that directory, silently. These pin the tri-state existence
+// check and the ~/.claude.json machine-wide sweep.
+
+test('commandScriptExists: tri-state over shell command strings', () => {
+  const home = tmpdir('cse');
+  const script = path.join(home, 'x.sh');
+  fs.writeFileSync(script, '#!/bin/sh\n');
+  // bare absolute path
+  assert.strictEqual(lib.commandScriptExists(script), 'exists');
+  assert.strictEqual(lib.commandScriptExists(path.join(home, 'nope.sh')), 'missing');
+  // interpreter-prefixed + args
+  assert.strictEqual(lib.commandScriptExists(`bash ${script} --flag`), 'exists');
+  assert.strictEqual(lib.commandScriptExists(`bash ${home}/nope.sh --flag`), 'missing');
+  // quoted path
+  assert.strictEqual(lib.commandScriptExists(`"${script}"`), 'exists');
+  // ~/ expansion
+  withHome(home, () => {
+    assert.strictEqual(lib.commandScriptExists('~/x.sh'), 'exists');
+    assert.strictEqual(lib.commandScriptExists('~/nope.sh'), 'missing');
+  });
+  // bare $PATH command — not ours to judge
+  assert.strictEqual(lib.commandScriptExists('starship prompt'), 'unknown');
+  assert.strictEqual(lib.commandScriptExists(''), 'unknown');
+  assert.strictEqual(lib.commandScriptExists(undefined), 'unknown');
+});
+
+test('auditProjectStatuslines: flags only dead scripts across the registry', () => {
+  const home = tmpdir('audit');
+  const liveDir = path.join(home, 'proj-live');
+  const deadDir = path.join(home, 'proj-dead');
+  const bareDir = path.join(home, 'proj-bare');
+  const noneDir = path.join(home, 'proj-none');
+  const liveScript = path.join(home, 'live.sh');
+  fs.writeFileSync(liveScript, '#!/bin/sh\n');
+  const mkSettings = (dir, statusLine) => {
+    fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.claude', 'settings.json'),
+      JSON.stringify(statusLine ? { statusLine } : {}));
+  };
+  mkSettings(liveDir, { type: 'command', command: liveScript });
+  // The exact Sep 2026 shape — retired ~/claude-code-cues layout:
+  mkSettings(deadDir, { type: 'command', command: path.join(home, 'claude-code-cues', '.cues', 'statusline.sh') });
+  mkSettings(bareDir, { type: 'command', command: 'starship prompt' });
+  mkSettings(noneDir, null);
+  fs.writeFileSync(path.join(home, '.claude.json'), JSON.stringify({
+    projects: {
+      [liveDir]: {}, [deadDir]: {}, [bareDir]: {}, [noneDir]: {},
+      [path.join(home, 'gone-dir')]: {}, // registered dir that no longer exists
+    },
+  }));
+  withHome(home, () => {
+    const rows = lib.auditProjectStatuslines();
+    assert.strictEqual(rows.length, 1);
+    assert.strictEqual(rows[0].dir, deadDir);
+    assert.ok(rows[0].cmd.endsWith('/.cues/statusline.sh'));
+    assert.strictEqual(rows[0].opencues, true);
+  });
+});
+
+test('auditProjectStatuslines: no registry → empty, never throws', () => {
+  const home = tmpdir('noreg');
+  withHome(home, () => {
+    assert.deepStrictEqual(lib.auditProjectStatuslines(), []);
+  });
+});

--- a/packages/opencues-runtime/adapters/cc/v2.1/boot.test.ts
+++ b/packages/opencues-runtime/adapters/cc/v2.1/boot.test.ts
@@ -219,4 +219,77 @@ describe('boot()', () => {
     expect(result.dynDefs.size).toBe(0);
     expect(result.hlState.active).toBe(false);
   });
+
+  // ── Viewport-slice rendering (the "draft email _ doesn't go grey" bug,
+  // Sep 2026). CC hands applyRender only the VISIBLE lines of a tall
+  // buffer; spans are full-buffer coords. Pre-fix, the ctx was built from
+  // the slice, DimRender's stale-def guard rejected every scrolled span,
+  // and a tall transform-blank rewrite lost its dim + inline note. These
+  // pin the SCENARIO at the boot-result level (fake host, real modules).
+  describe('viewport-slice rendering', () => {
+    // A transform-blank-shaped rewrite taller than the input zone: the
+    // host scrolls, S3 hands applyRender only the tail lines.
+    const FULL = 'AAA first line\n\nBBB middle line\n\nCCC last line';
+    const SLICE = FULL.slice(FULL.indexOf('BBB')); // first line scrolled off
+
+    function bootWithSpanDef(text: string) {
+      const host = fakeHost(text);
+      const result = boot(host);
+      result.dynDefs.set(0, {
+        originalWord: text,
+        blankName: 'transform-blank',
+        alternatives: [text, 'draft email _'],
+        currentIndex: 0,
+        spanStart: 0,
+        spanEnd: text.length,
+        clearOnEdit: true,
+      });
+      return { host, result };
+    }
+
+    it('scrolled slice still paints the span dim (ranges translated to slice coords)', () => {
+      const { result } = bootWithSpanDef(FULL);
+      const out = result.applyRender(SLICE, FULL, FULL.length) as string;
+      // The span [0, FULL.length) covers the whole slice → dim codes present,
+      // and never beyond the slice's own length.
+      expect(out).not.toBe(SLICE);
+      expect(out).toContain('\x1b[2m'); // ANSI dim on
+    });
+
+    it('scrolled slice with the CC cursor-cell pad space still translates', () => {
+      const { result } = bootWithSpanDef(FULL);
+      const out = result.applyRender(SLICE + ' ', FULL, FULL.length) as string;
+      expect(out).toContain('\x1b[2m');
+    });
+
+    it('unscrolled buffer behaves exactly as before (span dims at full coords)', () => {
+      const { result } = bootWithSpanDef('short span');
+      const out = result.applyRender('short span', 'short span', 0) as string;
+      expect(out).toContain('\x1b[2m');
+    });
+
+    it('non-contiguous slice falls back to pre-fix behaviour (no crash, no phantom dim)', () => {
+      const { result } = bootWithSpanDef(FULL);
+      // Simulate soft-wrap: the rendered text has an inserted newline the
+      // buffer doesn't contain → slice can't be located → legacy ctx.
+      const wrapped = 'CCC last\nline';
+      expect(() => result.applyRender(wrapped, FULL, 0)).not.toThrow();
+    });
+
+    it('span entirely above the viewport paints nothing into the slice', () => {
+      const host = fakeHost(FULL);
+      const result = boot(host);
+      result.dynDefs.set(0, {
+        originalWord: 'AAA',
+        blankName: 'transform-blank',
+        alternatives: ['AAA', 'ZZZ'],
+        currentIndex: 0,
+        spanStart: 0,
+        spanEnd: 3, // covers only the scrolled-off first line
+        clearOnEdit: true,
+      });
+      const out = result.applyRender(SLICE, FULL, FULL.length) as string;
+      expect(out).toBe(SLICE); // off-screen span → no codes injected into the slice
+    });
+  });
 });

--- a/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
+++ b/packages/opencues-runtime/adapters/cc/v2.1/boot.ts
@@ -14,6 +14,7 @@ import { Runtime } from '../../../src/runtime';
 import { buildBootApiKeys, pickAutoProvider } from '@opencues/core';
 import { ClaudeCodeV21Adapter, type HostBindings, normaliseKeyEvent, toggleZeroWidth } from './adapter';
 import { installMacDoubleEscStdinRewrite } from '../../../src/modules/mac-keyboard';
+import { locateViewportSlice, translateDirectivesToViewport } from './viewport';
 import { Navigation } from '../../../src/modules/navigation';
 import { DimRender } from '../../../src/modules/dim-render';
 import { Cycling } from '../../../src/modules/cycling';
@@ -1037,7 +1038,21 @@ export function boot(host: HostInfo): BootResult {
       // text-change side; this is the symmetric strip for the render
       // side. Keep the two boundaries in sync.
       const visibleText = rendered.replace(/\x1b\[[0-9;]*m/g, '');
-      const ctxText = visible(visibleText);
+      const sliceText = visible(visibleText);
+      // VIEWPORT translation (Sep 2026): CC renders tall buffers through a
+      // scrolled viewport — `rendered` is only the visible lines, while
+      // every span (DynDefs, cues, highlight) is in FULL-buffer coords.
+      // Building ctx from the slice made scrolled spans fail DimRender's
+      // stale-def guard and lose their dim/note ("draft email _ doesn't go
+      // grey"). Locate the slice inside the full buffer, hand handlers the
+      // FULL text, and translate directive ranges back into slice coords.
+      // No contiguous match (soft-wrap inserts, mid-render mutation) →
+      // pre-fix behaviour unchanged. See viewport.ts.
+      const fullText = visible(text);
+      const match = sliceText === fullText
+        ? { offset: 0, length: fullText.length }
+        : locateViewportSlice(fullText, sliceText, cursorOffset);
+      const ctxText = match ? fullText : sliceText;
       const ctx: RenderContext = {
         text: ctxText,
         cursor: cursorOffset,
@@ -1047,7 +1062,10 @@ export function boot(host: HostInfo): BootResult {
       const debugDirectives: unknown[] = [];
       for (const handler of renderHandlers) {
         try {
-          const directives = handler(ctx);
+          let directives = handler(ctx);
+          if (directives && match) {
+            directives = translateDirectivesToViewport(directives, match.offset, match.length, fullText.length);
+          }
           if (directives) {
             debugDirectives.push(directives);
             out = applyDirectives(out, directives, CC_INPUT_FIRST_LINE_INDENT);
@@ -1057,13 +1075,15 @@ export function boot(host: HostInfo): BootResult {
         }
       }
       if (isDebugEnabled()) {
-        const zwsStripped = visibleText.length - ctxText.length;
+        const zwsStripped = visibleText.length - sliceText.length;
         log('debug', 'applyRender', {
           textLen: text.length,
           visibleLen: visibleText.length,
           ctxLen: ctxText.length,
+          sliceLen: sliceText.length,
+          viewportOffset: match ? match.offset : null,
           zwsStripped,
-          visiblePreview: ctxText.slice(0, 60),
+          visiblePreview: sliceText.slice(0, 60),
           hlActive: hlState.active,
           hlWordIdx: hlState.wordIndex,
           directives: debugDirectives,

--- a/packages/opencues-runtime/adapters/cc/v2.1/viewport.test.ts
+++ b/packages/opencues-runtime/adapters/cc/v2.1/viewport.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { locateViewportSlice, translateDirectivesToViewport } from './viewport';
+import type { RenderDirectives } from '../../../src/adapter';
+
+// The bug these pin (Sep 2026): CC renders tall buffers through a scrolled
+// viewport; building the render ctx from the slice made full-buffer spans
+// read as stale and lose their dim ("draft email _ doesn't go grey" —
+// reproduced identically on CC 2.1.206 and 2.1.236).
+
+const EMAIL = 'Subject: [Subject]\n\nDear [Recipient],\n\n[Body]\n\nBest regards,\nWilfred';
+
+describe('locateViewportSlice', () => {
+  it('full text renders as-is → offset 0, full length', () => {
+    expect(locateViewportSlice(EMAIL, EMAIL, 0)).toEqual({ offset: 0, length: EMAIL.length });
+  });
+
+  it('scrolled slice (first line off-screen) → mid-buffer offset', () => {
+    const slice = EMAIL.slice(18); // "\nDear [Recipient],..."
+    expect(locateViewportSlice(EMAIL, slice, EMAIL.length)).toEqual({ offset: 18, length: slice.length });
+  });
+
+  it('CC cursor-cell pad: exactly ONE trailing space not in the buffer still matches', () => {
+    expect(locateViewportSlice('HELLO WORLD', 'HELLO WORLD ', 11)).toEqual({ offset: 0, length: 11 });
+    const slice = EMAIL.slice(18) + ' ';
+    expect(locateViewportSlice(EMAIL, slice, EMAIL.length)).toEqual({ offset: 18, length: EMAIL.length - 18 });
+  });
+
+  it('two trailing pad spaces are NOT trimmed (could be user text)', () => {
+    expect(locateViewportSlice('HELLO WORLD', 'HELLO WORLD  ', 11)).toBeNull();
+  });
+
+  it('non-contiguous slice (soft-wrap inserted chars) → null, caller falls back', () => {
+    expect(locateViewportSlice('a long unbroken line of text', 'a long unbroken\nline of text', 0)).toBeNull();
+  });
+
+  it('empty slice / slice longer than buffer → null', () => {
+    expect(locateViewportSlice('', ' ', 0)).toBeNull();
+    expect(locateViewportSlice('ab', 'abc', 0)).toBeNull();
+  });
+
+  it('ambiguous repetitive buffer → first occurrence containing the cursor wins', () => {
+    const full = 'line\nline\nline\nline';
+    // slice "line\nline" occurs at 0, 5, 10. Cursor 12 is inside the
+    // occurrences at 5 and 10 — the FIRST containing one (5) wins; with
+    // repetitive content every containing occurrence paints identically,
+    // so first-wins is deterministic and good enough.
+    expect(locateViewportSlice(full, 'line\nline', 12)).toEqual({ offset: 5, length: 9 });
+    // Cursor at 2 → only the occurrence at 0 contains it.
+    expect(locateViewportSlice(full, 'line\nline', 2)).toEqual({ offset: 0, length: 9 });
+    // Cursor inside none (impossible in practice) → first occurrence.
+    expect(locateViewportSlice(full, 'line\nline', 999)).toEqual({ offset: 0, length: 9 });
+  });
+});
+
+describe('translateDirectivesToViewport', () => {
+  const d: RenderDirectives = {
+    dimRanges: [{ start: 0, end: 143 }],
+    highlight: { start: 20, end: 30 },
+    coloredRanges: [{ start: 140, end: 141, ansi: 'red' }],
+    inlineNote: { spanStart: 0, spanEnd: 143, text: 'note', hint: '(underscore to cycle)' },
+  };
+
+  it('unscrolled fast path returns the directives untouched', () => {
+    expect(translateDirectivesToViewport(d, 0, 143, 143)).toBe(d);
+  });
+
+  it('shifts and clips every range family into slice coords', () => {
+    const t = translateDirectivesToViewport(d, 18, 125, 143);
+    expect(t.dimRanges).toEqual([{ start: 0, end: 125 }]);       // 0-143 clipped into the 125-char slice
+    expect(t.highlight).toEqual({ start: 2, end: 12 });           // 20-30 shifted by -18
+    expect(t.coloredRanges).toEqual([{ start: 122, end: 123, ansi: 'red' }]);
+    expect(t.inlineNote).toEqual({ spanStart: 0, spanEnd: 125, text: 'note', hint: '(underscore to cycle)' });
+  });
+
+  it('ranges entirely off-screen are dropped', () => {
+    const t = translateDirectivesToViewport(
+      { dimRanges: [{ start: 0, end: 10 }], highlight: { start: 5, end: 10 } },
+      18, 125, 143,
+    );
+    expect(t.dimRanges).toEqual([]);
+    expect(t.highlight).toBeUndefined();
+  });
+
+  it('inlineNote fully off-screen is dropped, never clamped to a fake anchor', () => {
+    const t = translateDirectivesToViewport(
+      { inlineNote: { spanStart: 0, spanEnd: 10, text: 'note' } },
+      18, 125, 143,
+    );
+    expect(t.inlineNote).toBeNull();
+  });
+
+  it('whole-buffer textOverride (glimmer) is sliced to the viewport; other lengths pass through', () => {
+    const full = 'x'.repeat(143);
+    const t = translateDirectivesToViewport({ textOverride: full }, 18, 125, 143);
+    expect(t.textOverride).toBe('x'.repeat(125));
+    const odd = translateDirectivesToViewport({ textOverride: 'short' }, 18, 125, 143);
+    expect(odd.textOverride).toBe('short');
+  });
+});

--- a/packages/opencues-runtime/adapters/cc/v2.1/viewport.ts
+++ b/packages/opencues-runtime/adapters/cc/v2.1/viewport.ts
@@ -1,0 +1,138 @@
+// CC input-zone VIEWPORT translation.
+//
+// CC renders tall buffers through a scrolled viewport: the string the S3
+// seam hands `applyRender` is only the VISIBLE lines, while DynDef spans,
+// highlight state and cue spans are all in FULL-buffer coordinates. Before
+// Sep 2026 the render ctx was built from the slice, so any span outside a
+// scrolled viewport failed DimRender's stale-def guard (`defSpanLive`) and
+// silently lost its dim / inline note / highlight — first reported as
+// "`draft email _` doesn't go grey" (the multi-line email rewrite is taller
+// than the input zone; reproduced identically on 2.1.206 and 2.1.236, so a
+// runtime bug, not a host-version one).
+//
+// The fix: locate the slice inside the full buffer, hand handlers the FULL
+// text (spans validate again), then translate every directive range back
+// into slice coordinates before painting. When the slice can't be located
+// (CC soft-wrap inserts characters, or the buffer mutated mid-render) we
+// fall back to the pre-fix behaviour byte-for-byte — never guess offsets.
+//
+// Both functions are pure; coordinates are in the ZWS-stripped visible
+// space on both sides (the same space handlers have always emitted in).
+
+import type { RenderDirectives, Range, ColoredRange, HighlightRange, InlineNote } from '../../../src/adapter';
+
+export interface ViewportMatch {
+  /** Slice start within the full text (visible coords). */
+  readonly offset: number;
+  /** Slice length. */
+  readonly length: number;
+}
+
+/**
+ * Locate the rendered viewport slice inside the full buffer text.
+ * Returns null when the slice is not a contiguous substring (soft-wrap
+ * inserted characters, mid-render mutation) — callers must then fall back
+ * to slice-as-ctx behaviour.
+ *
+ * Ambiguity (a repetitive buffer where the slice occurs more than once) is
+ * resolved toward the occurrence containing the cursor — the viewport
+ * follows the caret in CC — falling back to the first occurrence when the
+ * cursor sits in none of them.
+ */
+export function locateViewportSlice(fullText: string, sliceText: string, cursor: number): ViewportMatch | null {
+  // CC's rendered string appends ONE cursor-cell space that isn't buffer
+  // content ("HELLO WORLD" renders as "HELLO WORLD "). Try the exact slice
+  // first (the pad can be real content), then retry with a single trailing
+  // space trimmed. Never trim more than one — beyond the cursor cell,
+  // trailing spaces are user text.
+  const exact = locateRaw(fullText, sliceText, cursor);
+  if (exact) return exact;
+  if (sliceText.endsWith(' ')) return locateRaw(fullText, sliceText.slice(0, -1), cursor);
+  return null;
+}
+
+function locateRaw(fullText: string, sliceText: string, cursor: number): ViewportMatch | null {
+  if (sliceText.length === 0 || sliceText.length > fullText.length) return null;
+  if (sliceText === fullText) return { offset: 0, length: fullText.length };
+  const first = fullText.indexOf(sliceText);
+  if (first < 0) return null;
+  if (fullText.indexOf(sliceText, first + 1) < 0) return { offset: first, length: sliceText.length };
+  for (let idx = first; idx >= 0; idx = fullText.indexOf(sliceText, idx + 1)) {
+    if (cursor >= idx && cursor <= idx + sliceText.length) return { offset: idx, length: sliceText.length };
+  }
+  return { offset: first, length: sliceText.length };
+}
+
+function shiftClip<T extends Range>(r: T, offset: number, sliceLen: number): T | null {
+  const start = Math.max(r.start - offset, 0);
+  const end = Math.min(r.end - offset, sliceLen);
+  if (start >= end) return null;
+  return { ...r, start, end };
+}
+
+function shiftClipList<T extends Range>(rs: readonly T[] | undefined, offset: number, sliceLen: number): T[] | undefined {
+  if (!rs || rs.length === 0) return rs as T[] | undefined;
+  const out: T[] = [];
+  for (const r of rs) {
+    const t = shiftClip(r, offset, sliceLen);
+    if (t) out.push(t);
+  }
+  return out;
+}
+
+/**
+ * Translate directives computed against the FULL buffer into the viewport
+ * slice's coordinate space. Ranges are shifted by -offset and clipped to
+ * the slice; ranges falling entirely outside the viewport are dropped
+ * (their content isn't on screen). `textOverride` is sliced only when its
+ * length matches the full text (the glimmer whole-buffer override); any
+ * other length is passed through untouched — its semantics are unknown
+ * here and mangling it would corrupt the paint.
+ */
+export function translateDirectivesToViewport(
+  d: RenderDirectives,
+  offset: number,
+  sliceLen: number,
+  fullLen: number,
+): RenderDirectives {
+  if (offset === 0 && sliceLen >= fullLen) return d;
+
+  let textOverride = d.textOverride;
+  if (textOverride !== undefined && textOverride.length === fullLen) {
+    textOverride = textOverride.slice(offset, offset + sliceLen);
+  }
+
+  let highlight: HighlightRange | undefined;
+  if (d.highlight) highlight = shiftClip(d.highlight, offset, sliceLen) ?? undefined;
+
+  let inlineNote: InlineNote | null | undefined = d.inlineNote;
+  if (inlineNote) {
+    // Cursor-gated: the caret is inside the span, so at least part of the
+    // span is on screen in practice — but a fully off-screen span must not
+    // anchor a note at a clamped fake position.
+    if (inlineNote.spanEnd <= offset || inlineNote.spanStart >= offset + sliceLen) {
+      inlineNote = null;
+    } else {
+      inlineNote = {
+        ...inlineNote,
+        spanStart: Math.max(inlineNote.spanStart - offset, 0),
+        spanEnd: Math.min(inlineNote.spanEnd - offset, sliceLen),
+      };
+    }
+  }
+
+  return {
+    ...d,
+    ...(textOverride !== undefined ? { textOverride } : {}),
+    dimRanges: shiftClipList(d.dimRanges, offset, sliceLen),
+    boldRanges: shiftClipList(d.boldRanges, offset, sliceLen),
+    italicRanges: shiftClipList(d.italicRanges, offset, sliceLen),
+    codeRanges: shiftClipList(d.codeRanges, offset, sliceLen),
+    strikeRanges: shiftClipList(d.strikeRanges, offset, sliceLen),
+    headingRanges: shiftClipList(d.headingRanges, offset, sliceLen),
+    listRanges: shiftClipList(d.listRanges, offset, sliceLen),
+    coloredRanges: shiftClipList(d.coloredRanges as readonly ColoredRange[] | undefined, offset, sliceLen),
+    highlight,
+    inlineNote,
+  };
+}

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",


### PR DESCRIPTION
## What

Both issues from tonight's 2.1.236 field testing, root-caused and fixed. **Neither is a 2.1.236 regression** — both reproduce on current master / 2.1.206; the new pin just happened to be where they got noticed.

## 1. Tall spans never went grey / looked unselectable (`@opencues/runtime` 0.38.2)

`draft email _` produced a correct multi-line rewrite whose span never dimmed. Diagnosis from the live logs: CC renders tall buffers through a **scrolled viewport** — the S3 seam hands `applyRender` only the visible lines (log showed `textLen:144` vs `ctxLen:125`, first line absent), while DynDef spans are full-buffer coords. The ctx was built from the slice, so scrolled spans failed DimRender's stale-def guard (the guard that stops dim leaking onto new text) and dropped dim + inline note + highlight. Short buffers fit the viewport — which is why every harness scenario and everyday transform always looked fine, and why the harness never caught it.

**Fix** — new `adapters/cc/v2.1/viewport.ts`, wired into `boot.ts:applyRender`:
- `locateViewportSlice`: find the rendered slice inside the full buffer. Handles CC's one-trailing-space cursor-cell pad (never trims more than one — beyond that it's user text); ambiguity in repetitive buffers resolves toward the occurrence containing the caret.
- Handlers now receive the **full** text (spans validate again); every directive family — dim/markdown/colored ranges, highlight, inlineNote, the glimmer whole-buffer `textOverride` — is translated back into slice coordinates, with off-screen ranges dropped (an off-screen inlineNote is dropped, never clamped to a fake anchor).
- No contiguous match (soft-wrap inserts, mid-render mutation) → **pre-fix behaviour byte-for-byte**. Never guess offsets.

**Verification:** `viewport.test.ts` (locator + translation, incl. pad, ambiguity, off-screen drops) + boot-level scenario tests (scrolled slice paints dim; pad handled; span fully above the viewport paints nothing; fallback never throws). Live end-to-end on an isolated fork: the exact `draft an email _` repro that logged `directives: []` now logs `viewportOffset: 44` with `highlight {0,99}` + the `(underscore to cycle)` note painting into the slice, glimmer override correctly sliced.

## 2. "There is no statusline" — dead project-level statusLine scripts (CLI 0.7.10)

`~/testing/.claude/settings.json` (May-era) still pointed at the retired `~/claude-code-cues` layout; a project-level statusLine **shadows** the user-level one for sessions launched there, and doctor only inspects the cwd — so the breakage was invisible unless doctor happened to run from that directory.

**Fix** — `cc-statusline.cjs` gains `commandScriptExists` (tri-state over shell command strings: absolute-path tokens stat'd, `~/` expanded, bare `$PATH` commands never judged) and `auditProjectStatuslines` (walks CC's own `~/.claude.json` project registry — 41 dirs on this machine). Doctor emits a warn row per dead entry naming the directory, with `opencues statusline enable --project --force` as the fix when the dead path is ours, or an edit hint when it's custom. Pinned by three new tests in `cc-statusline.test.cjs` (hermetic, fake HOME).

## Gates

`pre-pr.sh` 20/21 (doctor fails on this machine's known state: fork drift from this very version bump + pre-existing chrome/dsh markers — my new sweep itself runs clean). Full runtime suite 2337 passed (one `seed-configs` 5s-timeout flake under build load; passes solo). CC band 67/67.

## Notes

- Independent of PR #431 (based on master). One deliberate omission: REPAIR.md's viewport row — #431 also appends to the quirk catalogue and both writing § 16 would conflict; whichever merges second picks it up (I'll do it).
- Forks rebuild via srcHash self-heal / `opencues install` after merge, as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBtLCdx8JSPuhyzjRByAJj
