### PR TITLE
fix(tips): a command tip's solution is the command plus real arguments, never the pack's line (core 0.60.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — a command tip's solution is the command plus real arguments, never the pack's line with the command in front (`@opencues/core` 0.60.1)
+- The grounding accepted any model `apply` that STARTED with the entry's command, so `/mcp list|enable|disable|reload manages MCP servers` (the tip text) and `/model set <name>` (a template) were "solutions" `_` would paste into the prompt (gemini-cli bench on qwen). `isGroundedCommandLine`: what follows the command must not be the entry's own tip / say text and must carry no `<placeholder>`; otherwise the solution collapses to the bare command. `/compact focus on the plan` and `/chat save` still pass.
+
+
 ### Added — the event bridge can seed a word def (`@opencues/runtime` 0.41.1); `@opencues/dsh` 0.2.21 carries the semantic tips
 - Bridge command `def:<wordIndex>:<json>` registers a word def straight into the band's DynDefs (every band already hands the bridge its state) — what the resolver does for a word-cue hit, exposed so an off-process driver can put a DETERMINISTIC cycleable def on a word without a model. Since 0.7.13 the only sources of word defs are LLM sources, and a runtime-contract check must not depend on a model's output. Emits `def.seeded`.
 - `@opencues/dsh` 0.2.20 → 0.2.21: republished with runtime 0.41 / core 0.60 inlined, so DeepSeek Harness users get the semantic tips and the static layer's removal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -733,7 +733,7 @@ done
 |---|---|---|---|
 | `SPEC.md` (open-standard) | `cues-spec` | 0.12 (draft) | exported as `SPEC_VERSION` from `@opencues/core` |
 | `package.json` (monorepo root) | `opencues` | 0.1.0 | private |
-| `packages/opencues-core/` | `@opencues/core` | 0.60.0 | private |
+| `packages/opencues-core/` | `@opencues/core` | 0.60.1 | private |
 | `packages/opencues-runtime/` | `@opencues/runtime` | 0.41.1 | private |
 | `packages/opencues-cli/` | `opencues` (real CLI) | 0.7.13 | **PUBLISHED on npm** (0.7.8 is the published release; 0.7.13 unreleased) |
 | `integrations/claude-code/` | `@opencues/claude-code` | 0.2.13 | private |

--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencues/core",
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Core OpenCues library - pure TypeScript, no I/O dependencies",
   "private": true,
   "main": "dist/index.js",

--- a/packages/opencues-core/src/sources/semantic-tips-source.test.ts
+++ b/packages/opencues-core/src/sources/semantic-tips-source.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { entryCommand, isGroundedRewrite, SemanticTipsSource } from './semantic-tips-source';
+import { entryCommand, isGroundedCommandLine, isGroundedRewrite, SemanticTipsSource } from './semantic-tips-source';
 import { buildTipsCatalog, TIPS_CATALOG_BUDGET_CHARS, TIPS_CATALOG_HEADER } from '../tips-catalog';
 import { getProvider } from '../llm-provider';
 import type { CueContext, HttpAdapter, LocalCueData } from '../types';
@@ -143,6 +143,20 @@ describe('SemanticTipsSource.getCues — grounding', () => {
     expect(entryCommand({ trigger: 'zwsl', tip: 'keep the repo under /home/you, not /mnt/c' })).toBeUndefined();   // paths (a bare `/word` still reads as a command — pack lines avoid it; the bench's solution column catches one)
     expect(entryCommand({ trigger: 'zwsl', tip: 'keep it under /mnt/c; then /zdoctor' })).toBe('/zdoctor');
     expect(entryCommand({ trigger: 'zkey', tip: 'press Ctrl+Z', say: 'press Ctrl+Z twice' })).toBeUndefined();
+  });
+  it('a command line keeps REAL arguments, but the pack’s own text behind the command or a <placeholder> collapses to the bare command', async () => {
+    const e = { tip: 'ALT-TIP /zmcp list|enable|disable|reload manages ZMCP servers', say: 'Connecting a tool? /zmcp shows what is live' };
+    expect(isGroundedCommandLine('/zmcp', '/zmcp', e)).toBe(true);
+    expect(isGroundedCommandLine('/zmcp add my-db', '/zmcp', e)).toBe(true);
+    expect(isGroundedCommandLine('/zmcp shows', '/zmcp', e)).toBe(true);                                                 // a short argument, even one the say line uses
+    expect(isGroundedCommandLine('/zmcp list|enable|disable|reload manages ZMCP servers', '/zmcp', e)).toBe(false);   // the tip with the command in front
+    expect(isGroundedCommandLine('/zmcp shows what is live', '/zmcp', e)).toBe(false);                                 // the say line
+    expect(isGroundedCommandLine('/zmodel set <name>', '/zmodel', { tip: 'x' })).toBe(false);                            // a template
+    expect(isGroundedCommandLine('/zother add', '/zmcp', e)).toBe(false);
+    const pack = buildTipsCatalog([{ id: 'm', words: { '/zmcp': { tip: e.tip, when: 'wants to connect a tool', say: e.say, alts: [] } } }]);
+    const s = new SemanticTipsSource({ ...baseConfig, httpAdapter: makeMockAdapter(
+      '[{"quote":"connect it to my db","tipId":"t1","apply":"/zmcp list|enable|disable|reload manages ZMCP servers"}]') });
+    expect((await s.getCues(ctx('connect it to my db', pack))).results[0].alternatives).toEqual(['connect it to my db', '/zmcp']);
   });
   it('a prose rewrite that is the tip’s own text, or drops the person’s words, is not a solution — the note stays advisory', async () => {
     expect(isGroundedRewrite('think really hard about this', 'think really hard about this ultrathink', { tip: 'Add ultrathink', say: 'A hard one? Put ultrathink in the prompt' })).toBe(true);

--- a/packages/opencues-core/src/sources/semantic-tips-source.ts
+++ b/packages/opencues-core/src/sources/semantic-tips-source.ts
@@ -107,6 +107,32 @@ export function entryCommand(entry: { trigger: string; say?: string; tip: string
 }
 
 /** lowercase, trailing punctuation stripped — the static path's token, as prose carries it */
+/**
+ * A command-tip solution is the entry's command, optionally with REAL
+ * arguments (`/compact focus on the plan`, `/chat save`). It is not the
+ * pack's own line with the command in front (`/mcp list|enable|disable
+ * manages MCP servers` — the gemini bench, 2026-09-07) and not a template
+ * with a `<placeholder>` (`/model set <name>`): either would paste a
+ * definition into the prompt. Those collapse to the bare command.
+ */
+export function isGroundedCommandLine(line: string, cmd: string, entry: { tip: string; say?: string }): boolean {
+  const l = line.trim();
+  if (!l.toLowerCase().startsWith(cmd.toLowerCase())) return false;
+  if (/<[^>]+>/.test(l)) return false;
+  const rest = l.slice(cmd.length).trim();
+  if (!rest) return true;
+  const norm = (t: string) => t.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ').split(/\s+/).filter(Boolean).join(' ');
+  const r = norm(rest);
+  // a short argument (`/chat save`) is allowed even if the say line mentions
+  // it; a run of three or more words lifted from the pack's line is prose
+  if (r.split(' ').length < 3) return true;
+  for (const own of [entry.tip, entry.say ?? '']) {
+    const o = norm(own);
+    if (o && (o.includes(r) || r.includes(o))) return false;
+  }
+  return true;
+}
+
 /** A prose rewrite keeps ≥ half of the quote's words and is not the entry's own tip or say line. */
 export function isGroundedRewrite(quote: string, rewrite: string, entry: { tip: string; say?: string }): boolean {
   const norm = (t: string) => t.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, ' ').split(/\s+/).filter(Boolean);
@@ -204,7 +230,7 @@ export class SemanticTipsSource implements CueSource {
       // The command line must START with the entry's command (the pack's,
       // not the model's); anything else — a paraphrase, the tip text, a
       // different command — collapses to the bare command.
-      if (cmd !== undefined) apply = applyRaw.toLowerCase().startsWith(cmd.toLowerCase()) ? applyRaw : cmd;
+      if (cmd !== undefined) apply = isGroundedCommandLine(applyRaw, cmd, entry) ? applyRaw : cmd;
       // Grounding 4, prose tips: the rewrite must be the PERSON's sentence
       // following the tip — it keeps at least half of the quote's words and
       // is not the pack's own line. qwen answered "apply" with the tip text

--- a/packages/opencues-runtime/testing/seed-configs.test.ts
+++ b/packages/opencues-runtime/testing/seed-configs.test.ts
@@ -18,6 +18,12 @@
 // HOME so they're hermetic.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Every phase spawns the real seed-configs over the whole defaults tree (and
+// the .cs compile on WSL), which runs past vitest's 5 s default whenever the
+// machine is busy — a build or a bench beside the suite made this the one
+// flaky file. It is real work, not a hang: give it the time.
+vi.setConfig({ testTimeout: 30_000 });
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';


### PR DESCRIPTION
The grounding accepted any model `apply` that STARTED with the entry's command, so `/mcp list|enable|disable|reload manages MCP servers` (the tip text) and `/model set <name>` (a template) counted as solutions `_` would paste into the prompt — surfaced by the gemini-cli bench on qwen while preparing its live test list. `isGroundedCommandLine`: what follows the command must not be a run of the entry's own tip / say text (three words or more) and must carry no `<placeholder>`; otherwise the solution collapses to the bare command. Short real arguments survive (`/chat save`, `/compact focus on the plan`).

Bench after the change: every pack passes on gpt-oss-120b and qwen-3.8-27b with the same recall as before. Also: the seed-configs tests get a 30 s timeout — they spawn the real seed over the defaults tree and were the one flaky file whenever a build or bench ran beside the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aa52PYn55dTUfUWm3n3rEv