### PR TITLE
build(core): wipe dist before tsc so a stale compiled test from another branch cannot fail the suite

### DIFF
--- a/packages/opencues-core/package.json
+++ b/packages/opencues-core/package.json
@@ -15,7 +15,7 @@
     "access": "restricted"
   },
   "scripts": {
-    "build": "tsc && node ../../scripts/build-shipped-manifest.cjs",
+    "build": "rm -rf dist && tsc && node ../../scripts/build-shipped-manifest.cjs",
     "typecheck": "tsc --noEmit",
     "test": "find dist -name '*.test.js' ! -name 'feature-registry*.test.js' ! -name 'llm-provider.drift.test.js' ! -name 'llm-provider.temperature.test.js' ! -name 'llm-provider.max-thinking.test.js' ! -name 'llm-provider.gemma.test.js' ! -name 'llm-provider.qwen.test.js' ! -name 'llm-provider.usage.test.js' ! -name 'model-thinking.test.js' ! -name 'conformance.test.js' ! -name 'harness-bridge.test.js' ! -name 'semantic-tips-source.test.js' | xargs node --test && vitest run",
     "prepublishOnly": "node ../../scripts/prepublish-guard.cjs",


### PR DESCRIPTION
Core's `npm test` runs `find dist -name '*.test.js' | xargs node --test`, and `tsc` never deletes outputs whose source is gone. Switching from a branch that had `src/resolver.gate.test.ts` back to master left `dist/resolver.gate.test.js` behind, and the suite ran (and failed) a test that does not exist on the branch — twice this week, once inside the pre-PR hermeticity gate. Runtime's build already does `rm -rf dist && tsc`; this brings core in line. No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aa52PYn55dTUfUWm3n3rEv