### PR TITLE
feat(bridge): def: seeds a word def deterministically; @opencues/dsh 0.2.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — the event bridge can seed a word def (`@opencues/runtime` 0.41.1); `@opencues/dsh` 0.2.21 carries the semantic tips
+- Bridge command `def:<wordIndex>:<json>` registers a word def straight into the band's DynDefs (every band already hands the bridge its state) — what the resolver does for a word-cue hit, exposed so an off-process driver can put a DETERMINISTIC cycleable def on a word without a model. Since 0.7.13 the only sources of word defs are LLM sources, and a runtime-contract check must not depend on a model's output. Emits `def.seeded`.
+- `@opencues/dsh` 0.2.20 → 0.2.21: republished with runtime 0.41 / core 0.60 inlined, so DeepSeek Harness users get the semantic tips and the static layer's removal.
+
+
 ## [0.7.13] - 2026-09-07
 
 ### Fixed — JS user blanks were silently disabled on Claude Code and OpenCode forks; a failed shell bundle reported success (`@opencues/claude-code` 0.2.13, `@opencues/opencode` 0.2.18, `@opencues/shell` 0.2.24)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -734,7 +734,7 @@ done
 | `SPEC.md` (open-standard) | `cues-spec` | 0.12 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
 | `packages/opencues-core/` | `@opencues/core` | 0.60.0 | private |
-| `packages/opencues-runtime/` | `@opencues/runtime` | 0.41.0 | private |
+| `packages/opencues-runtime/` | `@opencues/runtime` | 0.41.1 | private |
 | `packages/opencues-cli/` | `opencues` (real CLI) | 0.7.13 | **PUBLISHED on npm** (0.7.8 is the published release; 0.7.13 unreleased) |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.13 | private |
 | `integrations/opencode/` | `@opencues/opencode` | 0.2.18 | private |
@@ -742,7 +742,7 @@ done
 | `integrations/gemini-cli/` | `@opencues/gemini-cli` | 0.2.11 | private |
 | `integrations/shell/` | `@opencues/shell` | 0.2.24 | private |
 | `integrations/windows/` | `@opencues/windows` | 0.2.4 | private |
-| `integrations/dsh/` | `@opencues/dsh` | 0.2.20 | **PUBLISHABLE** — dsh installs plugins from npm |
+| `integrations/dsh/` | `@opencues/dsh` | 0.2.21 | **PUBLISHABLE** — dsh installs plugins from npm |
 
 The bare `opencues` name on npm is the real CLI (`packages/opencues-cli/`, **published** — v0.6.0 superseded the retired parking placeholder's v0.0.1; the old `packages/opencues-park/` source was deleted post-publish, July 2026). The npm org grants access via the `developers` team.
 

--- a/integrations/dsh/package.json
+++ b/integrations/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/dsh",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "OpenCues for DeepSeek Harness \u2014 LLM word alternatives and `_`-gated blank fill-ins in the dsh composer.",
   "license": "MIT",
   "homepage": "https://opencues.com",

--- a/packages/opencues-runtime/package.json
+++ b/packages/opencues-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/runtime",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "Host-agnostic runtime for OpenCues. Hosts implement HostAdapter; runtime owns all feature logic.",
   "private": true,
   "main": "dist/src/index.js",

--- a/packages/opencues-runtime/src/event-bridge.def.test.ts
+++ b/packages/opencues-runtime/src/event-bridge.def.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The bridge's `def:` command — an off-process driver registers a word def
+ * straight into the band's DynDefs, so a runtime-contract check can put a
+ * DETERMINISTIC cycleable def on a word without any model. Drives the real
+ * CommandRunner through `startEventBridge` + `poll`, on this process's
+ * own inject file (the bridge keys its files by pid); the file is removed
+ * again in `finally`. Fixtures are synthetic on purpose.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import { startEventBridge, type EventBridgeHandle } from './event-bridge';
+import { DynDefs } from './state/dyn-defs';
+import { HighlightState } from './state/highlight-state';
+import { MockAdapter } from '../testing/mock-adapter';
+
+let handle: EventBridgeHandle | null = null;
+afterEach(() => { handle?.stop(); handle = null; });
+
+function boot(text: string) {
+  const adapter = new MockAdapter();
+  adapter.pushText(text);
+  const dynDefs = new DynDefs();
+  handle = startEventBridge({
+    adapter,
+    dispatchKey: () => false,
+    state: { hlState: new HighlightState(), dynDefs },
+  });
+  return { adapter, dynDefs, handle };
+}
+
+function send(h: EventBridgeHandle, line: string): void {
+  fs.writeFileSync(h.paths.inject, line);
+  h.poll();
+}
+/** the event BODIES the bridge wrote (each line is an envelope {ts, v, pid, body}) */
+function events(h: EventBridgeHandle): Array<Record<string, unknown>> {
+  return fs.readFileSync(h.paths.events, 'utf8').split('\n').filter(Boolean)
+    .map((l) => (JSON.parse(l) as { body: Record<string, unknown> }).body);
+}
+
+describe('event bridge — def: seeds a word def deterministically', () => {
+  it('registers [word, ...alternatives] at the word’s char span; index 0 = the word', () => {
+    const { dynDefs, handle } = boot('we should zorbo this');
+    send(handle!, 'def:2:{"alternatives":["zorbi","zorbu zorba"],"cueTip":"ALT-TIP zorbo"}');
+    const def = dynDefs.get(2);
+    expect(def).toBeDefined();
+    expect(def!.originalWord).toBe('zorbo');
+    expect(def!.alternatives).toEqual(['zorbo', 'zorbi', 'zorbu zorba']);
+    expect(def!.currentIndex).toBe(0);
+    expect([def!.spanStart, def!.spanEnd]).toEqual(['we should '.length, 'we should zorbo'.length]);
+    expect(def!.cueTip).toBe('ALT-TIP zorbo');
+    const seeded = events(handle!).find((e) => e.type === 'def.seeded') as { wordIndex: number; word: string } | undefined;
+    expect(seeded).toMatchObject({ wordIndex: 2, word: 'zorbo' });
+  });
+  it('a word that is already alternatives[0] is not doubled', () => {
+    const { dynDefs, handle } = boot('zorbo');
+    send(handle!, 'def:0:{"alternatives":["zorbo","zorbi"]}');
+    expect(dynDefs.get(0)!.alternatives).toEqual(['zorbo', 'zorbi']);
+  });
+  it('a bad index, missing alternatives or malformed JSON is a command.error, never a throw out of the poll', () => {
+    const { dynDefs, handle } = boot('one two');
+    send(handle!, 'def:7:{"alternatives":["x"]}');
+    send(handle!, 'def:0:{"nope":1}');
+    send(handle!, 'def:0:not json');
+    expect(dynDefs.size).toBe(0);
+    const errs = events(handle!).filter((e) => e.type === 'command.error');
+    expect(errs).toHaveLength(3);
+  });
+});

--- a/packages/opencues-runtime/src/event-bridge.ts
+++ b/packages/opencues-runtime/src/event-bridge.ts
@@ -77,6 +77,7 @@
 
 import * as fs from 'node:fs';
 import type { HostAdapter, KeyEvent, AmbientContext } from './adapter';
+import type { WordDef } from './state/dyn-defs';
 
 // ─── Public API types ────────────────────────────────────────────────────
 
@@ -98,6 +99,7 @@ export type BridgeEventBody =
   | { type: 'command.unknown'; line: string }
   | { type: 'text.injected'; text: string; source: 'user' | 'runtime'; cursor: number }
   | { type: 'cursor.injected'; cursor: number }
+  | { type: 'def.seeded'; wordIndex: number; word: string; alternatives: readonly string[] }
   | { type: 'ambient.injected'; ambient: AmbientContext | null }
   | { type: 'cleared' }
   | { type: 'key.dispatched'; key: string; modifiers: KeyEvent['modifiers']; consumed: boolean }
@@ -628,6 +630,46 @@ class CommandRunner {
       }
       case 'dump': {
         this.writeDump();
+        return;
+      }
+      case 'def': {
+        // `def:<wordIndex>:<json WordDef>` — register a word def at a
+        // whitespace-word index, straight into the band's DynDefs (every
+        // band hands the bridge its state). What the resolver does for a
+        // word-cue hit, exposed so an off-process driver can put a
+        // DETERMINISTIC cycleable def on a word without any model — the
+        // only other sources of word defs are LLM sources, which no
+        // scenario should depend on for a runtime contract. The JSON needs
+        // at least `alternatives`; originalWord / currentIndex / span
+        // default from the live buffer (span = the word's char range,
+        // index 0 = the word itself).
+        const sep = arg.indexOf(':');
+        if (sep < 0) throw new Error('def needs <wordIndex>:<json>');
+        const wordIndex = Number.parseInt(arg.slice(0, sep), 10);
+        const raw = JSON.parse(arg.slice(sep + 1)) as Partial<WordDef> & { alternatives: string[] };
+        if (!Number.isInteger(wordIndex) || wordIndex < 0) throw new Error(`def: bad wordIndex ${arg.slice(0, sep)}`);
+        if (!Array.isArray(raw.alternatives) || raw.alternatives.length === 0) throw new Error('def: alternatives required');
+        const text = adapter.getText().replace(/[\u200B\u200C]/g, '');
+        const words: Array<{ word: string; start: number; end: number }> = [];
+        const re = /\S+/g; let m: RegExpExecArray | null;
+        while ((m = re.exec(text)) !== null) words.push({ word: m[0], start: m.index, end: m.index + m[0].length });
+        const w = words[wordIndex];
+        if (!w) throw new Error(`def: no word at index ${wordIndex} (buffer has ${words.length})`);
+        const def: WordDef = {
+          originalWord: raw.originalWord ?? w.word,
+          alternatives: raw.alternatives[0] === w.word ? raw.alternatives : [w.word, ...raw.alternatives.filter((a) => a !== w.word)],
+          currentIndex: raw.currentIndex ?? 0,
+          spanStart: raw.spanStart ?? w.start,
+          spanEnd: raw.spanEnd ?? w.end,
+          ...(raw.cueTip ? { cueTip: raw.cueTip } : {}),
+          ...(raw.cueSource ? { cueSource: raw.cueSource } : {}),
+          ...(raw.blankName ? { blankName: raw.blankName } : {}),
+        };
+        const dd = this.bindings.state?.dynDefs as { set?(i: number, d: WordDef): boolean } | undefined;
+        if (!dd || typeof dd.set !== 'function') throw new Error('def: this host band handed the bridge no DynDefs');
+        if (!dd.set(wordIndex, def)) throw new Error('def: DynDefs.set rejected it (overlaps a managed span?)');
+        adapter.forceRender();
+        this.stream.emit({ type: 'def.seeded', wordIndex, word: w.word, alternatives: def.alternatives });
         return;
       }
       case 'wait': {


### PR DESCRIPTION
- Bridge command `def:<wordIndex>:<json>` registers a word def straight into the band's DynDefs (every band already hands the bridge its state): what the resolver does for a word-cue hit, exposed so an off-process driver can put a deterministic cycleable def on a word without a model. Since 0.7.13 the only sources of word defs are LLM sources, and a runtime-contract check must not depend on a model's output. Emits `def.seeded`; errors surface as `command.error`. Unit-tested through the real command runner.
- `@opencues/dsh` 0.2.20 → 0.2.21: the committed bundle rebuilt with runtime 0.41 / core 0.60 so DeepSeek Harness users get the semantic tips. Publish follows the merge.

runtime 0.41.1. Runtime suite 2402, hermetic gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aa52PYn55dTUfUWm3n3rEv